### PR TITLE
API: Rename several confusing vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _CompileInfo
 *.~u
 TrialLicense.tclrs
 *.library
+*.tmcRefac
 
 # EPICS ignores
 O.*

--- a/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
@@ -5,17 +5,17 @@
 STRUCT
 	// Hardware
 	Axis: AXIS_REF;
-	bLimFwd AT %I*: BOOL;
-	bLimBwd AT %I*: BOOL;
+	bLimFwdOk AT %I*: BOOL;
+	bLimBwdOk AT %I*: BOOL;
 	bHome AT %I*: BOOL;
 	bBrakeRelease AT %Q*: BOOL;
 	
 	// Psuedo-hardware
-	bLimAllFwd: BOOL:=FALSE; // Forward enable EPS summary
-	bLimAllBwd: BOOL:=FALSE; // Forward enable EPS summary 
+	bLimAllFwdOk: BOOL:=FALSE; // Forward enable EPS summary
+	bLimAllBwdOk: BOOL:=FALSE; // Forward enable EPS summary
 	
-	bLimGntFwd: BOOL:=FALSE; // Forward virtual gantry limit switch
-	bLimGntBwd: BOOL:=FALSE; // Reverse virtual gantry limit switch
+	bLimGntFwdOk: BOOL:=FALSE; // Forward virtual gantry limit switch
+	bLimGntBwdOk: BOOL:=FALSE; // Reverse virtual gantry limit switch
 	
 	// Settings
 	bPowerSelf: BOOL:=TRUE;

--- a/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
@@ -5,17 +5,17 @@
 STRUCT
 	// Hardware
 	Axis: AXIS_REF;
-	bLimFwdOk AT %I*: BOOL;
-	bLimBwdOk AT %I*: BOOL;
+	bLimitForwardEnable AT %I*: BOOL;
+	bLimitBackwardEnable AT %I*: BOOL;
 	bHome AT %I*: BOOL;
 	bBrakeRelease AT %Q*: BOOL;
 	
 	// Psuedo-hardware
-	bLimAllFwdOk: BOOL:=FALSE; // Forward enable EPS summary
-	bLimAllBwdOk: BOOL:=FALSE; // Forward enable EPS summary
+	bAllForwardEnable: BOOL:=FALSE; // Forward enable EPS summary
+	bAllBackwardEnable: BOOL:=FALSE; // Forward enable EPS summary
 	
-	bLimGntFwdOk: BOOL:=FALSE; // Forward virtual gantry limit switch
-	bLimGntBwdOk: BOOL:=FALSE; // Reverse virtual gantry limit switch
+	bGantryForwardEnable: BOOL:=FALSE; // Forward virtual gantry limit switch
+	bGantryBackwardEnable: BOOL:=FALSE; // Reverse virtual gantry limit switch
 	
 	// Settings
 	bPowerSelf: BOOL:=TRUE;

--- a/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
@@ -8,7 +8,7 @@ STRUCT
 	bLimFwd AT %I*: BOOL;
 	bLimBwd AT %I*: BOOL;
 	bHome AT %I*: BOOL;
-	bBrake AT %Q*: BOOL;
+	bBrakeRelease AT %Q*: BOOL;
 	
 	// Psuedo-hardware
 	bLimAllFwd: BOOL:=FALSE; // Forward enable EPS summary

--- a/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
@@ -45,7 +45,7 @@ STRUCT
 	nMotionAxisID: UDINT:=0;
 	
 	// Returns
-	bEnabled: BOOL;
+	bEnableDone: BOOL;
 	bBusy: BOOL;
 	bDone: BOOL;
 	bError: BOOL;

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -28,7 +28,7 @@ CASE stMotionStage.nEnableMode OF
 		IF stMotionStage.bExecute THEN
 			stMotionStage.bEnable := TRUE;
 		END_IF
-		bExecute := stMotionStage.bExecute AND stMotionStage.bEnabled;
+		bExecute := stMotionStage.bExecute AND stMotionStage.bEnableDone;
 END_CASE
 
 // Automatically fill the correct nCmdData for homing
@@ -101,15 +101,15 @@ END_IF
 CASE stMotionStage.Axis.Status.MotionState OF
 	// We are not enabled if there is an issue
 	MC_AXISSTATE_UNDEFINED, MC_AXISSTATE_DISABLED, MC_AXISSTATE_ERRORSTOP:
-		stMotionStage.bEnabled := FALSE;
+		stMotionStage.bEnableDone := FALSE;
 	ELSE
-		stMotionStage.bEnabled := TRUE;
+		stMotionStage.bEnableDone := TRUE;
 END_CASE
 
 // Handle the brake. TRUE means brake disabled.
 CASE stMotionStage.nBrakeMode OF
 	ENUM_StageBrakeMode.STAGE_BRAKE_DISABLED:
-		stMotionStage.bBrakeRelease := stMotionStage.bEnabled AND stMotionStage.bExecute;
+		stMotionStage.bBrakeRelease := stMotionStage.bEnableDone AND stMotionStage.bExecute;
 	ENUM_StageBrakeMode.STAGE_BRAKE_STANDSTILL:
 		IF stMotionStage.Axis.Status.MotionState = MC_AXISSTATE_STANDSTILL THEN
 			stMotionStage.bBrakeRelease := FALSE;
@@ -124,7 +124,7 @@ END_CASE
 
 // Sync the epics status struct
 stMotionStage.stAxisStatus := fbDriveVirtual.stAxisStatus;
-stMotionStage.stAxisStatus.bEnabled := stMotionStage.bEnabled;
+stMotionStage.stAxisStatus.bEnabled := stMotionStage.bEnableDone;
 
 // Reset everything when bReset is flagged
 IF stMotionStage.bReset THEN
@@ -141,7 +141,7 @@ IF stMotionStage.nHomingMode = ENUM_EpicsHomeCmd.EPICS_MOTOR_HOME_NONE THEN
 END_IF]]></ST>
     </Implementation>
     <LineIds Name="FB_MotionStage">
-      <LineId Id="269" Count="123" />
+      <LineId Id="404" Count="123" />
       <LineId Id="109" Count="0" />
     </LineIds>
   </POU>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -109,17 +109,17 @@ END_CASE
 // Handle the brake. TRUE means brake disabled.
 CASE stMotionStage.nBrakeMode OF
 	ENUM_StageBrakeMode.STAGE_BRAKE_DISABLED:
-		stMotionStage.bBrake := stMotionStage.bEnabled AND stMotionStage.bExecute;
+		stMotionStage.bBrakeRelease := stMotionStage.bEnabled AND stMotionStage.bExecute;
 	ENUM_StageBrakeMode.STAGE_BRAKE_STANDSTILL:
 		IF stMotionStage.Axis.Status.MotionState = MC_AXISSTATE_STANDSTILL THEN
-			stMotionStage.bBrake := FALSE;
+			stMotionStage.bBrakeRelease := FALSE;
 		ELSE
-			stMotionStage.bBrake := TRUE;
+			stMotionStage.bBrakeRelease := TRUE;
 		END_IF
 END_CASE
 CASE stMotionStage.Axis.Status.MotionState OF
 	MC_AXISSTATE_UNDEFINED, MC_AXISSTATE_ERRORSTOP:
-		stMotionStage.bBrake := FALSE;
+		stMotionStage.bBrakeRelease := FALSE;
 END_CASE
 
 // Sync the epics status struct
@@ -141,86 +141,8 @@ IF stMotionStage.nHomingMode = ENUM_EpicsHomeCmd.EPICS_MOTOR_HOME_NONE THEN
 END_IF]]></ST>
     </Implementation>
     <LineIds Name="FB_MotionStage">
-      <LineId Id="54" Count="0" />
-      <LineId Id="43" Count="0" />
-      <LineId Id="88" Count="0" />
-      <LineId Id="73" Count="1" />
-      <LineId Id="76" Count="0" />
-      <LineId Id="79" Count="0" />
-      <LineId Id="90" Count="1" />
-      <LineId Id="77" Count="0" />
-      <LineId Id="82" Count="3" />
-      <LineId Id="75" Count="0" />
-      <LineId Id="61" Count="0" />
-      <LineId Id="148" Count="0" />
-      <LineId Id="150" Count="2" />
-      <LineId Id="149" Count="0" />
-      <LineId Id="185" Count="3" />
-      <LineId Id="55" Count="0" />
-      <LineId Id="42" Count="0" />
-      <LineId Id="14" Count="0" />
-      <LineId Id="17" Count="2" />
-      <LineId Id="21" Count="0" />
-      <LineId Id="23" Count="4" />
-      <LineId Id="29" Count="2" />
-      <LineId Id="46" Count="0" />
-      <LineId Id="45" Count="0" />
-      <LineId Id="37" Count="1" />
-      <LineId Id="40" Count="0" />
-      <LineId Id="53" Count="0" />
-      <LineId Id="70" Count="1" />
-      <LineId Id="171" Count="0" />
-      <LineId Id="173" Count="0" />
-      <LineId Id="118" Count="0" />
-      <LineId Id="95" Count="0" />
-      <LineId Id="103" Count="0" />
-      <LineId Id="99" Count="2" />
-      <LineId Id="98" Count="0" />
-      <LineId Id="242" Count="0" />
-      <LineId Id="244" Count="4" />
-      <LineId Id="243" Count="0" />
-      <LineId Id="121" Count="0" />
-      <LineId Id="250" Count="0" />
-      <LineId Id="92" Count="0" />
-      <LineId Id="58" Count="0" />
-      <LineId Id="251" Count="0" />
-      <LineId Id="47" Count="4" />
-      <LineId Id="128" Count="0" />
-      <LineId Id="252" Count="0" />
-      <LineId Id="129" Count="0" />
-      <LineId Id="254" Count="0" />
-      <LineId Id="256" Count="0" />
-      <LineId Id="255" Count="0" />
-      <LineId Id="257" Count="0" />
-      <LineId Id="253" Count="0" />
-      <LineId Id="131" Count="1" />
-      <LineId Id="198" Count="0" />
-      <LineId Id="133" Count="1" />
-      <LineId Id="136" Count="0" />
-      <LineId Id="207" Count="0" />
-      <LineId Id="135" Count="0" />
-      <LineId Id="130" Count="0" />
-      <LineId Id="138" Count="1" />
-      <LineId Id="141" Count="0" />
-      <LineId Id="140" Count="0" />
-      <LineId Id="96" Count="1" />
-      <LineId Id="41" Count="0" />
-      <LineId Id="59" Count="0" />
-      <LineId Id="142" Count="0" />
-      <LineId Id="154" Count="0" />
-      <LineId Id="156" Count="0" />
-      <LineId Id="213" Count="0" />
-      <LineId Id="157" Count="0" />
-      <LineId Id="159" Count="1" />
-      <LineId Id="162" Count="0" />
-      <LineId Id="158" Count="0" />
-      <LineId Id="155" Count="0" />
-      <LineId Id="143" Count="4" />
-      <LineId Id="9" Count="0" />
-      <LineId Id="174" Count="1" />
-      <LineId Id="102" Count="0" />
-      <LineId Id="176" Count="0" />
-      <LineId Id="104" Count="5" />
+      <LineId Id="269" Count="123" />
+      <LineId Id="109" Count="0" />
     </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -37,8 +37,8 @@ IF stMotionStage.nCommand = ENUM_EpicsMotorCmd.EPICS_MOTOR_HOME THEN
 END_IF
 
 // EPS Directional Enables
-stMotionStage.bLimAllFwdOk := stMotionStage.bLimFwdOk AND (stMotionStage.bLimGntFwdOk OR NOT stMotionStage.bGantryAxis);
-stMotionStage.bLimAllBwdOk := stMotionStage.bLimBwdOk AND (stMotionStage.bLimGntBwdOk OR NOT stMotionStage.bGantryAxis);
+stMotionStage.bAllForwardEnable := stMotionStage.bLimitForwardEnable AND (stMotionStage.bGantryForwardEnable OR NOT stMotionStage.bGantryAxis);
+stMotionStage.bAllBackwardEnable := stMotionStage.bLimitBackwardEnable AND (stMotionStage.bGantryBackwardEnable OR NOT stMotionStage.bGantryAxis);
 
 // Handle standard commands using ESS's FB
 fbDriveVirtual(En:=TRUE,
@@ -51,8 +51,8 @@ fbDriveVirtual(En:=TRUE,
 	fPosition:=stMotionStage.fPosition,
 	fAcceleration:=stMotionStage.fAcceleration,
 	fDeceleration:=stMotionStage.fDeceleration,
-	bLimitFwd:=stMotionStage.bLimAllFwdOk,
-	bLimitBwd:=stMotionStage.bLimAllBwdOk,
+	bLimitFwd:=stMotionStage.bAllForwardEnable,
+	bLimitBwd:=stMotionStage.bAllBackwardEnable,
 	bHomeSensor:=stMotionStage.bHome,
 	fHomePosition:=stMotionStage.fHomePosition,
 	bPowerSelf:=stMotionStage.bPowerSelf,
@@ -73,8 +73,8 @@ IF stMotionStage.bError THEN
 END_IF
 
 // Check the limits and cancel execution if appropriate. Without this block we have infinite error spam
-bFwdHit := stMotionStage.Axis.Status.PositiveDirection AND NOT stMotionStage.bLimAllFwdOk;
-bBwdHit := stMotionStage.Axis.Status.NegativeDirection AND NOT stMotionStage.bLimAllBwdOk;
+bFwdHit := stMotionStage.Axis.Status.PositiveDirection AND NOT stMotionStage.bAllForwardEnable;
+bBwdHit := stMotionStage.Axis.Status.NegativeDirection AND NOT stMotionStage.bAllBackwardEnable;
 IF bFwdHit OR bBwdHit THEN
 	stMotionStage.bExecute := FALSE;
 END_IF

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -37,8 +37,8 @@ IF stMotionStage.nCommand = ENUM_EpicsMotorCmd.EPICS_MOTOR_HOME THEN
 END_IF
 
 // EPS Directional Enables
-stMotionStage.bLimAllFwd := stMotionStage.bLimFwd AND (stMotionStage.bLimGntFwd OR NOT stMotionStage.bGantryAxis);
-stMotionStage.bLimAllBwd := stMotionStage.bLimBwd AND (stMotionStage.bLimGntBwd OR NOT stMotionStage.bGantryAxis);
+stMotionStage.bLimAllFwdOk := stMotionStage.bLimFwdOk AND (stMotionStage.bLimGntFwdOk OR NOT stMotionStage.bGantryAxis);
+stMotionStage.bLimAllBwdOk := stMotionStage.bLimBwdOk AND (stMotionStage.bLimGntBwdOk OR NOT stMotionStage.bGantryAxis);
 
 // Handle standard commands using ESS's FB
 fbDriveVirtual(En:=TRUE,
@@ -51,8 +51,8 @@ fbDriveVirtual(En:=TRUE,
 	fPosition:=stMotionStage.fPosition,
 	fAcceleration:=stMotionStage.fAcceleration,
 	fDeceleration:=stMotionStage.fDeceleration,
-	bLimitFwd:=stMotionStage.bLimAllFwd,
-	bLimitBwd:=stMotionStage.bLimAllBwd,
+	bLimitFwd:=stMotionStage.bLimAllFwdOk,
+	bLimitBwd:=stMotionStage.bLimAllBwdOk,
 	bHomeSensor:=stMotionStage.bHome,
 	fHomePosition:=stMotionStage.fHomePosition,
 	bPowerSelf:=stMotionStage.bPowerSelf,
@@ -73,8 +73,8 @@ IF stMotionStage.bError THEN
 END_IF
 
 // Check the limits and cancel execution if appropriate. Without this block we have infinite error spam
-bFwdHit := stMotionStage.Axis.Status.PositiveDirection AND NOT stMotionStage.bLimAllFwd;
-bBwdHit := stMotionStage.Axis.Status.NegativeDirection AND NOT stMotionStage.bLimAllBwd;
+bFwdHit := stMotionStage.Axis.Status.PositiveDirection AND NOT stMotionStage.bLimAllFwdOk;
+bBwdHit := stMotionStage.Axis.Status.NegativeDirection AND NOT stMotionStage.bLimAllBwdOk;
 IF bFwdHit OR bBwdHit THEN
 	stMotionStage.bExecute := FALSE;
 END_IF


### PR DESCRIPTION
Accepting suggestions for:
1. Better names
2. Other vars to permanently rename before we are locked in

List of renames:
- `bBrake` -> `bBrakeReleased` to indicate polarity
- `bEnabled` -> `bEnableDone` to remove visual confusion with `bEnable` and to make clear the intent of the variable
- `bLimFwd` -> `bLimFwdOk` (and equivalent change on all limit variables) to indicate polarity and status as a permission variable

closes #12 