### PR TITLE
ENH: Typhos Template and Quick Launcher

### DIFF
--- a/screens/detailed_beckhoff_motor.ui
+++ b/screens/detailed_beckhoff_motor.ui
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>353</width>
+    <height>530</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,0,3">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="name_label">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>20</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>${name}</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="underline">
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::HLine</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="TyphonPositionerWidget" name="TyphonPositionerWidget">
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="PyDMLabel" name="status_label">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}-MsgTxt</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::String</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMPushButton" name="error_reset_button">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Error Reset</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}-ErrRst</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="signal_tab">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>250</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>500</height>
+      </size>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="tabPosition">
+      <enum>QTabWidget::North</enum>
+     </property>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="elideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <property name="documentMode">
+      <bool>false</bool>
+     </property>
+     <property name="tabsClosable">
+      <bool>false</bool>
+     </property>
+     <property name="movable">
+      <bool>false</bool>
+     </property>
+     <property name="tabBarAutoHide">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="config_tab">
+      <attribute name="title">
+       <string>Configuration</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="config_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="config_scroll">
+         <property name="font">
+          <font>
+           <underline>false</underline>
+          </font>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="config_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>333</width>
+            <height>226</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphonSignalPanel" name="config_panel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showOmitted" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="misc_tab">
+      <attribute name="title">
+       <string>Miscellaneous</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="misc_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="misc_scroll">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="misc_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>98</width>
+            <height>28</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphonSignalPanel" name="misc_panel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showConfig" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphonSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhon.signal</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphonPositionerWidget</class>
+   <extends>QWidget</extends>
+   <header>typhon.positioner</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/screens/detailed_beckhoff_motor.ui
+++ b/screens/detailed_beckhoff_motor.ui
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,0,3">
+  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,0,0,3">
    <property name="spacing">
     <number>10</number>
    </property>
@@ -76,7 +76,7 @@
     </widget>
    </item>
    <item>
-    <widget class="TyphonPositionerWidget" name="TyphonPositionerWidget">
+    <widget class="TyphonPositionerWidget" name="TyphonPositionerWidget" native="true">
      <property name="toolTip">
       <string/>
      </property>
@@ -88,23 +88,54 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="PyDMLabel" name="status_label">
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Error Code:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="error_id_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="toolTip">
         <string/>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}-MsgTxt</string>
+        <string>ca://${prefix}:PLC:nErrorId_RBV</string>
        </property>
        <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::String</enum>
+        <enum>PyDMLabel::Default</enum>
        </property>
       </widget>
      </item>
      <item>
       <widget class="PyDMPushButton" name="error_reset_button">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -112,7 +143,7 @@
         <string>Error Reset</string>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}-ErrRst</string>
+        <string>ca://${prefix}PLC:bReset</string>
        </property>
        <property name="pressValue" stdset="0">
         <string>1</string>
@@ -120,6 +151,19 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="PyDMLabel" name="error_message_label">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${prefix}:PLC:sErrorMessage_RBV</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLabel::String</enum>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QTabWidget" name="signal_tab">
@@ -204,7 +248,7 @@
             <x>0</x>
             <y>0</y>
             <width>333</width>
-            <height>226</height>
+            <height>355</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -221,7 +265,7 @@
             <number>2</number>
            </property>
            <item>
-            <widget class="TyphonSignalPanel" name="config_panel">
+            <widget class="TyphonSignalPanel" name="config_panel" native="true">
              <property name="toolTip">
               <string/>
              </property>
@@ -298,7 +342,7 @@
             <number>2</number>
            </property>
            <item>
-            <widget class="TyphonSignalPanel" name="misc_panel">
+            <widget class="TyphonSignalPanel" name="misc_panel" native="true">
              <property name="toolTip">
               <string/>
              </property>
@@ -330,16 +374,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphonSignalPanel</class>
-   <extends>QWidget</extends>
-   <header>typhon.signal</header>
-  </customwidget>
-  <customwidget>
-   <class>TyphonPositionerWidget</class>
-   <extends>QWidget</extends>
-   <header>typhon.positioner</header>
-  </customwidget>
-  <customwidget>
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
@@ -348,6 +382,16 @@
    <class>PyDMPushButton</class>
    <extends>QPushButton</extends>
    <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphonSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhon.signal</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphonPositionerWidget</class>
+   <extends>QWidget</extends>
+   <header>typhon.positioner</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/screens/typhos_screen.py
+++ b/screens/typhos_screen.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     app = QApplication([])
     typhos.use_stylesheet()
     dirname, _ = os.path.split(os.path.abspath(__file__))
-    template = dirname + '/detailed_beckhoff_motor.ui'
+    template = os.path.join(dirname, 'detailed_beckhoff_motor.ui')
     suite = typhos.TyphosSuite.from_device(motor)
     suite.get_subdisplay(motor).load_template(macros=macros)
     suite.get_subdisplay(motor).force_template = template

--- a/screens/typhos_screen.py
+++ b/screens/typhos_screen.py
@@ -1,23 +1,34 @@
 #!/usr/bin/env python
-import os.path
-
+import argparse
 import logging
-from pcdsdevices.epics_motor import BeckhoffAxis
+import os.path
+import sys
+
 from qtpy.QtWidgets import QApplication
-import typhon
 
-logging.basicConfig(level=0)
+from pcdsdevices.epics_motor import BeckhoffAxis
+import typhos
 
-motor = BeckhoffAxis('TST:PPM:MMS:Y', name='test_ppm')
-macros = {'name': motor.name,
-          'prefix': motor.prefix}
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Launch a Typhos Beckhoff'
+                                                 'Motor Screen')
+    parser.add_argument('pvname', help='Base motor record pv name')
+    parser.add_argument('--loglevel', default=20, help='Python logging level')
 
-app = QApplication([])
-typhon.use_stylesheet()
-dirname, _ = os.path.split(os.path.abspath(__file__))
-template = dirname + '/detailed_beckhoff_motor.ui'
-suite = typhon.TyphonSuite.from_device(motor)
-suite.get_subdisplay(motor).load_template(macros=macros)
-suite.get_subdisplay(motor).force_template = template
-suite.show()
-app.exec_()
+    args = parser.parse_args()
+
+    logging.basicConfig(level=args.loglevel)
+
+    motor = BeckhoffAxis(args.pvname, name=args.pvname.replace(':', '_'))
+    macros = {'name': motor.name,
+              'prefix': motor.prefix}
+
+    app = QApplication([])
+    typhos.use_stylesheet()
+    dirname, _ = os.path.split(os.path.abspath(__file__))
+    template = dirname + '/detailed_beckhoff_motor.ui'
+    suite = typhos.TyphosSuite.from_device(motor)
+    suite.get_subdisplay(motor).load_template(macros=macros)
+    suite.get_subdisplay(motor).force_template = template
+    suite.show()
+    app.exec_()

--- a/screens/typhos_screen.py
+++ b/screens/typhos_screen.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import os.path
+
+import logging
+from pcdsdevices.epics_motor import BeckhoffAxis
+from qtpy.QtWidgets import QApplication
+import typhon
+
+logging.basicConfig(level=0)
+
+motor = BeckhoffAxis('TST:PPM:MMS:Y', name='test_ppm')
+macros = {'name': motor.name,
+          'prefix': motor.prefix}
+
+app = QApplication([])
+typhon.use_stylesheet()
+dirname, _ = os.path.split(os.path.abspath(__file__))
+template = dirname + '/detailed_beckhoff_motor.ui'
+suite = typhon.TyphonSuite.from_device(motor)
+suite.get_subdisplay(motor).load_template(macros=macros)
+suite.get_subdisplay(motor).force_template = template
+suite.show()
+app.exec_()

--- a/screens/typhos_screen.sh
+++ b/screens/typhos_screen.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+source /reg/g/pcds/pyps/conda/py36env.sh
+python "$(dirname $0)/typhon_screen.py"

--- a/screens/typhos_screen.sh
+++ b/screens/typhos_screen.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 source /reg/g/pcds/pyps/conda/py36env.sh
-python "$(dirname $0)/typhon_screen.py"
+python "$(dirname $0)/typhos_screen.py" $@


### PR DESCRIPTION
Add a typhos template for beckhoff motor screens and quick launcher scripts for people who just want a motor suite for quick testing. I'm not 100% sure this is best place for things like this, or if how I did it is even optimal, but here's something.

@ghalym @rajanplumley this is the screen I mentioned today

The template is based off of Teddy's positioner template with minor tweaks and additions.

Example screen called using `typhos_screen.sh IM3L0:PPM:MMS`
![image](https://user-images.githubusercontent.com/10647860/74891400-c9adae00-533b-11ea-8fd2-1f82e6adf976.png)
