### PR TITLE
MNT: reduce at limit error to warning

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -44,20 +44,24 @@ CASE stMotionStage.nEnableMode OF
             IF bPosGoal THEN
                 IF stMotionStage.bAllForwardEnable THEN
                     stMotionStage.bEnable := TRUE;
-                ELSE
-                    stMotionStage.bError := TRUE;
-                    stMotionStage.nErrorId := 16#4358;
+                ELSIF NOT stMotionStage.bError THEN
+                    // Not an error, just a warning
+                    stMotionStage.sErrorMessage := 'Cannot move past positive limit.';
                 END_IF
             ELSIF bNegGoal THEN
                 IF stMotionStage.bAllBackwardEnable THEN
                     stMotionStage.bEnable := TRUE;
-                ELSE
-                    stMotionStage.bError := TRUE;
-                    stMotionStage.nErrorId := 16#4357;
+                ELSIF NOT stMotionStage.bError THEN
+                    // Not an error, just a warning
+                    stMotionStage.sErrorMessage := 'Cannot move past negative limit.';
                 END_IF
             END_IF
         END_IF
         bExecute := stMotionStage.bExecute AND stMotionStage.bEnableDone;
+        IF bExecute AND NOT stMotionStage.bError THEN
+            // Reset local warnings if things are going well
+            stMotionStage.sErrorMessage := '';
+        END_IF
 END_CASE
 
 // Automatically fill the correct nCmdData for homing


### PR DESCRIPTION
Prospective fix for @ghalym 's reported slits motion issues.

The code prior to this PR raises an error if we are:
- At a limit switch
- We try to move past the switch

Because the user should be told of this so they know why the stage didn't move.

However, the consequence of making it an error is that this will lock up the motion until the error is acknowledged and cleared. This means that automation routines (even just "move the slit blades together" routines) need to know to clear errors to make them work reliably, and then we run a risk of automatically clearing other error types that might be more serious. In practice now, this may lead to the state where we ask for the slits to open twice, then some axes get stuck at a limit, so asking the slits to close causes not all the blades to close.

Since this status is not dangerous to anyone or anything, this PR reduces it to a warning. A warning:
- Uses the same error text field as the errors
- Does not bring the axis into a MAJOR/MINOR alarm state
- Does not flip `bError` to TRUE
- Does not provide an error code
- Will clear itself automatically at the next successful move

This can be read clearly in the screen for the user to know why a motion did not begin, but does not lend risks to automation routines.
