### PR TITLE
MNT: move arbiter pragma so EPICS works

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS_Base.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS_Base.TcPOU
@@ -12,10 +12,6 @@ VAR_IN_OUT
     arrStates: ARRAY[1..MOTION_GVL.MAX_STATES] OF DUT_PositionState;
 END_VAR
 VAR_INPUT
-    {attribute 'pytmc' := '
-        pv: ARB:ENABLE
-        io: io
-    '}
     bArbiterEnabled: BOOL := TRUE;
     {attribute 'pytmc' := '
         pv: MAINT

--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateBase_WithPMPS.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateBase_WithPMPS.TcPOU
@@ -15,6 +15,10 @@ VAR_INPUT
     stTransitionBeam: ST_BeamParams := PMPS_GVL.cst0RateBeam;
     nTransitionAssertionID: UDINT;
     nUnknownAssertionID: UDINT;
+    {attribute 'pytmc' := '
+        pv: ARB:ENABLE
+        io: io
+    '}
     bArbiterEnabled: BOOL := TRUE;
     tArbiterTimeout: TIME := T#1s;
     bMoveOnArbiterTimeout: BOOL := TRUE;


### PR DESCRIPTION
The pragma was putting to a lower-level caller that gets overridden in a higher level. This resolves the issue so that the built IOC will set/get from the correct variable.

closes #94 