### PR TITLE
ENH: Add +1 state allocation

### DIFF
--- a/lcls-twincat-motion/Library/GVLs/MOTION_GVL.TcGVL
+++ b/lcls-twincat-motion/Library/GVLs/MOTION_GVL.TcGVL
@@ -7,8 +7,8 @@ VAR_GLOBAL
     stInvalidState: DUT_PositionState;
 END_VAR
 VAR_GLOBAL CONSTANT
-    // Allocated space for 5 states besides Unknown (16 including Unknown is the max for an EPICS MBBI)
-    MAX_STATES: INT := 5;
+    // Allocated space for 6 states besides Unknown (16 including Unknown is the max for an EPICS MBBI)
+    MAX_STATES: INT := 6;
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/Library.tmc
+++ b/lcls-twincat-motion/Library/Library.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{12E5C0DE-6FF2-CDF1-66D4-B35B67225763}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{81FD7EDC-6BFF-5B9D-D2FB-B0C64C5D8EDA}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
@@ -153,6 +153,11 @@
         <Enum>5</Enum>
         <Comment>Sample delivery system</Comment>
       </EnumInfo>
+      <EnumInfo>
+        <Text>OPTICS</Text>
+        <Enum>6</Enum>
+        <Comment>Optics control system</Comment>
+      </EnumInfo>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.Tc3_EventLogger">I_ArgumentsChangeListener</Name>
@@ -215,31 +220,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>1267504</GetCodeOffs>
+        <GetCodeOffs>1197240</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>1267568</GetCodeOffs>
+        <GetCodeOffs>1197304</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>1267584</GetCodeOffs>
+        <GetCodeOffs>1197320</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>1267552</GetCodeOffs>
+        <GetCodeOffs>1197288</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>1267576</GetCodeOffs>
+        <GetCodeOffs>1197312</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1410,15 +1415,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>1267384</GetCodeOffs>
-        <SetCodeOffs>1267432</SetCodeOffs>
+        <GetCodeOffs>1197120</GetCodeOffs>
+        <SetCodeOffs>1197168</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>1267464</GetCodeOffs>
-        <SetCodeOffs>1267488</SetCodeOffs>
+        <GetCodeOffs>1197200</GetCodeOffs>
+        <SetCodeOffs>1197224</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
@@ -1681,31 +1686,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>1267680</GetCodeOffs>
+        <GetCodeOffs>1197416</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>1267640</GetCodeOffs>
+        <GetCodeOffs>1197376</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>1267808</GetCodeOffs>
+        <GetCodeOffs>1197544</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>1267728</GetCodeOffs>
+        <GetCodeOffs>1197464</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>1267816</GetCodeOffs>
+        <GetCodeOffs>1197552</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -2269,7 +2274,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>1267864</GetCodeOffs>
+        <GetCodeOffs>1197600</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -2445,8 +2450,117 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_Standard">F_TRIG</Name>
+      <Comment>
+	Falling Edge detection.
+</Comment>
+      <BitSize>96</BitSize>
+      <SubItem>
+        <Name>CLK</Name>
+        <Type>BOOL</Type>
+        <Comment> signal to detect </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> falling edge at signal detected </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>M</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Standard">R_TRIG</Name>
+      <Comment>
+	Rising Edge detection.
+</Comment>
+      <BitSize>96</BitSize>
+      <SubItem>
+        <Name>CLK</Name>
+        <Type>BOOL</Type>
+        <Comment> Signal to detect </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> rising edge at signal detected </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>M</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General">FB_LogMessage</Name>
-      <BitSize>129472</BitSize>
+      <BitSize>130240</BitSize>
       <SubItem>
         <Name>sMsg</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -2505,10 +2619,90 @@
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>nMinTimeViolationAcceptable</Name>
+        <Type>INT</Type>
+        <Comment> How many times the min. time can be violated before the CB trips</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>58160</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nLocalTripThreshold</Name>
+        <Type>TIME</Type>
+        <Comment> Minimum time between calls allowed, pairs with nMinTimeViolationAcceptable</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>58176</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTrickleTripThreshold</Name>
+        <Type>TIME</Type>
+        <Comment> Trickle trip, activated by global threshold, should be &gt;&gt; LocalTripThreshold</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>58208</BitOffs>
+        <Default>
+          <Value>100</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTripResetPeriod</Name>
+        <Type>TIME</Type>
+        <Comment> Time for auto-reset</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>58240</BitOffs>
+        <Default>
+          <Value>600000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableAutoReset</Name>
+        <Type>BOOL</Type>
+        <Comment>Enable circuit breaker auto-reset (true by default)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>58272</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>bInitialized</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>58152</BitOffs>
+        <BitOffs>58280</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -2517,7 +2711,7 @@
         <Name>bInitFailed</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>58160</BitOffs>
+        <BitOffs>58288</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -2526,13 +2720,13 @@
         <Name>sSubsystemSource</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>58168</BitOffs>
+        <BitOffs>58296</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMessage</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcMessage</Type>
         <BitSize>64</BitSize>
-        <BitOffs>58816</BitOffs>
+        <BitOffs>58944</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMessages</Name>
@@ -2542,46 +2736,55 @@
           <Elements>5</Elements>
         </ArrayInfo>
         <BitSize>61440</BitSize>
-        <BitOffs>58880</BitOffs>
+        <BitOffs>59008</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSource</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Type>
         <BitSize>6912</BitSize>
-        <BitOffs>120320</BitOffs>
+        <BitOffs>120448</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ipResultMessage</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Type>
         <BitSize>64</BitSize>
-        <BitOffs>127232</BitOffs>
+        <BitOffs>127360</BitOffs>
       </SubItem>
       <SubItem>
         <Name>hr</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>127296</BitOffs>
+        <BitOffs>127424</BitOffs>
       </SubItem>
       <SubItem>
         <Name>hrLastInternalError</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>127328</BitOffs>
+        <BitOffs>127456</BitOffs>
       </SubItem>
       <SubItem>
         <Name>eTraceLevel</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <BitOffs>127360</BitOffs>
+        <BitOffs>127488</BitOffs>
         <Default>
           <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstCall</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>127504</BitOffs>
+        <Default>
+          <Value>1</Value>
         </Default>
       </SubItem>
       <SubItem>
         <Name>sPath</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
         <BitSize>2048</BitSize>
-        <BitOffs>127376</BitOffs>
+        <BitOffs>127512</BitOffs>
         <Properties>
           <Property>
             <Name>instance-path</Name>
@@ -2591,6 +2794,109 @@
           </Property>
         </Properties>
       </SubItem>
+      <SubItem>
+        <Name>nTotalEvents</Name>
+        <Type>UINT</Type>
+        <Comment>////////////////////////////</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>129568</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nTimesViolated</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>129584</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LastCallTime</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>129600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CurrentCallTime</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>129664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DeltaSinceLastCall</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>129728</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>WhenTripsCleared</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>129792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftTrippedReleased</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>129856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLocalTrickleTripped</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>129952</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLocalTripped</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>129960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bTripped</Name>
+        <Type>BOOL</Type>
+        <Comment> Won't emit messages if true</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>129968</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+            pv: Tripped
+            io: i
+            field: DESC Log message FB tripped
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bResetBreaker</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>129976</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+            pv: Reset
+            io: o
+            field: DESC Rising-edge reset of trip
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtResetBreaker</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>129984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtTripped</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>130112</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>CircuitBreaker</Name>
+      </Action>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -3065,254 +3371,7 @@
       </SubItem>
     </DataType>
     <DataType>
-      <Name GUID="{D01709AA-9B4A-464A-B4D1-4BF476CFE7DE}">ST_PMPS_Attenuator_IO</Name>
-      <BitSize>32</BitSize>
-      <SubItem>
-        <Name>nTran</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xAttOK</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <Hides>
-        <Hide GUID="{76269EAC-36F0-4513-B811-3725FD02409A}"/>
-        <Hide GUID="{E96BEA56-6301-4A6A-BF6A-F08340C87594}"/>
-        <Hide GUID="{FE32F9A9-7E7A-413D-8D77-0C99C34D8CD9}"/>
-      </Hides>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">ST_PMPS_Attenuator</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType GUID="{D01709AA-9B4A-464A-B4D1-4BF476CFE7DE}">ST_PMPS_Attenuator_IO</ExtendsType>
-    </DataType>
-    <DataType>
-      <Name GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Name>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>Width</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
-        <Comment>distance between horizontal slits (x)</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: Width
-            io: i
-            field: EGU mm</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Height</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
-        <Comment>distance between vertical slits (y)</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: Height
-            io: i
-            field: EGU mm</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xOK</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <Comment>status of aperture, false if error or in motion</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>plcAttribute_pytmc</Name>
-            <Value>pv: OK
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">ST_PMPS_Aperture</Name>
-      <BitSize>96</BitSize>
-      <ExtendsType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</ExtendsType>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">ST_BeamParams</Name>
-      <BitSize>1216</BitSize>
-      <SubItem>
-        <Name>nTran</Name>
-        <Type>UINT</Type>
-        <Comment>  Requested pre-optic attenuation %  </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>100</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Transmission
-            io: i
-            field: EGU %
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nRate</Name>
-        <Type>UDINT</Type>
-        <Comment> Pulse-rate </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>120</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Rate
-            io: i
-            field: EGU Hz
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPP_mJ</Name>
-        <Type>REAL</Type>
-        <Comment> Per pulse max energy (mJ) </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>20</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: PulseEnergy
-            io: i
-            field: EGU mJ
-            field: DESC This beam parameter is non-op for now.
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>neVRange</Name>
-        <Type>WORD</Type>
-        <Comment> Photon energy ranges </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Default>
-          <Value>65535</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: PhotonEnergyRanges
-            io: i
-            field: EGU eV</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>binary</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astAttenuators</Name>
-        <Type Namespace="PMPS">ST_PMPS_Attenuator</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <Comment> Beamline attenuators </Comment>
-        <BitSize>512</BitSize>
-        <BitOffs>112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: AuxAtt
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>aStoppers</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <Comment> Stoppers </Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>624</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: ST
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astApertures</Name>
-        <Type Namespace="PMPS">ST_PMPS_Aperture</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>4</Elements>
-        </ArrayInfo>
-        <Comment> Apertures </Comment>
-        <BitSize>384</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xValidToggle</Name>
-        <Type>BOOL</Type>
-        <Comment> Toggle for watchdog</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xValid</Name>
-        <Type>BOOL</Type>
-        <Comment> Beam parameter set is valid (if readback), or acknowledged (if request)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Valid
-        io: i</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCohortInt</Name>
-        <Type>UDINT</Type>
-        <Comment> Cohort index. Identifies which cohort this BP set was included in arbitration</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>1184</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: Cohort
-        io: i
-            field: DESC Cohort inc on each arb cycle
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS.TcUnit">I_TestResultFormatter</Name>
+      <Name Namespace="LCLS_General.TcUnit">I_TestResultFormatter</Name>
       <BitSize>64</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -3429,14 +3488,14 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">FB_ADSTestResultFormatter</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_ADSTestResultFormatter</Name>
       <Comment>
     This function block reports the results from the tests using the built-in ADSLOGSTR functionality
     provided by the Tc2_System library. This sends the result using ADS, which is consumed by the error list
     of Visual Studio.
 </Comment>
       <BitSize>448</BitSize>
-      <Implements Namespace="PMPS.TcUnit">I_TestResultFormatter</Implements>
+      <Implements Namespace="LCLS_General.TcUnit">I_TestResultFormatter</Implements>
       <SubItem>
         <Name>ADSDelayTimer</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
@@ -3518,7 +3577,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">FB_TcUnitRunner</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_TcUnitRunner</Name>
       <Comment>
     This function block is responsible for holding track of the tests and executing them.
 </Comment>
@@ -3534,13 +3593,13 @@
       </SubItem>
       <SubItem>
         <Name>ADSTestResultFormatter</Name>
-        <Type Namespace="PMPS.TcUnit">FB_ADSTestResultFormatter</Type>
+        <Type Namespace="LCLS_General.TcUnit">FB_ADSTestResultFormatter</Type>
         <BitSize>448</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TestResultPrinter</Name>
-        <Type Namespace="PMPS.TcUnit">I_TestResultFormatter</Type>
+        <Type Namespace="LCLS_General.TcUnit">I_TestResultFormatter</Type>
         <BitSize>64</BitSize>
         <BitOffs>576</BitOffs>
       </SubItem>
@@ -3824,7 +3883,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">FB_AnyComparator</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_AnyComparator</Name>
       <Comment>
     This FB compares two instances of any object type and returns whether they
     are the same type, size and value or not. This is necessary for two reasons:
@@ -4464,7 +4523,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">FB_Test</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
 </Comment>
@@ -4526,60 +4585,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_Standard">R_TRIG</Name>
-      <Comment>
-	Rising Edge detection.
-</Comment>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>CLK</Name>
-        <Type>BOOL</Type>
-        <Comment> Signal to detect </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Q</Name>
-        <Type>BOOL</Type>
-        <Comment> rising edge at signal detected </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>72</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>M</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>80</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS.TcUnit">U_ExpectedOrActual</Name>
+      <Name Namespace="LCLS_General.TcUnit">U_ExpectedOrActual</Name>
       <BitSize>2048</BitSize>
       <SubItem>
         <Name>boolExpectedOrActual</Name>
@@ -4721,17 +4727,17 @@
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">ST_AssertResult</Name>
+      <Name Namespace="LCLS_General.TcUnit">ST_AssertResult</Name>
       <BitSize>8192</BitSize>
       <SubItem>
         <Name>Expected</Name>
-        <Type Namespace="PMPS.TcUnit">U_ExpectedOrActual</Type>
+        <Type Namespace="LCLS_General.TcUnit">U_ExpectedOrActual</Type>
         <BitSize>2048</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Actual</Name>
-        <Type Namespace="PMPS.TcUnit">U_ExpectedOrActual</Type>
+        <Type Namespace="LCLS_General.TcUnit">U_ExpectedOrActual</Type>
         <BitSize>2048</BitSize>
         <BitOffs>2048</BitOffs>
       </SubItem>
@@ -4749,11 +4755,11 @@
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">ST_AssertResultInstances</Name>
+      <Name Namespace="LCLS_General.TcUnit">ST_AssertResultInstances</Name>
       <BitSize>8256</BitSize>
       <SubItem>
         <Name>AssertResult</Name>
-        <Type Namespace="PMPS.TcUnit">ST_AssertResult</Type>
+        <Type Namespace="LCLS_General.TcUnit">ST_AssertResult</Type>
         <BitSize>8192</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -4773,7 +4779,7 @@
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">FB_AssertResultStatic</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_AssertResultStatic</Name>
       <Comment>
     This function block is responsible for keeping track of which asserts that have been made. The reason we need to
     keep track of these is because if the user does the same assert twice (because of running a test suite over several
@@ -4787,7 +4793,7 @@
       <BitSize>8224448</BitSize>
       <SubItem>
         <Name>AssertResults</Name>
-        <Type Namespace="PMPS.TcUnit">ST_AssertResult</Type>
+        <Type Namespace="LCLS_General.TcUnit">ST_AssertResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>500</Elements>
@@ -4812,7 +4818,7 @@
       </SubItem>
       <SubItem>
         <Name>AssertResultInstances</Name>
-        <Type Namespace="PMPS.TcUnit">ST_AssertResultInstances</Type>
+        <Type Namespace="LCLS_General.TcUnit">ST_AssertResultInstances</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>500</Elements>
@@ -5168,7 +5174,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Name>
+      <Name Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -5333,7 +5339,7 @@
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">ST_AssertArrayResult</Name>
+      <Name Namespace="LCLS_General.TcUnit">ST_AssertArrayResult</Name>
       <BitSize>4224</BitSize>
       <SubItem>
         <Name>ExpectedsSize</Name>
@@ -5344,7 +5350,7 @@
       </SubItem>
       <SubItem>
         <Name>ExpectedsTypeClass</Name>
-        <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
         <Comment> The data type of the expecteds-array</Comment>
         <BitSize>16</BitSize>
         <BitOffs>32</BitOffs>
@@ -5358,7 +5364,7 @@
       </SubItem>
       <SubItem>
         <Name>ActualsTypeClass</Name>
-        <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
         <Comment> The data type of the actuals-array</Comment>
         <BitSize>16</BitSize>
         <BitOffs>96</BitOffs>
@@ -5377,11 +5383,11 @@
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">ST_AssertArrayResultInstances</Name>
+      <Name Namespace="LCLS_General.TcUnit">ST_AssertArrayResultInstances</Name>
       <BitSize>4256</BitSize>
       <SubItem>
         <Name>AssertArrayResult</Name>
-        <Type Namespace="PMPS.TcUnit">ST_AssertArrayResult</Type>
+        <Type Namespace="LCLS_General.TcUnit">ST_AssertArrayResult</Type>
         <BitSize>4224</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -5401,7 +5407,7 @@
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">FB_AssertArrayResultStatic</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_AssertArrayResultStatic</Name>
       <Comment>
     This function block is responsible for keeping track of which array-asserts that have been made.
     The reason we need to keep track of these is because if the user does the same assert twice
@@ -5417,7 +5423,7 @@
       <BitSize>4240448</BitSize>
       <SubItem>
         <Name>AssertArrayResults</Name>
-        <Type Namespace="PMPS.TcUnit">ST_AssertArrayResult</Type>
+        <Type Namespace="LCLS_General.TcUnit">ST_AssertArrayResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>500</Elements>
@@ -5442,7 +5448,7 @@
       </SubItem>
       <SubItem>
         <Name>AssertArrayResultInstances</Name>
-        <Type Namespace="PMPS.TcUnit">ST_AssertArrayResultInstances</Type>
+        <Type Namespace="LCLS_General.TcUnit">ST_AssertArrayResultInstances</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>500</Elements>
@@ -5471,7 +5477,7 @@
         </Parameter>
         <Parameter>
           <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5481,7 +5487,7 @@
         </Parameter>
         <Parameter>
           <Name>ActualsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5509,7 +5515,7 @@
         </Parameter>
         <Parameter>
           <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5519,7 +5525,7 @@
         </Parameter>
         <Parameter>
           <Name>ActualsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5549,7 +5555,7 @@
         </Parameter>
         <Parameter>
           <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5559,7 +5565,7 @@
         </Parameter>
         <Parameter>
           <Name>ActualsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5589,7 +5595,7 @@
         </Parameter>
         <Parameter>
           <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5599,7 +5605,7 @@
         </Parameter>
         <Parameter>
           <Name>ActualsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5627,7 +5633,7 @@
         </Parameter>
         <Parameter>
           <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5637,7 +5643,7 @@
         </Parameter>
         <Parameter>
           <Name>ActualsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5724,7 +5730,7 @@
         </Parameter>
         <Parameter>
           <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5734,7 +5740,7 @@
         </Parameter>
         <Parameter>
           <Name>ActualsTypeClass</Name>
-          <Type Namespace="PMPS.TcUnit.IBaseLibrary">TypeClass</Type>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -5756,7 +5762,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">I_AssertMessageFormatter</Name>
+      <Name Namespace="LCLS_General.TcUnit">I_AssertMessageFormatter</Name>
       <BitSize>64</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -5784,7 +5790,7 @@
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax252CharLength</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_AdjustAssertFailureMessageToMax252CharLength</Name>
       <Comment>
     This function block is responsible for making sure that the asserted test instance path and test message are not
     loo long. The total printed message can not be more than 252 characters long.
@@ -5881,14 +5887,14 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">FB_ADSAssertMessageFormatter</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_ADSAssertMessageFormatter</Name>
       <Comment>
     This function block is responsible for printing the results of the assertions using the built-in
     ADSLOGSTR functionality provided by the Tc2_System library. This sends the result using ADS, which
     is consumed by the error list of Visual Studio.
 </Comment>
       <BitSize>128</BitSize>
-      <Implements Namespace="PMPS.TcUnit">I_AssertMessageFormatter</Implements>
+      <Implements Namespace="LCLS_General.TcUnit">I_AssertMessageFormatter</Implements>
       <Method>
         <Name>LogAssertFailure</Name>
         <Parameter>
@@ -5913,7 +5919,7 @@
         </Parameter>
         <Local>
           <Name>AdjustAssertFailureMessageToMax252CharLength</Name>
-          <Type Namespace="PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax252CharLength</Type>
+          <Type Namespace="LCLS_General.TcUnit">FB_AdjustAssertFailureMessageToMax252CharLength</Type>
           <BitSize>11616</BitSize>
         </Local>
         <Local>
@@ -5950,7 +5956,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">FB_TestSuite</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_TestSuite</Name>
       <Comment> This function block is responsible for holding the internal state of the test suite.
    Every test suite can have one or more tests, and every test can do one or more asserts.
    It's also responsible for providing all the assert-methods for asserting different data types.
@@ -5988,7 +5994,7 @@
       </SubItem>
       <SubItem>
         <Name>Tests</Name>
-        <Type Namespace="PMPS.TcUnit">FB_Test</Type>
+        <Type Namespace="LCLS_General.TcUnit">FB_Test</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>100</Elements>
@@ -6018,25 +6024,25 @@
       </SubItem>
       <SubItem>
         <Name>AssertResults</Name>
-        <Type Namespace="PMPS.TcUnit">FB_AssertResultStatic</Type>
+        <Type Namespace="LCLS_General.TcUnit">FB_AssertResultStatic</Type>
         <BitSize>8224448</BitSize>
         <BitOffs>229632</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertArrayResult</Name>
-        <Type Namespace="PMPS.TcUnit">FB_AssertArrayResultStatic</Type>
+        <Type Namespace="LCLS_General.TcUnit">FB_AssertArrayResultStatic</Type>
         <BitSize>4240448</BitSize>
         <BitOffs>8454080</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSAssertMessageFormatter</Name>
-        <Type Namespace="PMPS.TcUnit">FB_ADSAssertMessageFormatter</Type>
+        <Type Namespace="LCLS_General.TcUnit">FB_ADSAssertMessageFormatter</Type>
         <BitSize>128</BitSize>
         <BitOffs>12694528</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertMessageFormatter</Name>
-        <Type Namespace="PMPS.TcUnit">I_AssertMessageFormatter</Type>
+        <Type Namespace="LCLS_General.TcUnit">I_AssertMessageFormatter</Type>
         <BitSize>64</BitSize>
         <BitOffs>12694656</BitOffs>
       </SubItem>
@@ -6136,6 +6142,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -6271,6 +6282,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -6430,6 +6446,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfSuccessfulTests</Name>
@@ -6536,6 +6557,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -6672,6 +6698,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_LINT</Name>
@@ -6763,7 +6794,7 @@
         </Local>
         <Local>
           <Name>AnyComparator</Name>
-          <Type Namespace="PMPS.TcUnit">FB_AnyComparator</Type>
+          <Type Namespace="LCLS_General.TcUnit">FB_AnyComparator</Type>
           <BitSize>384</BitSize>
         </Local>
         <Local>
@@ -7134,6 +7165,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -7878,6 +7914,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_TIME</Name>
@@ -8256,6 +8297,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_INT</Name>
@@ -8347,6 +8393,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -8474,6 +8525,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_LWORD</Name>
@@ -8575,6 +8631,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -8879,6 +8940,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AreAllTestsFinished</Name>
@@ -9043,6 +9109,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -9227,6 +9298,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_LREAL</Name>
@@ -9327,6 +9403,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -9342,7 +9423,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">ST_ADSLogStringMessage</Name>
+      <Name Namespace="LCLS_General.TcUnit">ST_ADSLogStringMessage</Name>
       <BitSize>4096</BitSize>
       <SubItem>
         <Name>MsgFmtStr</Name>
@@ -9605,7 +9686,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS.TcUnit">FB_ADSLogStringMessageFifoQueue</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_ADSLogStringMessageFifoQueue</Name>
       <Comment> This function block is responsible for making sure that the ADSLOGSTR-messages to the ADS-router are transmitted
    cyclically and not in a burst. The reason this is necessary is because that if too many messages are sent at the
    same time some get lost and are never printed to the error list output
@@ -9701,7 +9782,7 @@
         </Parameter>
         <Local>
           <Name>AdsLogStringMessage</Name>
-          <Type Namespace="PMPS.TcUnit">ST_ADSLogStringMessage</Type>
+          <Type Namespace="LCLS_General.TcUnit">ST_ADSLogStringMessage</Type>
           <BitSize>4096</BitSize>
         </Local>
       </Method>
@@ -9709,7 +9790,7 @@
         <Name>GetLog</Name>
         <Parameter>
           <Name>AdsLogStringMessage</Name>
-          <Type Namespace="PMPS.TcUnit">ST_ADSLogStringMessage</Type>
+          <Type Namespace="LCLS_General.TcUnit">ST_ADSLogStringMessage</Type>
           <BitSize>4096</BitSize>
           <Properties>
             <Property>
@@ -9735,6 +9816,789 @@
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{D01709AA-9B4A-464A-B4D1-4BF476CFE7DE}">ST_PMPS_Attenuator_IO</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>nTran</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xAttOK</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <Hides>
+        <Hide GUID="{76269EAC-36F0-4513-B811-3725FD02409A}"/>
+        <Hide GUID="{E96BEA56-6301-4A6A-BF6A-F08340C87594}"/>
+        <Hide GUID="{FE32F9A9-7E7A-413D-8D77-0C99C34D8CD9}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">ST_PMPS_Attenuator</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType GUID="{D01709AA-9B4A-464A-B4D1-4BF476CFE7DE}">ST_PMPS_Attenuator_IO</ExtendsType>
+    </DataType>
+    <DataType>
+      <Name GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Name>
+      <BitSize>96</BitSize>
+      <SubItem>
+        <Name>Width</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
+        <Comment>distance between horizontal slits (x)</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: Width
+            io: i
+            field: EGU mm</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Height</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
+        <Comment>distance between vertical slits (y)</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: Height
+            io: i
+            field: EGU mm</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xOK</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <Comment>status of aperture, false if error or in motion</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>plcAttribute_pytmc</Name>
+            <Value>pv: OK
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">ST_PMPS_Aperture</Name>
+      <BitSize>96</BitSize>
+      <ExtendsType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</ExtendsType>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">ST_BeamParams</Name>
+      <BitSize>1216</BitSize>
+      <SubItem>
+        <Name>nTran</Name>
+        <Type>UINT</Type>
+        <Comment>  Requested pre-optic attenuation %  </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>100</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Transmission
+            io: i
+            field: EGU %
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nRate</Name>
+        <Type>UDINT</Type>
+        <Comment> Pulse-rate </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>120</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Rate
+            io: i
+            field: EGU Hz
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPP_mJ</Name>
+        <Type>REAL</Type>
+        <Comment> Per pulse max energy (mJ) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>20</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: PulseEnergy
+            io: i
+            field: EGU mJ
+            field: DESC This beam parameter is non-op for now.
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>neVRange</Name>
+        <Type>WORD</Type>
+        <Comment> Photon energy ranges </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>65535</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: PhotonEnergyRanges
+            io: i
+            field: EGU eV</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>binary</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astAttenuators</Name>
+        <Type Namespace="PMPS">ST_PMPS_Attenuator</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> Beamline attenuators </Comment>
+        <BitSize>512</BitSize>
+        <BitOffs>112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: AuxAtt
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>aStoppers</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> Stoppers </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: ST
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astApertures</Name>
+        <Type Namespace="PMPS">ST_PMPS_Aperture</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>4</Elements>
+        </ArrayInfo>
+        <Comment> Apertures </Comment>
+        <BitSize>384</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xValidToggle</Name>
+        <Type>BOOL</Type>
+        <Comment> Toggle for watchdog</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xValid</Name>
+        <Type>BOOL</Type>
+        <Comment> Beam parameter set is valid (if readback), or acknowledged (if request)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Valid
+        io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCohortInt</Name>
+        <Type>UDINT</Type>
+        <Comment> Cohort index. Identifies which cohort this BP set was included in arbitration</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Cohort
+        io: i
+            field: DESC Cohort inc on each arb cycle
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">PE_Ranges</Name>
+      <Comment> Does nothing other than set the gvl for photon energy bitmask to one of two constants, K or L.
+ Workaround for compile defines not fully working for libraries at the time of writing this.
+ Otherwise I would have just used the compile define in the GVL declaration.</Comment>
+      <BitSize>64</BitSize>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.Tc3_JsonXml">FB_JsonSaxWriter</Name>
+      <Comment> | Provides the functionality to create a JSON document.
+ | Steps of documentation creation:
+ | 1. StartObject() to start a new object in the document.
+ | 2. Add several keys/values via AddKeyString() and the other methods.
+ | 3. EndObject() to finish object.
+ | 4. GetDocument() in order to get the full document as string.
+ | 5. ResetDocument() if a new document should be created with the same SaxWriter instance.</Comment>
+      <BitSize>384</BitSize>
+      <SubItem>
+        <Name>initStatus</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ipWriter</Name>
+        <Type GUID="{E695C12A-2D9A-408E-B9B2-508D7CE3AF9A}">ITcJsonSaxWriter</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ipWriter2</Name>
+        <Type GUID="{472183F9-5D09-4D8C-92FD-E0524EF658BF}">ITcJsonSaxWriter2</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CLSID_TcJsonSaxWriter</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000024}">CLSID</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.Data1</Name>
+            <Value>3870298264</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data2</Name>
+            <Value>56256</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data3</Name>
+            <Value>17669</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[0]</Name>
+            <Value>158</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[1]</Name>
+            <Value>60</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[2]</Name>
+            <Value>93</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[3]</Name>
+            <Value>248</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[4]</Name>
+            <Value>70</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[5]</Name>
+            <Value>150</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[6]</Name>
+            <Value>7</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[7]</Name>
+            <Value>196</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <Method>
+        <Name>AddKeyNumber</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddString</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKeyFileTime</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsComplete</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AddUdint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddLint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddLreal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKey</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ResetDocument</Name>
+      </Method>
+      <Method>
+        <Name>AddKeyLreal</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>StartObject</Name>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddKeyDcTime</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDateTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddRawObject</Name>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetMaxDecimalPlaces</Name>
+        <Parameter>
+          <Name>decimalPlaces</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="0">__get_ipWriter</Name>
+        <ReturnType GUID="{E695C12A-2D9A-408E-B9B2-508D7CE3AF9A}" RpcDirection="out">ITcJsonSaxWriter</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>_ipWriter</Name>
+          <Type GUID="{E695C12A-2D9A-408E-B9B2-508D7CE3AF9A}">ITcJsonSaxWriter</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>AddKeyBool</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddDint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddRawArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKeyString</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CopyDocument</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of the target string buffer</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddKeyDateTime</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBool</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBase64</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDcTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EndArray</Name>
+      </Method>
+      <Method>
+        <Name>EndObject</Name>
+      </Method>
+      <Method>
+        <Name>StartArray</Name>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
         </Property>
       </Properties>
     </DataType>
@@ -15263,2096 +16127,6 @@ External Setpoint Generation:
         <BitSize>768</BitSize>
         <BitOffs>20288</BitOffs>
       </SubItem>
-    </DataType>
-    <DataType>
-      <Name>DUT_PositionState</Name>
-      <BitSize>2432</BitSize>
-      <SubItem>
-        <Name>sName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Name as queried via the NAME PV in EPICS</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <String>Invalid</String>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: NAME
-        io: input
-        field: DESC Name of this position state
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosition</Name>
-        <Type>LREAL</Type>
-        <Comment> Position associated with this state</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: SETPOINT
-        io: io
-        field: DESC Axis position associated with this state
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nEncoderCount</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ENCODER
-        io: i
-        field: DESC Encoder count associated with this state
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDelta</Name>
-        <Type>LREAL</Type>
-        <Comment> Maximum allowable deviation from fPosition while at the state</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DELTA
-        io: io
-        field: DRVL 0.0
-        field: DESC Max deviation from position at this state
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fVelocity</Name>
-        <Type>LREAL</Type>
-        <Comment> Speed at which to move to this state</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>896</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: VELO
-        io: io
-        field: DESC Speed at which to move to this state
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fAccel</Name>
-        <Type>LREAL</Type>
-        <Comment> (optional) Acceleration to use for moves to this state</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ACCL
-        io: io
-        field: DESC Acceleration to use for moves to this state
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDecel</Name>
-        <Type>LREAL</Type>
-        <Comment> (optional) Deceleration to use for moves to this state</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1024</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DCCL
-        io: io
-        field: DESC Deceleration to use for moves to this state
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveOk</Name>
-        <Type>BOOL</Type>
-        <Comment> Safety parameter. This must be set to TRUE by the PLC program to allow moves to this state. This is expected to change as conditions change.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: MOVE_OK
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if the move would be safe
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bLocked</Name>
-        <Type>BOOL</Type>
-        <Comment> Signifies to FB_PositionStateLock that this state should be immutable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1096</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: LOCKED
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if state is immutable
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bValid</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE when you make your state. This defaults to FALSE so that uninitialized states can never be moved to</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1104</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: VALID
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if this is a real state
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bUseRawCounts</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE when you want to use the raw encoder counts to define the state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1112</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bUpdated</Name>
-        <Type>BOOL</Type>
-        <Comment> Is set to TRUE by FB_PositionStateInternal when called</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1120</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stBeamParams</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <Comment> Beam parameters associated with this state</Comment>
-        <BitSize>1216</BitSize>
-        <BitOffs>1152</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.nTran</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.fPP_mJ</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.neVRange</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.nRate</Name>
-            <Value>0</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nRequestAssertionID</Name>
-        <Type>UDINT</Type>
-        <Comment> Transition ID associated with this state</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2368</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name>ENUM_MotionRequest</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>WAIT</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>INTERRUPT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ABORT</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Standard">F_TRIG</Name>
-      <Comment>
-	Falling Edge detection.
-</Comment>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>CLK</Name>
-        <Type>BOOL</Type>
-        <Comment> signal to detect </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Q</Name>
-        <Type>BOOL</Type>
-        <Comment> falling edge at signal detected </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>72</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>M</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>80</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>FB_MotionRequest</Name>
-      <BitSize>1920</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type ReferenceTo="true">DUT_MotionStage</Type>
-        <Comment> Motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Start move on rising edge, stop move on falling edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Reset errors on rising edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumMotionRequest</Name>
-        <Type>ENUM_MotionRequest</Type>
-        <Comment> Define behavior for when the motor is already moving</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>144</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPos</Name>
-        <Type>LREAL</Type>
-        <Comment> Goal position</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fVel</Name>
-        <Type>LREAL</Type>
-        <Comment> Move velocity</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fAcc</Name>
-        <Type>LREAL</Type>
-        <Comment> Optional acceleration</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDec</Name>
-        <Type>LREAL</Type>
-        <Comment> Optional deceleration</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> True if in error state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorId</Name>
-        <Type>UDINT</Type>
-        <Comment> Error code</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>480</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> What the error code means</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are moving the motor</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are not moving the motor and our most recent move was successful</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1168</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rtExec</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftExec</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>1344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReset</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>1472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftBusy</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>1600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nState</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1696</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bMyMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1712</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bCausedError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1720</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>INIT</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1728</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_EXEC</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1744</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>PICK_REQUEST</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1760</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_OTHER_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1776</BitOffs>
-        <Default>
-          <Value>3</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>STOP_OTHER_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1792</BitOffs>
-        <Default>
-          <Value>4</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>START_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1808</BitOffs>
-        <Default>
-          <Value>5</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_MY_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1824</BitOffs>
-        <Default>
-          <Value>6</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>STOP_MY_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1840</BitOffs>
-        <Default>
-          <Value>7</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>DONE_MOVING</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1856</BitOffs>
-        <Default>
-          <Value>8</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ERROR</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1872</BitOffs>
-        <Default>
-          <Value>9</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>FB_PositionStateMove</Name>
-      <BitSize>2944</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type ReferenceTo="true">DUT_MotionStage</Type>
-        <Comment> Motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type ReferenceTo="true">DUT_PositionState</Type>
-        <Comment> State to move to</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv:
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Start move on rising edge, stop move on falling edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GO
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Rising edge error reset</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RESET
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumMotionRequest</Name>
-        <Type>ENUM_MotionRequest</Type>
-        <Comment> Define behavior for when a move is already active</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>208</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAtState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if the motor is at this state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: AT_STATE
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we have an error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>232</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorID</Name>
-        <Type>UDINT</Type>
-        <Comment> Error code</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRID
-        io: input
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Error description</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRMSG
-        io: input
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we are moving to a state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>936</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: BUSY
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we are note moving and we reached a state successfully on our last move</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>944</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DONE
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionRequest</Name>
-        <Type>FB_MotionRequest</Type>
-        <BitSize>1920</BitSize>
-        <BitOffs>960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bAllowMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2880</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>ENUM_EpicsInOut</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>UNKNOWN</Text>
-        <Enum>0</Enum>
-        <Comment> UNKNOWN must be in slot 0 or the FB breaks</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-        <Comment> OUT at slot 1 is a convention</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>IN</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name>FB_RawCountConverter</Name>
-      <BitSize>8576</BitSize>
-      <SubItem>
-        <Name>stParameters</Name>
-        <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
-        <Comment> Parameters to check against</Comment>
-        <BitSize>8192</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCountCheck</Name>
-        <Type>UDINT</Type>
-        <Comment> Optional count to convert to a real position</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>8256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosCheck</Name>
-        <Type>LREAL</Type>
-        <Comment> Optional position to convert to encoder counts</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>8320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCountGet</Name>
-        <Type>UDINT</Type>
-        <Comment> If converting position, the number of counts</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>8384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosGet</Name>
-        <Type>LREAL</Type>
-        <Comment> If converting counts, the position</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>8448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> True during a parameter get/calc</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> True after a successful get/calc</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8520</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> True if the calculation errored</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>FB_PositionStateLock</Name>
-      <BitSize>2688</BitSize>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type ReferenceTo="true">DUT_PositionState</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stCachedPositionState</Name>
-        <Type>DUT_PositionState</Type>
-        <BitSize>2432</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2624</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>FB_PositionStateInternal</Name>
-      <BitSize>11456</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type ReferenceTo="true">DUT_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type ReferenceTo="true">DUT_PositionState</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbEncConverter</Name>
-        <Type>FB_RawCountConverter</Type>
-        <BitSize>8576</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbLock</Name>
-        <Type>FB_PositionStateLock</Type>
-        <BitSize>2688</BitSize>
-        <BitOffs>8768</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>FB_PositionStateManager</Name>
-      <BitSize>180928</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type ReferenceTo="true">DUT_MotionStage</Type>
-        <Comment> Motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrStates</Name>
-        <Type>DUT_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Allocated space for 15 states besides Unknown (16 is the max for an EPICS MBBI)</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv:
-        io: io
-        expand: %.2d
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>setState</Name>
-        <Type ReferenceTo="true">INT</Type>
-        <Comment> Corresponding arrStates index to move to, or 0 if no move selected</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, start a move when setState transitions to a nonzero number</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> On rising edge, reset this FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>264</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RESET
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, there is an error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorId</Name>
-        <Type>UDINT</Type>
-        <Comment> Error ID</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRID
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The error that caused bError to flip TRUE</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRMSG
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are moving the motor</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>968</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: BUSY
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are not moving the motor and the last move completed successfully</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>976</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DONE
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>goalState</Name>
-        <Type>INT</Type>
-        <Comment> The current position we are trying to reach, or 0</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>992</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>getState</Name>
-        <Type>INT</Type>
-        <Comment> The readback position</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>1008</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stUnknown</Name>
-        <Type>DUT_PositionState</Type>
-        <BitSize>2432</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stGoal</Name>
-        <Type>DUT_PositionState</Type>
-        <BitSize>2432</BitSize>
-        <BitOffs>3520</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateMove</Name>
-        <Type>FB_PositionStateMove</Type>
-        <BitSize>2944</BitSize>
-        <BitOffs>5952</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateInternal</Name>
-        <Type>FB_PositionStateInternal</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <BitSize>171840</BitSize>
-        <BitOffs>8896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>180736</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bNewGoal</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>180752</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInnerExec</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>180760</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInnerReset</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>180768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReset</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>180800</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveRequested</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>180896</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>FB_EpicsInOut</Name>
-      <BitSize>218496</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type ReferenceTo="true">DUT_MotionStage</Type>
-        <Comment> Motor to apply states to</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stOut</Name>
-        <Type ReferenceTo="true">DUT_PositionState</Type>
-        <Comment> NOTE: Do not pragma these, let it happen in the manager.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stIn</Name>
-        <Type ReferenceTo="true">DUT_PositionState</Type>
-        <Comment> Information about the IN parameter</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, the motor will be moved when enumSet is changed</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumSet</Name>
-        <Type>ENUM_EpicsInOut</Type>
-        <Comment> NOTE: Please copy this pragma exactly on your enumSet</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: SET
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> NOTE: do not pragma these, already has pragma in manager</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorId</Name>
-        <Type>UDINT</Type>
-        <Comment> Error code</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Message associated with bError = TRUE</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>352</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are currently moving between states</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1000</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we asked for a move between states, it completed successfully, and there is no ongoing move</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1008</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumGet</Name>
-        <Type>ENUM_EpicsInOut</Type>
-        <Comment> NOTE: Please copy this pragma exactly on your enumGet</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>1024</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GET
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1040</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>arrStates</Name>
-        <Type>DUT_PositionState</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <BitSize>36480</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateManager</Name>
-        <Type>FB_PositionStateManager</Type>
-        <Comment> NOTE: Please copy this pragma exactly to pick up the standard PVs</Comment>
-        <BitSize>180928</BitSize>
-        <BitOffs>37568</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv:
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>VERSION</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>uiMajor</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>uiMinor</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>uiServicePack</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>uiPatch</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>48</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name GUID="{5456DAC5-9FA5-4A6B-B497-840FCC690FDD}" Namespace="PLC" TcBaseType="true">PlcLicenseInfo</Name>
-      <BitSize>1024</BitSize>
-      <SubItem>
-        <Name>LicenseId</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Instances</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LicenseName</Name>
-        <Type GUID="{18071995-0000-0000-0000-00010000005F}">STRING(95)</Type>
-        <BitSize>768</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}" Namespace="PLC" TcBaseType="true">PlcAppSystemInfo</Name>
-      <BitSize>2048</BitSize>
-      <SubItem>
-        <Name>ObjId</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TaskCnt</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OnlineChangeCnt</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Flags</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AdsPort</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>BootDataLoaded</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OldBootData</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AppTimestamp</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000004C}">DT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>KeepOutputsOnBP</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ShutdownInProgress</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>200</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LicensesPending</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>BSODOccured</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LoggedIn</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TComSrvPtr</Name>
-        <Type GUID="{00000030-0000-0000-E000-000000000064}">ITComObjectServer</Type>
-        <BitSize X64="64">32</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcComInterface</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>AppName</Name>
-        <Type GUID="{18071995-0000-0000-0000-00010000003F}">STRING(63)</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ProjectName</Name>
-        <Type GUID="{18071995-0000-0000-0000-00010000003F}">STRING(63)</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <Hides>
-        <Hide GUID="{D91E046A-A488-4D27-8D43-0F3C40ED5081}"/>
-        <Hide GUID="{5DCEB2BC-E196-43AD-80B7-EBACF31A430B}"/>
-        <Hide GUID="{1B9FDDE4-B3B7-4F0F-AB14-24EDC2F643E7}"/>
-        <Hide GUID="{C1C52E30-BC0B-44CA-BF39-E2FE7F2D145C}"/>
-      </Hides>
-    </DataType>
-    <DataType>
-      <Name GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}" Namespace="PLC" TcBaseType="true">PlcTaskSystemInfo</Name>
-      <BitSize>1024</BitSize>
-      <SubItem>
-        <Name>ObjId</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CycleTime</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Priority</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AdsPort</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CycleCount</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DcTaskTime</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000C}">LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LastExecTime</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>FirstCycle</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CycleTimeExceeded</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>232</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>InCallAfterOutputUpdate</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>240</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>RTViolation</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>248</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TaskName</Name>
-        <Type GUID="{18071995-0000-0000-0000-00010000003F}">STRING(63)</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <Hides>
-        <Hide GUID="{6A76D020-03A2-465C-A678-C341951E9EF3}"/>
-        <Hide GUID="{6F7D679F-72A0-4831-A7F1-085F839743ED}"/>
-      </Hides>
-    </DataType>
-    <DataType>
-      <Name>_Implicit_KindOfTask</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>_implicit_cyclic</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>_implicit_event</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>_implicit_external</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>_implicit_freewheeling</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name>_Implicit_Jitter_Distribution</Name>
-      <BitSize>48</BitSize>
-      <SubItem>
-        <Name>wRangeMax</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wCountJitterNeg</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wCountJitterPos</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>hide</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>_Implicit_Task_Info</Name>
-      <BitSize>896</BitSize>
-      <SubItem>
-        <Name>dwVersion</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>pszName</Name>
-        <Type PointerTo="1">STRING(80)</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nPriority</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>KindOf</Name>
-        <Type>_Implicit_KindOfTask</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>144</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bWatchdog</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bProfilingTask</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>168</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwEventFunctionPointer</Name>
-        <Type PointerTo="1">BYTE</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>pszExternalEvent</Name>
-        <Type PointerTo="1">STRING(80)</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwTaskEntryFunctionPointer</Name>
-        <Type PointerTo="1">BYTE</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwWatchdogSensitivity</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwInterval</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>416</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwWatchdogTime</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwLastCycleTime</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwAverageCycleTime</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwMaxCycleTime</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwMinCycleTime</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diJitter</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diJitterMin</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diJitterMax</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwCycleCount</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wTaskStatus</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>736</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wNumOfJitterDistributions</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>752</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>pJitterDistribution</Name>
-        <Type PointerTo="1">_Implicit_Jitter_Distribution</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bWithinSPSTimeSlicing</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>byDummy</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>840</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bShouldBlock</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bActive</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>856</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwIECCycleCount</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>864</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>hide</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
-      <DisplayName TxtId="">Log event</DisplayName>
-      <EventId>
-        <Name Id="0">Critical</Name>
-        <DisplayName TxtId="">Critical</DisplayName>
-        <Severity>Critical</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="1">Error</Name>
-        <DisplayName TxtId="">Error</DisplayName>
-        <Severity>Error</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="2">Warning</Name>
-        <DisplayName TxtId="">Warning</DisplayName>
-        <Severity>Warning</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="3">Info</Name>
-        <DisplayName TxtId="">Info</DisplayName>
-        <Severity>Info</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="4">Verbose</Name>
-        <DisplayName TxtId="">Verbose</DisplayName>
-        <Severity>Verbose</Severity>
-      </EventId>
-      <Hides>
-        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
-        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
-        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
-        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
-        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
-        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
-        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
-      </Hides>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_E_TcMC_STATES</Name>
@@ -25267,6 +24041,1315 @@ External Setpoint Generation:
         </Property>
       </Properties>
     </DataType>
+    <DataType>
+      <Name>DUT_PositionState</Name>
+      <BitSize>2432</BitSize>
+      <SubItem>
+        <Name>sName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Name as queried via the NAME PV in EPICS</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <String>Invalid</String>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: NAME
+        io: input
+        field: DESC Name of this position state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosition</Name>
+        <Type>LREAL</Type>
+        <Comment> Position associated with this state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: SETPOINT
+        io: io
+        field: DESC Axis position associated with this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nEncoderCount</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ENCODER
+        io: i
+        field: DESC Encoder count associated with this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDelta</Name>
+        <Type>LREAL</Type>
+        <Comment> Maximum allowable deviation from fPosition while at the state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DELTA
+        io: io
+        field: DRVL 0.0
+        field: DESC Max deviation from position at this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVelocity</Name>
+        <Type>LREAL</Type>
+        <Comment> Speed at which to move to this state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: VELO
+        io: io
+        field: DESC Speed at which to move to this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fAccel</Name>
+        <Type>LREAL</Type>
+        <Comment> (optional) Acceleration to use for moves to this state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ACCL
+        io: io
+        field: DESC Acceleration to use for moves to this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDecel</Name>
+        <Type>LREAL</Type>
+        <Comment> (optional) Deceleration to use for moves to this state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DCCL
+        io: io
+        field: DESC Deceleration to use for moves to this state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveOk</Name>
+        <Type>BOOL</Type>
+        <Comment> Safety parameter. This must be set to TRUE by the PLC program to allow moves to this state. This is expected to change as conditions change.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MOVE_OK
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if the move would be safe
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bLocked</Name>
+        <Type>BOOL</Type>
+        <Comment> Signifies to FB_PositionStateLock that this state should be immutable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1096</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: LOCKED
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if state is immutable
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE when you make your state. This defaults to FALSE so that uninitialized states can never be moved to</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: VALID
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if this is a real state
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bUseRawCounts</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE when you want to use the raw encoder counts to define the state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bUpdated</Name>
+        <Type>BOOL</Type>
+        <Comment> Is set to TRUE by FB_PositionStateInternal when called</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1120</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stBeamParams</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment> Beam parameters associated with this state</Comment>
+        <BitSize>1216</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.nTran</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fPP_mJ</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.neVRange</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nRate</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nRequestAssertionID</Name>
+        <Type>UDINT</Type>
+        <Comment> Transition ID associated with this state</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2368</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name>ENUM_MotionRequest</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>WAIT</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>INTERRUPT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ABORT</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name>FB_MotionRequest</Name>
+      <BitSize>1920</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type ReferenceTo="true">DUT_MotionStage</Type>
+        <Comment> Motor to move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Start move on rising edge, stop move on falling edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Reset errors on rising edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>enumMotionRequest</Name>
+        <Type>ENUM_MotionRequest</Type>
+        <Comment> Define behavior for when the motor is already moving</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPos</Name>
+        <Type>LREAL</Type>
+        <Comment> Goal position</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVel</Name>
+        <Type>LREAL</Type>
+        <Comment> Move velocity</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fAcc</Name>
+        <Type>LREAL</Type>
+        <Comment> Optional acceleration</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDec</Name>
+        <Type>LREAL</Type>
+        <Comment> Optional deceleration</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> True if in error state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorId</Name>
+        <Type>UDINT</Type>
+        <Comment> Error code</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> What the error code means</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are moving the motor</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are not moving the motor and our most recent move was successful</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1168</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftExec</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>1472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>1600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nState</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1696</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bMyMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1712</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bCausedError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1720</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>INIT</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_EXEC</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1744</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>PICK_REQUEST</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1760</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_OTHER_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1776</BitOffs>
+        <Default>
+          <Value>3</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>STOP_OTHER_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1792</BitOffs>
+        <Default>
+          <Value>4</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>START_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1808</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_MY_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1824</BitOffs>
+        <Default>
+          <Value>6</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>STOP_MY_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1840</BitOffs>
+        <Default>
+          <Value>7</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>DONE_MOVING</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1856</BitOffs>
+        <Default>
+          <Value>8</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ERROR</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1872</BitOffs>
+        <Default>
+          <Value>9</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>FB_PositionStateMove</Name>
+      <BitSize>2944</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type ReferenceTo="true">DUT_MotionStage</Type>
+        <Comment> Motor to move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type ReferenceTo="true">DUT_PositionState</Type>
+        <Comment> State to move to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv:
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Start move on rising edge, stop move on falling edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: GO
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge error reset</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RESET
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>enumMotionRequest</Name>
+        <Type>ENUM_MotionRequest</Type>
+        <Comment> Define behavior for when a move is already active</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>208</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAtState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if the motor is at this state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: AT_STATE
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we have an error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorID</Name>
+        <Type>UDINT</Type>
+        <Comment> Error code</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRID
+        io: input
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Error description</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRMSG
+        io: input
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we are moving to a state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>936</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BUSY
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we are note moving and we reached a state successfully on our last move</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>944</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DONE
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionRequest</Name>
+        <Type>FB_MotionRequest</Type>
+        <BitSize>1920</BitSize>
+        <BitOffs>960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAllowMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2880</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>VERSION</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>uiMajor</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>uiMinor</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>uiServicePack</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>uiPatch</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>48</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name GUID="{5456DAC5-9FA5-4A6B-B497-840FCC690FDD}" Namespace="PLC" TcBaseType="true">PlcLicenseInfo</Name>
+      <BitSize>1024</BitSize>
+      <SubItem>
+        <Name>LicenseId</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Instances</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LicenseName</Name>
+        <Type GUID="{18071995-0000-0000-0000-00010000005F}">STRING(95)</Type>
+        <BitSize>768</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}" Namespace="PLC" TcBaseType="true">PlcAppSystemInfo</Name>
+      <BitSize>2048</BitSize>
+      <SubItem>
+        <Name>ObjId</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TaskCnt</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OnlineChangeCnt</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Flags</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AdsPort</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>BootDataLoaded</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OldBootData</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AppTimestamp</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000004C}">DT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>KeepOutputsOnBP</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ShutdownInProgress</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LicensesPending</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>BSODOccured</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LoggedIn</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TComSrvPtr</Name>
+        <Type GUID="{00000030-0000-0000-E000-000000000064}">ITComObjectServer</Type>
+        <BitSize X64="64">32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcComInterface</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>AppName</Name>
+        <Type GUID="{18071995-0000-0000-0000-00010000003F}">STRING(63)</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ProjectName</Name>
+        <Type GUID="{18071995-0000-0000-0000-00010000003F}">STRING(63)</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <Hides>
+        <Hide GUID="{D91E046A-A488-4D27-8D43-0F3C40ED5081}"/>
+        <Hide GUID="{5DCEB2BC-E196-43AD-80B7-EBACF31A430B}"/>
+        <Hide GUID="{1B9FDDE4-B3B7-4F0F-AB14-24EDC2F643E7}"/>
+        <Hide GUID="{C1C52E30-BC0B-44CA-BF39-E2FE7F2D145C}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}" Namespace="PLC" TcBaseType="true">PlcTaskSystemInfo</Name>
+      <BitSize>1024</BitSize>
+      <SubItem>
+        <Name>ObjId</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CycleTime</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Priority</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AdsPort</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>80</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CycleCount</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DcTaskTime</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000C}">LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LastExecTime</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FirstCycle</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CycleTimeExceeded</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>232</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>InCallAfterOutputUpdate</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>240</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>RTViolation</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>248</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TaskName</Name>
+        <Type GUID="{18071995-0000-0000-0000-00010000003F}">STRING(63)</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <Hides>
+        <Hide GUID="{6A76D020-03A2-465C-A678-C341951E9EF3}"/>
+        <Hide GUID="{6F7D679F-72A0-4831-A7F1-085F839743ED}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name>_Implicit_KindOfTask</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>_implicit_cyclic</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>_implicit_event</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>_implicit_external</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>_implicit_freewheeling</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name>_Implicit_Jitter_Distribution</Name>
+      <BitSize>48</BitSize>
+      <SubItem>
+        <Name>wRangeMax</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wCountJitterNeg</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wCountJitterPos</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>hide</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>_Implicit_Task_Info</Name>
+      <BitSize>896</BitSize>
+      <SubItem>
+        <Name>dwVersion</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>pszName</Name>
+        <Type PointerTo="1">STRING(80)</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nPriority</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>KindOf</Name>
+        <Type>_Implicit_KindOfTask</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bWatchdog</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bProfilingTask</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>168</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwEventFunctionPointer</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>pszExternalEvent</Name>
+        <Type PointerTo="1">STRING(80)</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwTaskEntryFunctionPointer</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwWatchdogSensitivity</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwInterval</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>416</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwWatchdogTime</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwLastCycleTime</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwAverageCycleTime</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwMaxCycleTime</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwMinCycleTime</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diJitter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diJitterMin</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diJitterMax</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwCycleCount</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wTaskStatus</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>736</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wNumOfJitterDistributions</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>pJitterDistribution</Name>
+        <Type PointerTo="1">_Implicit_Jitter_Distribution</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bWithinSPSTimeSlicing</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>byDummy</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>840</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bShouldBlock</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>848</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bActive</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwIECCycleCount</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>864</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>hide</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
+      <DisplayName TxtId="">Log event</DisplayName>
+      <EventId>
+        <Name Id="0">Critical</Name>
+        <DisplayName TxtId="">Critical</DisplayName>
+        <Severity>Critical</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1">Error</Name>
+        <DisplayName TxtId="">Error</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="2">Warning</Name>
+        <DisplayName TxtId="">Warning</DisplayName>
+        <Severity>Warning</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="3">Info</Name>
+        <DisplayName TxtId="">Info</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="4">Verbose</Name>
+        <DisplayName TxtId="">Verbose</DisplayName>
+        <Severity>Verbose</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
+        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
+        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
+        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
+      </Hides>
+    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{DED1545C-5FCD-48E2-B686-7D2C250A3641}" TcSmClass="TComPlcObjDef">
@@ -25293,7 +25376,7 @@ External Setpoint Generation:
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1966080</ByteSize>
+          <ByteSize>1900544</ByteSize>
           <Symbol>
             <Name>LCLS_General.DefaultGlobals.stSys.I_EcatMaster1</Name>
             <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
@@ -25321,7 +25404,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8804224</BitOffs>
+            <BitOffs>8677120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.bLimitForwardEnable</Name>
@@ -25344,7 +25427,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8812160</BitOffs>
+            <BitOffs>8685056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.bLimitBackwardEnable</Name>
@@ -25367,7 +25450,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8812168</BitOffs>
+            <BitOffs>8685064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.bHome</Name>
@@ -25390,7 +25473,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8812176</BitOffs>
+            <BitOffs>8685072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.bHardwareEnable</Name>
@@ -25413,7 +25496,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8812192</BitOffs>
+            <BitOffs>8685088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.nRawEncoderULINT</Name>
@@ -25426,7 +25509,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8812224</BitOffs>
+            <BitOffs>8685120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.nRawEncoderUINT</Name>
@@ -25439,7 +25522,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8812288</BitOffs>
+            <BitOffs>8685184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.nRawEncoderINT</Name>
@@ -25452,7 +25535,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8812304</BitOffs>
+            <BitOffs>8685200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.fbMotionStageSim.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>8699904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.Axis.NcToPlc</Name>
@@ -25464,7 +25559,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>9448704</BitOffs>
+            <BitOffs>8885696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.bLimitForwardEnable</Name>
@@ -25487,7 +25582,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>9456640</BitOffs>
+            <BitOffs>8893632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.bLimitBackwardEnable</Name>
@@ -25510,7 +25605,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>9456648</BitOffs>
+            <BitOffs>8893640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.bHome</Name>
@@ -25533,7 +25628,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>9456656</BitOffs>
+            <BitOffs>8893648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.bHardwareEnable</Name>
@@ -25556,7 +25651,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>9456672</BitOffs>
+            <BitOffs>8893664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.nRawEncoderULINT</Name>
@@ -25569,7 +25664,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>9456704</BitOffs>
+            <BitOffs>8893696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.nRawEncoderUINT</Name>
@@ -25582,7 +25677,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>9456768</BitOffs>
+            <BitOffs>8893760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.nRawEncoderINT</Name>
@@ -25595,19 +25690,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>9456784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.fbMotionStageSim.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>14771968</BitOffs>
+            <BitOffs>8893776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.fbMotion.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -25619,14 +25702,14 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>15135168</BitOffs>
+            <BitOffs>8908480</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1966080</ByteSize>
+          <ByteSize>1900544</ByteSize>
           <Symbol>
             <Name>Interactive.M1.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -25637,7 +25720,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>8803200</BitOffs>
+            <BitOffs>8676096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.bBrakeRelease</Name>
@@ -25660,7 +25743,19 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>8812184</BitOffs>
+            <BitOffs>8685080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.fbMotionStageSim.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>8698880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.Axis.PlcToNc</Name>
@@ -25672,7 +25767,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>9447680</BitOffs>
+            <BitOffs>8884672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.bBrakeRelease</Name>
@@ -25695,19 +25790,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>9456664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.fbMotionStageSim.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>14770944</BitOffs>
+            <BitOffs>8893656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.fbMotion.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -25719,14 +25802,14 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>15134144</BitOffs>
+            <BitOffs>8907456</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1966080</ByteSize>
+          <ByteSize>1900544</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -25740,14 +25823,19 @@ External Setpoint Generation:
             <BitOffs>4096000</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_LOADED</Name>
-            <Comment> Retain data loaded </Comment>
+            <Name>GVL_Logger.bTrickleTripped</Name>
+            <Comment> Global trickle trip flag</Comment>
             <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
+            <BaseType>BOOL</BaseType>
             <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)LCLSGeneral:GlobalLogTrickleTrip
+		io: i
+		field: DESC Tripped by overall log count
+	</Value>
+              </Property>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
@@ -25777,12 +25865,12 @@ External Setpoint Generation:
             <BitOffs>4096096</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Variables.AMSPORT_LOGGER</Name>
-            <Comment> Logger </Comment>
+            <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
+            <Comment> Trip if `nLocalTripThreshold` exceeded `nMinTimeViolationAcceptable` times</Comment>
             <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
+            <BaseType>INT</BaseType>
             <Default>
-              <Value>100</Value>
+              <Value>5</Value>
             </Default>
             <Properties>
               <Property>
@@ -25848,6 +25936,81 @@ External Setpoint Generation:
             <BitOffs>4096320</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_LOADED</Name>
+            <Comment> Retain data loaded </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nLocalTripThreshold</Name>
+            <Comment> Minimum time between log messages</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
+            <Comment> Default trickle trip, activated by global threshold</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTrickleTripTime</Name>
+            <Comment> Default time for log-handler to recognize a trickle overload condition, many log-message FB occasionally creating a message</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>10000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTripResetPeriod</Name>
+            <Comment> Default time for CB auto-reset</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>600000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096480</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>GVL_Logger.sPlcHostname</Name>
             <BitSize>648</BitSize>
             <BaseType>STRING(80)</BaseType>
@@ -25859,7 +26022,37 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096376</BitOffs>
+            <BitOffs>4096512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_INVALID</Name>
+            <Comment> Retain data is invalid </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4097160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_LOGGER</Name>
+            <Comment> Logger </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4097168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
@@ -25877,49 +26070,54 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.AMSPORT_EVENTLOG</Name>
-            <Comment> Event logger </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>110</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4097056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.AMSPORT_R0_RTIME</Name>
-            <Comment> R0 Real time </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>200</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4097072</BitOffs>
+            <BitOffs>4097184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.fbRootLogger</Name>
             <Comment>Instantiated here to be used everywhere</Comment>
-            <BitSize>129472</BitSize>
+            <BitSize>130240</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogMessage</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097088</BitOffs>
+            <BitOffs>4097216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nGlobAccEvents</Name>
+            <Comment> Global log message count</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)LCLSGeneral:LogMessageCount
+		io: i
+		field: DESC Total log messages on the last cycle
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4227456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTrickleThreshold</Name>
+            <Comment> If GlobAccEvents goes over this level for longer than the </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4227488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_System</Name>
@@ -25955,7 +26153,37 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226560</BitOffs>
+            <BitOffs>4227520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_EVENTLOG</Name>
+            <Comment> Event logger </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>110</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4227808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_R0_RTIME</Name>
+            <Comment> R0 Real time </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>200</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4227824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_IO</Name>
@@ -25970,7 +26198,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226848</BitOffs>
+            <BitOffs>4227840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NC</Name>
@@ -25984,7 +26212,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226864</BitOffs>
+            <BitOffs>4227856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSAF</Name>
@@ -25998,7 +26226,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226880</BitOffs>
+            <BitOffs>4227872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSVB</Name>
@@ -26012,7 +26240,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226896</BitOffs>
+            <BitOffs>4227888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_ISG</Name>
@@ -26026,7 +26254,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226912</BitOffs>
+            <BitOffs>4227904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CNC</Name>
@@ -26040,7 +26268,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226928</BitOffs>
+            <BitOffs>4227920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_LINE</Name>
@@ -26054,7 +26282,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226944</BitOffs>
+            <BitOffs>4227936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC</Name>
@@ -26068,7 +26296,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226960</BitOffs>
+            <BitOffs>4227952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS1</Name>
@@ -26083,7 +26311,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226976</BitOffs>
+            <BitOffs>4227968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS2</Name>
@@ -26098,7 +26326,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4226992</BitOffs>
+            <BitOffs>4227984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS3</Name>
@@ -26113,7 +26341,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227008</BitOffs>
+            <BitOffs>4228000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS4</Name>
@@ -26128,7 +26356,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227024</BitOffs>
+            <BitOffs>4228016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAM</Name>
@@ -26142,7 +26370,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227040</BitOffs>
+            <BitOffs>4228032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAMTOOL</Name>
@@ -26157,7 +26385,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227056</BitOffs>
+            <BitOffs>4228048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
@@ -26172,7 +26400,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227072</BitOffs>
+            <BitOffs>4228064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SCOPESERVER</Name>
@@ -26187,7 +26415,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227088</BitOffs>
+            <BitOffs>4228080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INVALID</Name>
@@ -26202,7 +26430,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227104</BitOffs>
+            <BitOffs>4228096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_IDLE</Name>
@@ -26216,7 +26444,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227120</BitOffs>
+            <BitOffs>4228112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESET</Name>
@@ -26230,7 +26458,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227136</BitOffs>
+            <BitOffs>4228128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INIT</Name>
@@ -26244,7 +26472,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227152</BitOffs>
+            <BitOffs>4228144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_START</Name>
@@ -26258,7 +26486,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227168</BitOffs>
+            <BitOffs>4228160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RUN</Name>
@@ -26272,7 +26500,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227184</BitOffs>
+            <BitOffs>4228176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOP</Name>
@@ -26286,7 +26514,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227200</BitOffs>
+            <BitOffs>4228192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SAVECFG</Name>
@@ -26300,7 +26528,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227216</BitOffs>
+            <BitOffs>4228208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_LOADCFG</Name>
@@ -26314,7 +26542,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227232</BitOffs>
+            <BitOffs>4228224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERFAILURE</Name>
@@ -26328,7 +26556,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227248</BitOffs>
+            <BitOffs>4228240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERGOOD</Name>
@@ -26342,7 +26570,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227264</BitOffs>
+            <BitOffs>4228256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_ERROR</Name>
@@ -26356,7 +26584,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227280</BitOffs>
+            <BitOffs>4228272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SHUTDOWN</Name>
@@ -26370,7 +26598,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227296</BitOffs>
+            <BitOffs>4228288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SUSPEND</Name>
@@ -26384,7 +26612,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227312</BitOffs>
+            <BitOffs>4228304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESUME</Name>
@@ -26398,7 +26626,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227328</BitOffs>
+            <BitOffs>4228320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_CONFIG</Name>
@@ -26413,7 +26641,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227344</BitOffs>
+            <BitOffs>4228336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RECONFIG</Name>
@@ -26428,7 +26656,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227360</BitOffs>
+            <BitOffs>4228352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOPPING</Name>
@@ -26442,7 +26670,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227376</BitOffs>
+            <BitOffs>4228368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INCOMPATIBLE</Name>
@@ -26456,7 +26684,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227392</BitOffs>
+            <BitOffs>4228384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_EXCEPTION</Name>
@@ -26470,7 +26698,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227408</BitOffs>
+            <BitOffs>4228400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_MAXSTATES</Name>
@@ -26485,22 +26713,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_INVALID</Name>
-            <Comment> Retain data is invalid </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227440</BitOffs>
+            <BitOffs>4228416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_REQUESTED</Name>
@@ -26514,916 +26727,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYMTAB</Name>
-            <Comment> Symbol table </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61440</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYMNAME</Name>
-            <Comment> Symbol name </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61441</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYMVAL</Name>
-            <Comment> Symbol value </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61442</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_HNDBYNAME</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61443</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_VALBYNAME</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61444</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227584</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_VALBYHND</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61445</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_RELEASEHND</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61446</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAME</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61447</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_VERSION</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61448</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAMEEX</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61449</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_DOWNLOAD</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61450</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_UPLOAD</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61451</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227808</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_UPLOADINFO</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61452</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYMNOTE</Name>
-            <Comment> Notification of named handle </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61456</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIB</Name>
-            <Comment> Read/write input BYTE(S) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61472</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227904</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIX</Name>
-            <Comment> Read/write input bit </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61473</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RISIZE</Name>
-            <Comment> Read input size (in BYTE) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61477</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227968</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOB</Name>
-            <Comment> Read/write output BYTE(S) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61488</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOX</Name>
-            <Comment> Read/write output bit </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61489</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228032</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_ROSIZE</Name>
-            <Comment> Read/write output bit </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61493</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARI</Name>
-            <Comment> Write inputs TO null </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61504</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARO</Name>
-            <Comment> Write outputs TO null </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61520</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIOB</Name>
-            <Comment> Read input AND write output BYTE(S)  ADS-READWRITE </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61536</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_DEVICE_DATA</Name>
-            <Comment> State, name, etc... </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61696</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228192</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIOFFS_DEVDATA_ADSSTATE</Name>
-            <Comment> Ads state OF device </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIOFFS_DEVDATA_DEVSTATE</Name>
-            <Comment> Device state </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_OPENCREATE</Name>
-            <Comment> Open and if not existing create </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_OPENREAD</Name>
-            <Comment> Open existing for read access </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>101</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228320</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_OPENWRITE</Name>
-            <Comment> Open existing for write access </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>102</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_CREATEFILE</Name>
-            <Comment> Create </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>110</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_CLOSEHANDLE</Name>
-            <Comment> Close </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>111</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FOPEN</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>120</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FCLOSE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>121</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FREAD</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>122</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FWRITE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>123</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FSEEK</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>124</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228576</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FTELL</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>125</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FGETS</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>126</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228640</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FPUTS</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>127</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FSCANF</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>128</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228704</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FPRINTF</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>129</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FEOF</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>130</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228768</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FDELETE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>131</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FRENAME</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>132</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_MKDIR</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>138</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_RMDIR</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>139</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>200</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_SENDEMAIL</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>300</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_TIMESERVICES</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>400</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_STARTPROCESS</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>500</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_CHANGENETID</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>600</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TIMESERVICE_DATEANDTIME</Name>
-            <Comment> Date/time </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229088</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TIMESERVICE_SYSTEMTIMES</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TIMESERVICE_RTCTIMEDIFF</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>3</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229152</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TIMESERVICE_ADJUSTTIMETORTC</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TIMESERVICE_TIMEZONINFORMATION</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>6</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
-            <Comment> Hint icon </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_WARN</Name>
-            <Comment> Warning icon </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
-            <Comment> Error icon </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
-            <Comment> Write message to log file </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_MSGBOX</Name>
-            <Comment> View message in message box </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>32</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_RESOURCE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>64</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_STRING</Name>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>128</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4229440</BitOffs>
+            <BitOffs>4228432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_LOADED</Name>
@@ -27438,7 +26742,916 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
+            <BitOffs>4228440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYMTAB</Name>
+            <Comment> Symbol table </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61440</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYMNAME</Name>
+            <Comment> Symbol name </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61441</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYMVAL</Name>
+            <Comment> Symbol value </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61442</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_HNDBYNAME</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61443</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_VALBYNAME</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61444</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_VALBYHND</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61445</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_RELEASEHND</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61446</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAME</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61447</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_VERSION</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61448</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAMEEX</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61449</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_DOWNLOAD</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61450</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_UPLOAD</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61451</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_UPLOADINFO</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61452</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYMNOTE</Name>
+            <Comment> Notification of named handle </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61456</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIB</Name>
+            <Comment> Read/write input BYTE(S) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61472</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIX</Name>
+            <Comment> Read/write input bit </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61473</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RISIZE</Name>
+            <Comment> Read input size (in BYTE) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61477</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOB</Name>
+            <Comment> Read/write output BYTE(S) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61488</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4228992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOX</Name>
+            <Comment> Read/write output bit </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61489</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_ROSIZE</Name>
+            <Comment> Read/write output bit </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61493</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARI</Name>
+            <Comment> Write inputs TO null </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61504</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARO</Name>
+            <Comment> Write outputs TO null </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61520</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIOB</Name>
+            <Comment> Read input AND write output BYTE(S)  ADS-READWRITE </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61536</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_DEVICE_DATA</Name>
+            <Comment> State, name, etc... </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61696</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIOFFS_DEVDATA_ADSSTATE</Name>
+            <Comment> Ads state OF device </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIOFFS_DEVDATA_DEVSTATE</Name>
+            <Comment> Device state </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_OPENCREATE</Name>
+            <Comment> Open and if not existing create </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_OPENREAD</Name>
+            <Comment> Open existing for read access </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>101</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_OPENWRITE</Name>
+            <Comment> Open existing for write access </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>102</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_CREATEFILE</Name>
+            <Comment> Create </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>110</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_CLOSEHANDLE</Name>
+            <Comment> Close </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>111</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FOPEN</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>120</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FCLOSE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>121</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
             <BitOffs>4229472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FREAD</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>122</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FWRITE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>123</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FSEEK</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>124</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FTELL</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>125</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FGETS</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>126</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FPUTS</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>127</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FSCANF</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>128</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FPRINTF</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>129</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FEOF</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>130</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FDELETE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>131</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FRENAME</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>132</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_MKDIR</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>138</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_RMDIR</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>139</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>200</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_SENDEMAIL</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>300</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_TIMESERVICES</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>400</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4229984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_STARTPROCESS</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>500</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_CHANGENETID</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>600</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TIMESERVICE_DATEANDTIME</Name>
+            <Comment> Date/time </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TIMESERVICE_SYSTEMTIMES</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TIMESERVICE_RTCTIMEDIFF</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>3</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TIMESERVICE_ADJUSTTIMETORTC</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TIMESERVICE_TIMEZONINFORMATION</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>6</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
+            <Comment> Hint icon </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_WARN</Name>
+            <Comment> Warning icon </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
+            <Comment> Error icon </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
+            <Comment> Write message to log file </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_MSGBOX</Name>
+            <Comment> View message in message box </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>32</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_RESOURCE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>64</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_STRING</Name>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>128</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_INVALID</Name>
@@ -27453,7 +27666,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229480</BitOffs>
+            <BitOffs>4230464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_BSOD</Name>
@@ -27468,7 +27681,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229488</BitOffs>
+            <BitOffs>4230472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_RTVIOLATION</Name>
@@ -27483,7 +27696,19 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229496</BitOffs>
+            <BitOffs>4230480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.nWatchdogTime</Name>
+            <Comment> Watchdog time. Depending of g_WatchdogConfig : seconds or minutes </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4230488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEREAD</Name>
@@ -27498,7 +27723,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229504</BitOffs>
+            <BitOffs>4230496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEWRITE</Name>
@@ -27513,7 +27738,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229536</BitOffs>
+            <BitOffs>4230528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEAPPEND</Name>
@@ -27528,7 +27753,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229568</BitOffs>
+            <BitOffs>4230560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEPLUS</Name>
@@ -27543,7 +27768,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229600</BitOffs>
+            <BitOffs>4230592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEBINARY</Name>
@@ -27558,7 +27783,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229632</BitOffs>
+            <BitOffs>4230624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODETEXT</Name>
@@ -27573,7 +27798,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229664</BitOffs>
+            <BitOffs>4230656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_PRIOCLASS</Name>
@@ -27588,7 +27813,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229920</BitOffs>
+            <BitOffs>4230912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_FMTSELF</Name>
@@ -27603,7 +27828,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229936</BitOffs>
+            <BitOffs>4230928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_LOG</Name>
@@ -27618,7 +27843,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229952</BitOffs>
+            <BitOffs>4230944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_MSGBOX</Name>
@@ -27633,7 +27858,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229968</BitOffs>
+            <BitOffs>4230960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_SRCID</Name>
@@ -27648,7 +27873,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229984</BitOffs>
+            <BitOffs>4230976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_AUTOFMTALL</Name>
@@ -27662,7 +27887,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230000</BitOffs>
+            <BitOffs>4230992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_INVALID</Name>
@@ -27677,7 +27902,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230016</BitOffs>
+            <BitOffs>4231008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_SIGNALED</Name>
@@ -27692,7 +27917,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230032</BitOffs>
+            <BitOffs>4231024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESET</Name>
@@ -27707,7 +27932,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230048</BitOffs>
+            <BitOffs>4231040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_CONFIRMED</Name>
@@ -27722,7 +27947,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230064</BitOffs>
+            <BitOffs>4231056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESETCON</Name>
@@ -27737,7 +27962,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230080</BitOffs>
+            <BitOffs>4231072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_SRCNAMESIZE</Name>
@@ -27751,7 +27976,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230096</BitOffs>
+            <BitOffs>4231088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_FMTPRGSIZE</Name>
@@ -27765,7 +27990,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230112</BitOffs>
+            <BitOffs>4231104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.eWatchdogConfig</Name>
@@ -27779,21 +28004,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.PI</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>3.14159265358979</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4230144</BitOffs>
+            <BitOffs>4231120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_ADS_TIMEOUT</Name>
@@ -27808,7 +28019,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230208</BitOffs>
+            <BitOffs>4231136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.PI</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>3.14159265358979</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4231168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_STRING_LENGTH</Name>
@@ -27823,19 +28048,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.nWatchdogTime</Name>
-            <Comment> Watchdog time. Depending of g_WatchdogConfig : seconds or minutes </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4230784</BitOffs>
+            <BitOffs>4231232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_Module</Name>
@@ -27871,30 +28084,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_AVERAGE_MEASURES</Name>
-            <Comment> Max. number of measures used in the profiler function block: 2..100 </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>LowerBorder</Name>
-                <Value>2</Value>
-              </Property>
-              <Property>
-                <Name>UpperBorder</Name>
-                <Value>100</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4231408</BitOffs>
+            <BitOffs>4231776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Utilities</Name>
@@ -27930,52 +28120,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.GLOBAL_FORMAT_HASH_PREFIX_TYPE</Name>
-            <Comment> Global hash prefix type constant used for binary, octal or hexadecimal string format type </Comment>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="Tc2_Utilities">E_HashPrefixTypes</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4231840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.GLOBAL_SBCS_TABLE</Name>
-            <Comment>Windows SBCS (Single Byte Character Set) Code Page Table </Comment>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="Tc2_Utilities">E_SBCSType</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4231856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.GLOBAL_DCF77_PULSE_SPLIT</Name>
-            <Comment> Default DCF77 short/long pulse split time value. Bit == 0 =&gt; pulse &lt; 140ms, Bit == 1 =&gt; pulse &gt;= 140ms </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>140</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4231872</BitOffs>
+            <BitOffs>4232448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_DCF77_SEQUENCE_CHECK</Name>
@@ -27990,7 +28135,75 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231904</BitOffs>
+            <BitOffs>4232744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_AVERAGE_MEASURES</Name>
+            <Comment> Max. number of measures used in the profiler function block: 2..100 </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>LowerBorder</Name>
+                <Value>2</Value>
+              </Property>
+              <Property>
+                <Name>UpperBorder</Name>
+                <Value>100</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4232752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.GLOBAL_FORMAT_HASH_PREFIX_TYPE</Name>
+            <Comment> Global hash prefix type constant used for binary, octal or hexadecimal string format type </Comment>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="Tc2_Utilities">E_HashPrefixTypes</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4232832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.GLOBAL_SBCS_TABLE</Name>
+            <Comment>Windows SBCS (Single Byte Character Set) Code Page Table </Comment>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="Tc2_Utilities">E_SBCSType</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4232848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.GLOBAL_DCF77_PULSE_SPLIT</Name>
+            <Comment> Default DCF77 short/long pulse split time value. Bit == 0 =&gt; pulse &lt; 140ms, Bit == 1 =&gt; pulse &gt;= 140ms </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>140</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4232864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_FIELD_SEP</Name>
@@ -28005,232 +28218,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_REMOTE_PCS</Name>
-            <Comment> Max. number of TwinCAT remote systems/PC's </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>99</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4231920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_ADAPTER_NAME_LENGTH</Name>
-            <Comment> Max. System Service local adapter name length (256 + 4 inkl. \0) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>259</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_ADAPTER_DESCRIPTION_LENGTH</Name>
-            <Comment> Max. System Service local adapter descirpion length (128 + 4 inkl. \0) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>131</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_ADAPTER_ADDRESS_LENGTH</Name>
-            <Comment> Max. System Service local adapter physical address length (bytes[0..7]) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>7</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_IPHELPERAPI</Name>
-            <Comment> IPHELPERAPI index group </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>701</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_IPHOSTNAME</Name>
-            <Comment> IPHOSTNAME index group </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>702</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.IPHELPERAPI_ADAPTERSINFO</Name>
-            <Comment> IPHELPERAPI index offset </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.IPHELPERAPI_IPADDRBYHOSTNAME</Name>
-            <Comment> IPHELPERAPI index offset </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_LOCAL_ADAPTERS</Name>
-            <Comment> Max. number of local network adapters </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>5</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_ADDREMOTE</Name>
-            <Comment> System Service route function: Add route </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>801</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_DELREMOTE</Name>
-            <Comment> System Service route function: Delete route  </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>802</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_ENUMREMOTE</Name>
-            <Comment> System Service route function: Enumerater route </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>803</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_TEMPORARY</Name>
-            <Comment> TwinCAT route flag: Temporary </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_DYNAMIC</Name>
-            <Comment> TwinCAT route flag: Hostname instead OF IP address </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_NOOVERRIDE</Name>
-            <Comment> TwinCAT route flag: No override </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4293824</BitOffs>
+            <BitOffs>4232896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_NAME_LEN</Name>
@@ -28245,7 +28233,232 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4293856</BitOffs>
+            <BitOffs>4232904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_REMOTE_PCS</Name>
+            <Comment> Max. number of TwinCAT remote systems/PC's </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>99</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4232912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_ADAPTER_NAME_LENGTH</Name>
+            <Comment> Max. System Service local adapter name length (256 + 4 inkl. \0) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>259</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_ADAPTER_DESCRIPTION_LENGTH</Name>
+            <Comment> Max. System Service local adapter descirpion length (128 + 4 inkl. \0) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>131</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_ADAPTER_ADDRESS_LENGTH</Name>
+            <Comment> Max. System Service local adapter physical address length (bytes[0..7]) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>7</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_IPHELPERAPI</Name>
+            <Comment> IPHELPERAPI index group </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>701</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_IPHOSTNAME</Name>
+            <Comment> IPHOSTNAME index group </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>702</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.IPHELPERAPI_ADAPTERSINFO</Name>
+            <Comment> IPHELPERAPI index offset </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.IPHELPERAPI_IPADDRBYHOSTNAME</Name>
+            <Comment> IPHELPERAPI index offset </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_LOCAL_ADAPTERS</Name>
+            <Comment> Max. number of local network adapters </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>5</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_ADDREMOTE</Name>
+            <Comment> System Service route function: Add route </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>801</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_DELREMOTE</Name>
+            <Comment> System Service route function: Delete route  </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>802</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_ENUMREMOTE</Name>
+            <Comment> System Service route function: Enumerater route </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>803</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_TEMPORARY</Name>
+            <Comment> TwinCAT route flag: Temporary </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_DYNAMIC</Name>
+            <Comment> TwinCAT route flag: Hostname instead OF IP address </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_NOOVERRIDE</Name>
+            <Comment> TwinCAT route flag: No override </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_ADDR_LEN</Name>
@@ -28260,7 +28473,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4293864</BitOffs>
+            <BitOffs>4294848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MIN_ROUTE_TRANSPORT</Name>
@@ -28275,7 +28488,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4293872</BitOffs>
+            <BitOffs>4294856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_TRANSPORT</Name>
@@ -28290,7 +28503,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4293880</BitOffs>
+            <BitOffs>4294864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.DEFAULT_CSV_FIELD_DOUBLE_QUOTE</Name>
+            <Comment> CSV separator constant: double-quote (") =&gt; used to enclose special characters like line breaks, double-quotes, commas... </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>34</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4294872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ROUTE_ENTRY</Name>
@@ -28324,7 +28552,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4293888</BitOffs>
+            <BitOffs>4294880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FFILEFIND</Name>
@@ -28339,7 +28567,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295072</BitOffs>
+            <BitOffs>4296064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.HKEY_MAX_BINARY_DATA_SIZE</Name>
@@ -28354,7 +28582,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295104</BitOffs>
+            <BitOffs>4296096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IGR_GENERAL</Name>
@@ -28369,7 +28597,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295136</BitOffs>
+            <BitOffs>4296128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IOF_MODE</Name>
@@ -28384,7 +28612,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295168</BitOffs>
+            <BitOffs>4296160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_AMSLOGGER</Name>
@@ -28399,7 +28627,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295200</BitOffs>
+            <BitOffs>4296192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_MAX_ARGS</Name>
@@ -28414,7 +28642,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295216</BitOffs>
+            <BitOffs>4296208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_NAN</Name>
@@ -28429,7 +28657,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295232</BitOffs>
+            <BitOffs>4296224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_INF</Name>
@@ -28444,7 +28672,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295248</BitOffs>
+            <BitOffs>4296240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_DIGITS</Name>
@@ -28459,7 +28687,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295264</BitOffs>
+            <BitOffs>4296256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_PRECISION</Name>
@@ -28474,7 +28702,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295280</BitOffs>
+            <BitOffs>4296272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MIN_PRECISION</Name>
@@ -28489,7 +28717,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295296</BitOffs>
+            <BitOffs>4296288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_NOERROR</Name>
@@ -28504,7 +28732,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295328</BitOffs>
+            <BitOffs>4296320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PERCENTSIGNPOSITION</Name>
@@ -28519,7 +28747,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295360</BitOffs>
+            <BitOffs>4296352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ASTERISKPOSITION</Name>
@@ -28534,7 +28762,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295392</BitOffs>
+            <BitOffs>4296384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHVALUE</Name>
@@ -28549,7 +28777,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295424</BitOffs>
+            <BitOffs>4296416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONVALUE</Name>
@@ -28564,7 +28792,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295456</BitOffs>
+            <BitOffs>4296448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_FLAGPOSITION</Name>
@@ -28579,7 +28807,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295488</BitOffs>
+            <BitOffs>4296480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHPRECISIONVALPOS</Name>
@@ -28594,7 +28822,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295520</BitOffs>
+            <BitOffs>4296512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONDOTPOSITION</Name>
@@ -28609,7 +28837,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295552</BitOffs>
+            <BitOffs>4296544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_TYPEFIELDVALUE</Name>
@@ -28624,7 +28852,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295584</BitOffs>
+            <BitOffs>4296576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ARGTYPEINVALID</Name>
@@ -28639,7 +28867,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295616</BitOffs>
+            <BitOffs>4296608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_UNACCEPTEDPARAMETER</Name>
@@ -28654,7 +28882,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295648</BitOffs>
+            <BitOffs>4296640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INSUFFICIENTARGS</Name>
@@ -28669,7 +28897,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295680</BitOffs>
+            <BitOffs>4296672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_DESTBUFFOVERFLOW</Name>
@@ -28684,7 +28912,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295712</BitOffs>
+            <BitOffs>4296704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INVALIDPOINTERINPUT</Name>
@@ -28699,22 +28927,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMTIME_DATEDELTA_OFFSET</Name>
-            <Comment> Number of past days since year zero until 1 January 1601 </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>584389</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4295776</BitOffs>
+            <BitOffs>4296736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ARG_VALUE</Name>
@@ -28740,7 +28953,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295808</BitOffs>
+            <BitOffs>4296768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_HEXASC_CODES</Name>
@@ -28889,7 +29102,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4295936</BitOffs>
+            <BitOffs>4296896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_DECASC_CODES</Name>
@@ -28947,7 +29160,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296192</BitOffs>
+            <BitOffs>4297152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_MONTHDAYS</Name>
@@ -29064,7 +29277,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4301680</BitOffs>
+            <BitOffs>4302640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_YEARSDAY</Name>
@@ -29197,7 +29410,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4302064</BitOffs>
+            <BitOffs>4303024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMTIME_DATEDELTA_OFFSET</Name>
+            <Comment> Number of past days since year zero until 1 January 1601 </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>584389</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4303488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC</Name>
@@ -29219,7 +29447,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4302528</BitOffs>
+            <BitOffs>4303520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC</Name>
@@ -29241,7 +29469,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4302592</BitOffs>
+            <BitOffs>4303584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY</Name>
@@ -29263,7 +29491,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4302656</BitOffs>
+            <BitOffs>4303648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN</Name>
@@ -29285,7 +29513,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4302720</BitOffs>
+            <BitOffs>4303712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX</Name>
@@ -29307,7 +29535,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4302784</BitOffs>
+            <BitOffs>4303776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.DATE_AND_TIME_SECPERDAY</Name>
+            <Comment> Number of seconds per day </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>86400</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4303840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC64</Name>
@@ -29322,7 +29565,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4302848</BitOffs>
+            <BitOffs>4303872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC64</Name>
@@ -29337,7 +29580,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4302912</BitOffs>
+            <BitOffs>4303936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY64</Name>
@@ -29352,7 +29595,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4302976</BitOffs>
+            <BitOffs>4304000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN64</Name>
@@ -29367,7 +29610,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303040</BitOffs>
+            <BitOffs>4304064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX64</Name>
@@ -29382,7 +29625,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303104</BitOffs>
+            <BitOffs>4304128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.WEST_EUROPE_TZI</Name>
@@ -29455,22 +29698,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303168</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.DATE_AND_TIME_SECPERDAY</Name>
-            <Comment> Number of seconds per day </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>86400</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4308128</BitOffs>
+            <BitOffs>4304192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DATE_AND_TIME_SECPERWEEK</Name>
@@ -29485,7 +29713,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4308160</BitOffs>
+            <BitOffs>4309152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_NONE</Name>
@@ -29500,7 +29728,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4314368</BitOffs>
+            <BitOffs>4315360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_LOG</Name>
@@ -29515,7 +29743,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4314400</BitOffs>
+            <BitOffs>4315392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_FILE</Name>
@@ -29530,7 +29758,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4314432</BitOffs>
+            <BitOffs>4315424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_VISU</Name>
@@ -29545,22 +29773,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4314464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.DEFAULT_CSV_FIELD_DOUBLE_QUOTE</Name>
-            <Comment> CSV separator constant: double-quote (") =&gt; used to enclose special characters like line breaks, double-quotes, commas... </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>34</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4433232</BitOffs>
+            <BitOffs>4315456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_CR</Name>
@@ -29575,7 +29788,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4433240</BitOffs>
+            <BitOffs>4315504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_LF</Name>
@@ -29590,7 +29803,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4434192</BitOffs>
+            <BitOffs>4315512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_SEVERITY</Name>
@@ -29604,22 +29817,33 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4434224</BitOffs>
+            <BitOffs>4435184</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_CUSTOM_CONSTANTS.MAX_FAST_FAULTS</Name>
-            <Comment> Maximum number of fast faults that can be associated with a FFO</Comment>
+            <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
+            <Comment> Indication of whether the last instantiated test suite has an assert instance created </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4436904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
             <Default>
-              <Value>50</Value>
+              <Value>500</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4435920</BitOffs>
+            <BitOffs>4436912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRUCT</Name>
@@ -29676,7 +29900,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4435936</BitOffs>
+            <BitOffs>4436928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRING</Name>
@@ -29690,7 +29914,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4436064</BitOffs>
+            <BitOffs>4437056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_REGSTRING</Name>
@@ -29704,7 +29928,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4436360</BitOffs>
+            <BitOffs>4437352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>.TCPADS_MAXUDP_BUFFSIZE</Name>
@@ -29718,7 +29942,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4436672</BitOffs>
+            <BitOffs>4437664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_EVENT_CLASS</Name>
@@ -29775,7 +29999,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4436704</BitOffs>
+            <BitOffs>4437696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_EVENT_ID</Name>
@@ -29789,7 +30013,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4436832</BitOffs>
+            <BitOffs>4437824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.SUCCESS_EVENT</Name>
@@ -29854,7 +30078,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4436864</BitOffs>
+            <BitOffs>4437856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.nLangId_OnlineMonitoring</Name>
@@ -29869,7 +30093,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437056</BitOffs>
+            <BitOffs>4438048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>ParameterList.cSourceNameSize</Name>
@@ -29892,7 +30116,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437088</BitOffs>
+            <BitOffs>4438080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_EventLogger</Name>
@@ -29932,7 +30156,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437120</BitOffs>
+            <BitOffs>4438112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_INTERNAL.UNINITIALIZED_CLASS_GUID</Name>
@@ -29990,7 +30214,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437408</BitOffs>
+            <BitOffs>4438400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_JsonXml</Name>
@@ -30026,463 +30250,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.stRequestedBeamParameters</Name>
-            <Comment>Summarized request for the line, as recognized by the line arbiter PLC</Comment>
-            <BitSize>1216</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)RequestedBP
-        archive: 1Hz monitor
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4437824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.stCurrentBeamParameters</Name>
-            <Comment>Currently active BP set, broadcast by the line arbiter PLC</Comment>
-            <BitSize>1216</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)CurrentBP
-        archive: 1Hz monitor
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4439040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.fbLog</Name>
-            <BitSize>129472</BitSize>
-            <BaseType Namespace="LCLS_General">FB_LogMessage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.eSubsystem</Name>
-                <Value>2</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4440256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
-            <Comment>An assertion ID that should always return "not found" in the assertion pool</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>4294967295</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4569728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>300</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4569760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4569792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4569856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.MAX_STOPPERS</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4569920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>20</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4569936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cstFullBeam</Name>
-            <BitSize>1216</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nTran</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fPP_mJ</Name>
-                <Value>10000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.neVRange</Name>
-                <Value>65535</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nRate</Name>
-                <Value>1000000</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)FullBeamCnst
-        archive: 1Hz monitor
-        field: DESC Full beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4569952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cstSafeBeam</Name>
-            <BitSize>1216</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nTran</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fPP_mJ</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.neVRange</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nRate</Name>
-                <Value>0</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)SafeBeamCnst
-        archive: 1Hz monitor
-        field: DESC Safe beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4571168</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
-            <Comment> Maximum # of attenuators in the PMPS</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4572384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.MAX_APERTURES</Name>
-            <Comment> Maximum # of power slits in the PMPS</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4572400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>16</Elements>
-            </ArrayInfo>
-            <Properties>
-              <Property>
-                <Name>suppress_warning_0</Name>
-                <Value>C0228</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4572416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.MAX_ASSERTIONS</Name>
-            <Comment>Maximum number of assertions permitted in the arbiter</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>20</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4572928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.g_cBoundaries</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>15</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4572960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>500</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4572976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.reVHyst</Name>
-            <Comment> </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>5</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)eVRangeHyst
-        archive: 1Hz monitor
-        field: DESC eV Range hystersis
-        field: EGU eV
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4572992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.g_areVBoundaries</Name>
-            <BitSize>512</BitSize>
-            <BaseType>REAL</BaseType>
-            <ArrayInfo>
-              <LBound>0</LBound>
-              <Elements>16</Elements>
-            </ArrayInfo>
-            <Default>
-              <SubItem>
-                <Name>[0]</Name>
-                <Value>200</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1]</Name>
-                <Value>300</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[2]</Name>
-                <Value>400</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[3]</Name>
-                <Value>500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[4]</Name>
-                <Value>600</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[5]</Name>
-                <Value>700</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[6]</Name>
-                <Value>800</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[7]</Name>
-                <Value>900</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[8]</Name>
-                <Value>1000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[9]</Name>
-                <Value>1100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[10]</Name>
-                <Value>1200</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[11]</Name>
-                <Value>1300</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[12]</Name>
-                <Value>1400</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[13]</Name>
-                <Value>1500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[14]</Name>
-                <Value>1600</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[15]</Name>
-                <Value>1700</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)eVRangeCnst
-        archive: 1Hz monitor
-        field: DESC eV Range constants
-        field: EGU eV
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4573024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_PMPS</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>5</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>0.5.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4573536</BitOffs>
+            <BitOffs>4438528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
@@ -30496,7 +30264,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4573824</BitOffs>
+            <BitOffs>4438816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfAsserts</Name>
@@ -30510,19 +30278,42 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4573840</BitOffs>
+            <BitOffs>4438832</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
-            <Comment> Indication of whether the last instantiated test suite has an assert instance created </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>GVL_TcUnit.TcUnitRunner</Name>
+            <BitSize>768</BitSize>
+            <BaseType Namespace="LCLS_General.TcUnit">FB_TcUnitRunner</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4573856</BitOffs>
+            <BitOffs>4438848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
+            <Comment> Pointer to current test suite being called </Comment>
+            <BitSize>64</BitSize>
+            <BaseType PointerTo="1" Namespace="LCLS_General.TcUnit">FB_TestSuite</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4439616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
+            <Comment> Current name of test being called </Comment>
+            <BitSize>2048</BitSize>
+            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4439680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
@@ -30536,7 +30327,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4573864</BitOffs>
+            <BitOffs>4441728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -30552,47 +30343,26 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4573872</BitOffs>
+            <BitOffs>4441744</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_TcUnit.TcUnitRunner</Name>
-            <BitSize>768</BitSize>
-            <BaseType Namespace="PMPS.TcUnit">FB_TcUnitRunner</BaseType>
+            <Name>PMPS_GVL.MAX_FAST_FAULTS</Name>
+            <BitSize>32</BitSize>
+            <BaseType>DINT</BaseType>
+            <Default>
+              <Value>50</Value>
+            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4573888</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
-            <Comment> Pointer to current test suite being called </Comment>
-            <BitSize>64</BitSize>
-            <BaseType PointerTo="1" Namespace="PMPS.TcUnit">FB_TestSuite</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4574656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
-            <Comment> Current name of test being called </Comment>
-            <BitSize>2048</BitSize>
-            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4574720</BitOffs>
+            <BitOffs>4441760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
             <BitSize>32000</BitSize>
-            <BaseType PointerTo="1" Namespace="PMPS.TcUnit">FB_TestSuite</BaseType>
+            <BaseType PointerTo="1" Namespace="LCLS_General.TcUnit">FB_TestSuite</BaseType>
             <ArrayInfo>
               <LBound>1</LBound>
               <Elements>500</Elements>
@@ -30602,19 +30372,19 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4576768</BitOffs>
+            <BitOffs>4441792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.AdsLogger</Name>
             <Comment> Buffered ADS logger for output to the error list </Comment>
             <BitSize>4129152</BitSize>
-            <BaseType Namespace="PMPS.TcUnit">FB_ADSLogStringMessageFifoQueue</BaseType>
+            <BaseType Namespace="LCLS_General.TcUnit">FB_ADSLogStringMessageFifoQueue</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4608768</BitOffs>
+            <BitOffs>4473792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -30650,7 +30420,664 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8737920</BitOffs>
+            <BitOffs>8602944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stRequestedBeamParameters</Name>
+            <Comment>Summarized request for the line, as recognized by the line arbiter PLC</Comment>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)RequestedBP
+		io: i
+        archive: 1Hz monitor
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8603232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stCurrentBeamParameters</Name>
+            <Comment>Currently active BP set, broadcast by the line arbiter PLC</Comment>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)CurrentBP
+		io: i
+        archive: 1Hz monitor
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8604448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_areVBoundaries</Name>
+            <BitSize>512</BitSize>
+            <BaseType>REAL</BaseType>
+            <ArrayInfo>
+              <LBound>0</LBound>
+              <Elements>16</Elements>
+            </ArrayInfo>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)eVRangeCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Active eV Range constants
+        field: EGU eV
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8605664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
+            <Comment>An assertion ID that should always return "not found" in the assertion pool</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>4294967295</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8606176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.PERange</Name>
+            <Comment>Included to place the ev ranges properly</Comment>
+            <BitSize>64</BitSize>
+            <BaseType Namespace="PMPS">PE_Ranges</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8606208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8606272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8606336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>300</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8606400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_STOPPERS</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8606432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>20</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8606448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstFullBeam</Name>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fPP_mJ</Name>
+                <Value>10000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.neVRange</Name>
+                <Value>65535</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nRate</Name>
+                <Value>1000000</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)FullBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Full beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8606464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstSafeBeam</Name>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fPP_mJ</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.neVRange</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nRate</Name>
+                <Value>0</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)SafeBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Safe beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8607680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
+            <Comment> Maximum # of attenuators in the PMPS</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8608896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_APERTURES</Name>
+            <Comment> Maximum # of power slits in the PMPS</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8608912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
+            <BitSize>512</BitSize>
+            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>16</Elements>
+            </ArrayInfo>
+            <Properties>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8608928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_ASSERTIONS</Name>
+            <Comment>Maximum number of assertions permitted in the arbiter</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>20</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8609440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_cBoundaries</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>15</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8609472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.bInit</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <BitOffs>8609488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.bOut</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>8609496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.iLowBound_LUnd</Name>
+            <Comment>///////////////////////
+///////////////////////</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>24</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)L:UND:FirstSegment
+		io: i
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8609504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.iHighBound_LUnd</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>46</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+		pv: @(PREFIX)L:UND:LastSegment
+		io: i
+	</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8609536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.reVHyst</Name>
+            <Comment>////////////////////////////////////		</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>5</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)eVRangeHyst
+		io: i
+        archive: 1Hz monitor
+        field: DESC eV Range hystersis
+        field: EGU eV
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8609568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.fPeriod_mm_LUnd</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>26</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: Period
+        io: i
+        field: EGU mm
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8609600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.fLowK_LUnd</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>0.54</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)L:UND:LowK
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8609664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.fHiK_LUnd</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>2.5</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)L:UND:HiK
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8609728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_areVBoundariesL</Name>
+            <BitSize>512</BitSize>
+            <BaseType>REAL</BaseType>
+            <ArrayInfo>
+              <LBound>0</LBound>
+              <Elements>16</Elements>
+            </ArrayInfo>
+            <Default>
+              <SubItem>
+                <Name>[0]</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[1]</Name>
+                <Value>2700</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[2]</Name>
+                <Value>4400</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[3]</Name>
+                <Value>6100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[4]</Name>
+                <Value>7800</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[5]</Name>
+                <Value>9500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[6]</Name>
+                <Value>11200</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[7]</Name>
+                <Value>12900</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[8]</Name>
+                <Value>14600</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[9]</Name>
+                <Value>16300</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[10]</Name>
+                <Value>18000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[11]</Name>
+                <Value>19700</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[12]</Name>
+                <Value>21400</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[13]</Name>
+                <Value>23100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[14]</Name>
+                <Value>24800</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[15]</Name>
+                <Value>25000</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)L:eVRangeCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC eV Range constants
+        field: EGU eV
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8609792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_areVBoundariesK</Name>
+            <BitSize>512</BitSize>
+            <BaseType>REAL</BaseType>
+            <ArrayInfo>
+              <LBound>0</LBound>
+              <Elements>16</Elements>
+            </ArrayInfo>
+            <Default>
+              <SubItem>
+                <Name>[0]</Name>
+                <Value>250</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[1]</Name>
+                <Value>270</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[2]</Name>
+                <Value>400</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[3]</Name>
+                <Value>540</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[4]</Name>
+                <Value>850</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[5]</Name>
+                <Value>1150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[6]</Name>
+                <Value>1250</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[7]</Name>
+                <Value>1450</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[8]</Name>
+                <Value>1550</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[9]</Name>
+                <Value>1650</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[10]</Name>
+                <Value>1750</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[11]</Name>
+                <Value>1820</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[12]</Name>
+                <Value>2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[13]</Name>
+                <Value>3200</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[14]</Name>
+                <Value>5000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[15]</Name>
+                <Value>7100</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)K:eVRangeCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC eV Range constants
+        field: EGU eV
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8610304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_TOOLS.fbJson</Name>
+            <BitSize>384</BitSize>
+            <BaseType Namespace="LCLS_General.Tc3_JsonXml">FB_JsonSaxWriter</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8610816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -30690,7 +31117,25 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8738208</BitOffs>
+            <BitOffs>8611200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.nCounter</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>8611488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.bGoOut</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>8611504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.bIn</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>8611512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -30701,46 +31146,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8738496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.bInit</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <BitOffs>8745608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.nCounter</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>8745616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.bOut</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>8745632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.bGoOut</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>8745640</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.bIn</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>8745648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.bGoIn</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>8745656</BitOffs>
+            <BitOffs>8611520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -30754,7 +31160,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8745664</BitOffs>
+            <BitOffs>8618624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -30768,122 +31174,118 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8745728</BitOffs>
+            <BitOffs>8618688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1</Name>
             <BitSize>21056</BitSize>
             <BaseType>DUT_MotionStage</BaseType>
-            <BitOffs>8803136</BitOffs>
+            <BitOffs>8676032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.fbMotionStageSim</Name>
+            <BitSize>171328</BitSize>
+            <BaseType>FB_MotionStageSim</BaseType>
+            <BitOffs>8697088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.stOut</Name>
             <BitSize>2432</BitSize>
             <BaseType>DUT_PositionState</BaseType>
-            <BitOffs>8995520</BitOffs>
+            <BitOffs>8868416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.fbGoOut</Name>
             <BitSize>2944</BitSize>
             <BaseType>FB_PositionStateMove</BaseType>
-            <BitOffs>8997952</BitOffs>
+            <BitOffs>8870848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.stIn</Name>
             <BitSize>2432</BitSize>
             <BaseType>DUT_PositionState</BaseType>
-            <BitOffs>9000896</BitOffs>
+            <BitOffs>8873792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.fbGoIn</Name>
             <BitSize>2944</BitSize>
             <BaseType>FB_PositionStateMove</BaseType>
-            <BitOffs>9003328</BitOffs>
+            <BitOffs>8876224</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Interactive.stUnsafe</Name>
-            <BitSize>2432</BitSize>
-            <BaseType>DUT_PositionState</BaseType>
-            <BitOffs>9006272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.fbGoBad</Name>
-            <BitSize>2944</BitSize>
-            <BaseType>FB_PositionStateMove</BaseType>
-            <BitOffs>9008704</BitOffs>
+            <Name>Interactive.bGoIn</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>8879168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.bHCF</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>9011648</BitOffs>
+            <BitOffs>8879176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.bGoHCF</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>9011656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.setState</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <BitOffs>9011664</BitOffs>
+            <BitOffs>8879184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.bError</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>9011680</BitOffs>
+            <BitOffs>8879192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.errState</Name>
             <BitSize>16</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_AxisStates</BaseType>
-            <BitOffs>9011696</BitOffs>
+            <BitOffs>8879200</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Interactive.fbEpicsInOut</Name>
-            <BitSize>218496</BitSize>
-            <BaseType>FB_EpicsInOut</BaseType>
+            <Name>MOTION_GVL.MAX_STATES</Name>
+            <Comment> Allocated space for 6 states besides Unknown (16 including Unknown is the max for an EPICS MBBI)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>6</Value>
+            </Default>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: TST:STATE
-        io: io
-    </Value>
+                <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9011712</BitOffs>
+            <BitOffs>8879216</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Interactive.fbStateManager</Name>
-            <BitSize>180928</BitSize>
-            <BaseType>FB_PositionStateManager</BaseType>
-            <BitOffs>9230208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.arrStates</Name>
-            <BitSize>36480</BitSize>
+            <Name>Interactive.stUnsafe</Name>
+            <BitSize>2432</BitSize>
             <BaseType>DUT_PositionState</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>15</Elements>
-            </ArrayInfo>
-            <BitOffs>9411136</BitOffs>
+            <BitOffs>8879232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.fbGoBad</Name>
+            <BitSize>2944</BitSize>
+            <BaseType>FB_PositionStateMove</BaseType>
+            <BitOffs>8881664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor</Name>
             <BitSize>21056</BitSize>
             <BaseType>DUT_MotionStage</BaseType>
-            <BitOffs>9447616</BitOffs>
+            <BitOffs>8884608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>BasicTests.fbMotion</Name>
+            <BitSize>171328</BitSize>
+            <BaseType>FB_MotionStageSim</BaseType>
+            <BitOffs>8905664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.fbRequest</Name>
             <BitSize>1920</BitSize>
             <BaseType>FB_MotionRequest</BaseType>
-            <BitOffs>9640000</BitOffs>
+            <BitOffs>9076992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.stUnknownState</Name>
@@ -30900,7 +31302,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9642944</BitOffs>
+            <BitOffs>9079936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.stInvalidState</Name>
@@ -30911,7 +31313,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9645376</BitOffs>
+            <BitOffs>9082368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_lcls_twincat_motion</Name>
@@ -30950,7 +31352,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9647808</BitOffs>
+            <BitOffs>9084800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.nHomingError</Name>
@@ -30964,7 +31366,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9648096</BitOffs>
+            <BitOffs>9085088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_ErrorSystem.cSizeOfErrorData</Name>
@@ -30978,7 +31380,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9648128</BitOffs>
+            <BitOffs>9085120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -30993,22 +31395,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9648144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9648152</BitOffs>
+            <BitOffs>9085144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -31038,7 +31425,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9648160</BitOffs>
+            <BitOffs>9085152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -31068,7 +31455,36 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9648224</BitOffs>
+            <BitOffs>9085216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9085280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bFPUSupport</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9085288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -31083,7 +31499,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9648288</BitOffs>
+            <BitOffs>9085296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -31098,21 +31514,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9648304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bFPUSupport</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9648320</BitOffs>
+            <BitOffs>9085312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -31126,7 +31528,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9648352</BitOffs>
+            <BitOffs>9085344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -31140,7 +31542,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9648384</BitOffs>
+            <BitOffs>9085376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -31209,7 +31611,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9648416</BitOffs>
+            <BitOffs>9085408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -31223,7 +31625,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9649440</BitOffs>
+            <BitOffs>9086432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -31237,7 +31639,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9649472</BitOffs>
+            <BitOffs>9086464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -31255,7 +31657,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9651520</BitOffs>
+            <BitOffs>9088512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -31269,7 +31671,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9652544</BitOffs>
+            <BitOffs>9089536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -31290,7 +31692,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9652608</BitOffs>
+            <BitOffs>9089600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -31313,26 +31715,14 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>10022080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.fbMotionStageSim</Name>
-            <BitSize>171328</BitSize>
-            <BaseType>FB_MotionStageSim</BaseType>
-            <BitOffs>14769152</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>BasicTests.fbMotion</Name>
-            <BitSize>171328</BitSize>
-            <BaseType>FB_MotionStageSim</BaseType>
-            <BitOffs>15132352</BitOffs>
+            <BitOffs>9459072</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1966080</ByteSize>
+          <ByteSize>1900544</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -31386,15 +31776,15 @@ External Setpoint Generation:
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2020-07-30T10:16:33</Value>
+          <Value>2020-09-10T11:02:58</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>602112</Value>
+          <Value>606208</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>757760</Value>
+          <Value>688128</Value>
         </Property>
       </Properties>
     </Module>

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -1009,6 +1009,55 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>Interactive.fbMotionStageSim.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
 					<Name>BasicTests.Motor.Axis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -1107,55 +1156,6 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>Interactive.fbMotionStageSim.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
-				</Var>
-				<Var>
 					<Name>BasicTests.fbMotion.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -1219,6 +1219,10 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>Interactive.fbMotionStageSim.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
 					<Name>BasicTests.Motor.Axis.PlcToNc</Name>
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
@@ -1228,10 +1232,6 @@ External Setpoint Generation:
 						<![CDATA[ NC Brake Output: TRUE to release brake]]>
 					</Comment>
 					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>Interactive.fbMotionStageSim.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>BasicTests.fbMotion.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>


### PR DESCRIPTION
Increase MAX_STATES from 5 to 6, because the WFS has 6 states (Out and 5 targets).

Still unsure on a long-term solution for states devices.
On the Python side we'll probably end up giving in and making different class variants for each state count to optimize the experience/performance at the cost of one-time annoying programming.
On the PLC side we want to minimize the PV count because it improves IOC performance, but I'm not sure the best way. Perhaps we end up allocating max states but finding a way to only generate PVs for the states in use via new pytmc magic.