### PR TITLE
MNT: unpin PMPS lib and rebuild

### DIFF
--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -409,7 +409,7 @@
   </ItemGroup>
   <ItemGroup>
     <PlaceholderResolution Include="PMPS">
-      <Resolution>PMPS, 0.5.0 (SLAC - LCLS)</Resolution>
+      <Resolution>PMPS, * (SLAC - LCLS)</Resolution>
     </PlaceholderResolution>
   </ItemGroup>
   <ItemGroup>

--- a/lcls-twincat-motion/Library/Library.tmc
+++ b/lcls-twincat-motion/Library/Library.tmc
@@ -31440,7 +31440,7 @@ External Setpoint Generation:
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2020-07-15T09:03:04</Value>
+          <Value>2020-07-15T09:23:11</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-twincat-motion/Library/Library.tmc
+++ b/lcls-twincat-motion/Library/Library.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{6AB428EB-B27F-DFA9-5812-11CB4733A631}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{70E3A81A-4537-7C2B-8CB4-D817AB9C08C3}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
@@ -23134,6 +23134,12 @@ External Setpoint Generation:
           <Value>1</Value>
         </Default>
       </SubItem>
+      <SubItem>
+        <Name>nLatchErrId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2464</BitOffs>
+      </SubItem>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31434,7 +31440,7 @@ External Setpoint Generation:
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2020-07-13T12:00:52</Value>
+          <Value>2020-07-15T09:03:04</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
Mistakenly had a 0.5.0 pin in the previous merge