### PR TITLE
ENH: Relative encoder support (homing, saving)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ fbMotionStage(stMotionStage := stMotionStage);
 | `Enum_StageEnableMode` | enum | Options for axis enable/disable handling. Axis can be enabled always, never, or only during motion. |
 
 ## Homing
-To activate a homing routing, put 1 to the EPICS `.HOMF` or `.HOMR` fields. As far as the TwinCAT program is concerned, these both mean the same thing: "home using our internal configuration".
+To activate a homing routing, put 1 to the EPICS `:PLC:bHomeCmd` field. Note: the `.HOMF` and `.HOMR` fields work in some cases at the IOC, but are currently buggy.
 
 To configure a homing routine, set the `fHomePosition` variable to the position to use after homing, and set the `nHomingMode` variable to pick a strategy. These strategies are stored in `ENUM_EpicsHomeCmd` enum. All homing motion strategies move towards their destinations using the "Homing Velocity (towards plc cam)" parameter , then off of the switch using the "Homing velocity (off plc cam)" parameter. The normal options are:
 - `LOW_LIMIT`: Move to the low limit (backward) switch. Set home position at the first point we see as we leave the switch.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ fbMotionStage(stMotionStage := stMotionStage);
 | `bPowerSelf` | `BOOL` | If `FALSE` (default), then `FB_MotionStage` will expect an external PMPS function block to call `MC_Power` appropriately. You can switch this to `TRUE` to opt out of PMPS and handle motor enabling within `FB_MotionStage`. | `FALSE` |
 | `nEnableMode` | `ENUM_StageEnableMode` | Automatically enable the NC Axis `ALWAYS`, `NEVER`, or only `DURING_MOTION` (default). Switch this to `ALWAYS` if you want active position correction at all times and to `NEVER` if you're doing checkout with the TwinCAT NC GUI. | `DURING_MOTION` |
 | `nBrakeMode` | `ENUM_StageBrakeMode` | Break disengage timing. Disengage the break `IF_ENABLED` (default), `IF_MOVING`, or never change the break state with `NO_BRAKE`. Note that this does nothing unless a brake is linked to `bBrakeRelease`. | `IF_ENABLED` |
-| `nHomingMode` | `ENUM_EpicsHomeCmd` | Pick which switch to home to, or not to require homing (default) | `NONE` |
-| `bGantryMode` | `BOOL` | Set to `TRUE` to activate gantry EPS | `FALSE` |
+| `nHomingMode` | `ENUM_EpicsHomeCmd` | Pick which switch to home to, or not to require homing (default). | `NONE` |
+| `fHomePosition` | `LREAL` | The position to set at the home switch. | 0 |
+| `bGantryMode` | `BOOL` | Set to `TRUE` to activate gantry EPS. | `FALSE` |
 | `nGantryTol` | `LINT` | If the gantry error is greater than this number of encoder counts, trigger a virtual limit. | 0 |
 | `nEncRef` | `ULINT` | Encoder count for gantry motion where the two axes are aligned. | 0 |
 
@@ -62,9 +63,22 @@ fbMotionStage(stMotionStage := stMotionStage);
 | `ENUM_StageBrakeMode` | enum | Options for axis brake mode. Brake can be enabled at standstill or at disabled. |
 | `Enum_StageEnableMode` | enum | Options for axis enable/disable handling. Axis can be enabled always, never, or only during motion. |
 
+## Homing
+To activate a homing routing, put 1 to the EPICS `.HOMF` or `.HOMR` fields. As far as the TwinCAT program is concerned, these both mean the same thing: "home using our internal configuration".
+
+To configure a homing routine, set the `fHomePosition` variable to the position to use after homing, and set the `nHomingMode` variable to pick a strategy. These strategies are stored in `ENUM_EpicsHomeCmd` enum. All homing motion strategies move towards their destinations using the "Homing Velocity (towards plc cam)" parameter , then off of the switch using the "Homing velocity (off plc cam)" parameter. The normal options are:
+- `LOW_LIMIT`: Move to the low limit (backward) switch. Set home position at the first point we see as we leave the switch.
+- `HIGH_LIMIT`: Move to the high limit (forward) switch. Set home position at the first point we see as we leave the switch.
+- `HOME_VIA_LOW`: Move towards the low limit (backward) switch, seeking out the position where `bHome` is `TRUE`. If we reach the limit switch without finding `bHome`, reverse direction and try moving towards the high switch. Set home position to the point just above the `bHome` signal.
+- `HOME_VIA_HIGH`: Move towards the high limit (forward) switch, seeking out the position where `bHome` is `TRUE`. If we reach the limit switch without finding `bHome`, reverse direction and try moving towards the low switch. Set home position to the point just below the `bHome` signal.
+
+There are two additional special-case options:
+- `ABSOLUTE_SET`: When we ask for a home, do not move the motor- simply declare the current position as "home". This is basically a manual homing routine.
+- `None`: Do not home! Ever! This is actually the default value, and the only one "implemented" prior to this PR.
+
+If the homing strategy is set to any value other than `None`, the library knows we have a motor that wants save/restore. In these cases, the last position of the motor will be saved on TwinCAT shutdown and restored on the first cycle of the PLC program. This prevents the location of your relatively encoded motor from being lost when the PLC is reconfigured.
 
 ## Confluence links
-
 * Flight rules: https://confluence.slac.stanford.edu/display/PCDS/Beckhoff+Flight+Rules
 * Axis setup: https://confluence.slac.stanford.edu/display/PCDS/Basic+Beckhoff+Stepper+Axis+Software+Setup
 * Axis tuning: https://confluence.slac.stanford.edu/display/PCDS/Beckhoff+Stepper+Axis+Tuning

--- a/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
@@ -265,7 +265,7 @@ STRUCT
         field: DESC Used internally and by the IOC to pick home position
     '}
     fHomePosition: LREAL;
-    
+
     (* Info *)
     // Unique ID assigned to each axis in the NC
     {attribute 'pytmc' := '

--- a/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
@@ -199,6 +199,22 @@ STRUCT
     '}
     bExecute: BOOL;
 
+    (* Shortcut Commands *)
+    // Start a move to fPosition with fVelocity
+    {attribute 'pytmc' := '
+        pv: PLC:bMoveCmd
+        io: io
+        field: DESC Start a move
+    '}
+    bMoveCmd: BOOL;
+    // Start the homing routine
+    {attribute 'pytmc' := '
+        pv: PLC:bHomeCmd
+        io: io
+        field: DESC Start the homing routine
+    '}
+    bHomeCmd: BOOL;
+
     (* Command Args *)
     // Used internally and by the IOC to pick what kind of move to do
     {attribute 'pytmc' := '
@@ -249,7 +265,7 @@ STRUCT
         field: DESC Used internally and by the IOC to pick home position
     '}
     fHomePosition: LREAL;
-
+    
     (* Info *)
     // Unique ID assigned to each axis in the NC
     {attribute 'pytmc' := '
@@ -287,6 +303,13 @@ STRUCT
         field: DESC TRUE if command finished successfully
     '}
     bDone: BOOL;
+    // TRUE if the motor has been homed, or does not need to be homed
+    {attribute 'pytmc' := '
+        pv: PLC:bHomed
+        io: i
+        field: DESC TRUE if the motor has been homed
+    '}
+    bHomed: BOOL;
     // TRUE if we have safety permission to move
     {attribute 'pytmc' := '
         pv: PLC:bSafetyReady

--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -131,6 +131,12 @@
     <Compile Include="POUs\Motion\FB_EncoderValue.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Motion\FB_EncSaveRestore.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Motion\FB_MotionHoming.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Motion\FB_MotionRequest.TcPOU">
       <SubType>Code</SubType>
     </Compile>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
@@ -42,7 +42,6 @@ END_VAR
     // Only load once, at startup
     bLoad R= fbSetPos.Done OR fbSetPos.Error;
 
-
     IF fbSetPos.Error THEN
         // Keep the error latched, it can disappear if Execute is set to FALSE
         nLatchError := fbSetPos.ErrorID;

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
@@ -53,7 +53,7 @@ END_VAR
 
     // Check DUT_MotionStage for an encoder error (range 0x44nn)
     bEncError := stMotionStage.bError AND stMotionStage.nErrorId >= 16#4400 AND stMotionStage.nErrorId <= 16#44FF;
-    
+
     // Do not save if we're currently loading or if there is an encoder error
     IF NOT bLoad AND NOT bEncError THEN
         fPosition := stMotionStage.stAxisStatus.fActPosition;

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_EncSaveRestore" Id="{7f38772f-c9da-4f49-aee1-95cd4af3fbdf}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_EncSaveRestore
+VAR_IN_OUT
+    stMotionStage: DUT_MotionStage;
+END_VAR
+VAR_INPUT
+    bEnable: BOOL;
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR
+    fbSetPos: MC_SetPosition;
+    timer: TON;
+    tSaveDelay: TIME := T#10s;
+    bInit: BOOL;
+    bLoad: BOOL;
+    nLatchError: UDINT;
+END_VAR
+VAR PERSISTENT
+    bSaved: BOOL;
+    fPosition: LREAL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF bEnable THEN
+    // Trigger a load if anything was saved at all
+    IF NOT bInit THEN
+        bInit := TRUE;
+        bLoad S= bSaved;
+        fbSetPos.Options.ClearPositionLag := TRUE;
+    END_IF
+    
+    // Set our position if bLoad is true
+    fbSetPos(
+        Axis:=stMotionStage.Axis,
+        Execute:=bLoad,
+        Position:=fPosition);
+        
+    // Only load once, at startup
+    bLoad R= fbSetPos.Done OR fbSetPos.Error;
+    
+    // Keep the error latched, it can disappear if Execute is set to FALSE
+    IF fbSetPos.Error THEN
+        nLatchError := fbSetPos.ErrorID;
+    END_IF
+    
+    // Do not save if we're currently loading
+    IF NOT bLoad THEN
+        fPosition := stMotionStage.stAxisStatus.fActPosition;
+        // This persistent variable lets us check if anything was saved
+        // It will be TRUE at startup if we have saved values
+        bSaved := TRUE;
+    END_IF
+END_IF]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
@@ -31,21 +31,21 @@ END_VAR
         bLoad S= bSaved;
         fbSetPos.Options.ClearPositionLag := TRUE;
     END_IF
-    
+
     // Set our position if bLoad is true
     fbSetPos(
         Axis:=stMotionStage.Axis,
         Execute:=bLoad,
         Position:=fPosition);
-        
+
     // Only load once, at startup
     bLoad R= fbSetPos.Done OR fbSetPos.Error;
-    
+
     // Keep the error latched, it can disappear if Execute is set to FALSE
     IF fbSetPos.Error THEN
         nLatchError := fbSetPos.ErrorID;
     END_IF
-    
+
     // Do not save if we're currently loading
     IF NOT bLoad THEN
         fPosition := stMotionStage.stAxisStatus.fActPosition;

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
@@ -41,9 +41,14 @@ END_VAR
     // Only load once, at startup
     bLoad R= fbSetPos.Done OR fbSetPos.Error;
 
-    // Keep the error latched, it can disappear if Execute is set to FALSE
+
     IF fbSetPos.Error THEN
+        // Keep the error latched, it can disappear if Execute is set to FALSE
         nLatchError := fbSetPos.ErrorID;
+        // Alert the user that something has gone wrong
+        stMotionStage.bError := TRUE;
+        stMotionStage.nErrorId := fbSetPos.ErrorID;
+        stMotionStage.sCustomErrorMessage := 'Error loading previously saved position.';
     END_IF
 
     // Do not save if we're currently loading

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
@@ -17,6 +17,7 @@ VAR
     bInit: BOOL;
     bLoad: BOOL;
     nLatchError: UDINT;
+    bEncError: BOOL;
 END_VAR
 VAR PERSISTENT
     bSaved: BOOL;
@@ -51,8 +52,11 @@ END_VAR
         stMotionStage.sCustomErrorMessage := 'Error loading previously saved position.';
     END_IF
 
-    // Do not save if we're currently loading
-    IF NOT bLoad THEN
+    // Check DUT_MotionStage for an encoder error (range 0x44nn)
+    bEncError := DUT_MotionStage.bError AND DUT_MotionStage.nErrorId >= 16#4400 AND DUT_MotionStage.nErrorId <= 16#44FF;
+    
+    // Do not save if we're currently loading or if there is an encoder error
+    IF NOT bLoad AND NOT bEncError THEN
         fPosition := stMotionStage.stAxisStatus.fActPosition;
         // This persistent variable lets us check if anything was saved
         // It will be TRUE at startup if we have saved values

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
@@ -53,7 +53,7 @@ END_VAR
     END_IF
 
     // Check DUT_MotionStage for an encoder error (range 0x44nn)
-    bEncError := DUT_MotionStage.bError AND DUT_MotionStage.nErrorId >= 16#4400 AND DUT_MotionStage.nErrorId <= 16#44FF;
+    bEncError := stMotionStage.bError AND stMotionStage.nErrorId >= 16#4400 AND stMotionStage.nErrorId <= 16#44FF;
     
     // Do not save if we're currently loading or if there is an encoder error
     IF NOT bLoad AND NOT bEncError THEN

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -8,6 +8,9 @@ END_VAR
 VAR_INPUT
     bExecute: BOOL;
 END_VAR
+VAR_OUTPUT
+    bDone: BOOL;
+END_VAR
 VAR
     fbSetPos: MC_SetPosition;
     fbJog: MC_Jog;
@@ -58,6 +61,9 @@ CASE stMotionStage.nHomingMode OF
             Execute:=bExecute,
             Position:=stMotionStage.fHomePosition);
         bMove := FALSE;
+    ENUM_EpicsHomeCmd.NONE:
+        bMove := FALSE;
+        bDone := TRUE;
     ELSE
         bMove := FALSE;
 END_CASE
@@ -69,6 +75,7 @@ IF bMove THEN
             IF rtExec.Q THEN
                 nHomeStateMachine := NEXT_MOVE;
                 nMoves := 0;
+                bDone := FALSE;
 			END_IF
         // Figure out whether to move forward, move backward, or give up
         NEXT_MOVE:
@@ -164,6 +171,7 @@ IF bMove THEN
                 Execute:=TRUE,
                 Position:=stMotionStage.fHomePosition);
             nHomeStateMachine := IDLE;
+            bDone := TRUE;
         ERROR:
             nHomeStateMachine := IDLE;
 	END_CASE

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -18,12 +18,14 @@ VAR
     fbSetPos: MC_SetPosition;
     fbJog: MC_Jog;
     rtExec: R_TRIG;
+    ftExec: F_TRIG;
     nHomeStateMachine: INT := IDLE;
     nMoves: INT;
     bFirstDirection: BOOL;
     bAtHome: BOOL;
     bMove: BOOL;
     nErrCount: INT;
+    bInterrupted: BOOL;
 END_VAR
 VAR CONSTANT
     IDLE: INT := 0;
@@ -41,6 +43,7 @@ END_VAR]]></Declaration>
       <ST><![CDATA[
 fbSetPos.Options.ClearPositionLag := TRUE;
 rtExec(CLK:=bExecute);
+ftExec(CLK:=bExecute);
 
 CASE stMotionStage.nHomingMode OF
     ENUM_EpicsHomeCmd.LOW_LIMIT:
@@ -76,8 +79,9 @@ CASE stMotionStage.nHomingMode OF
 END_CASE
 
 IF bMove THEN
-    IF NOT bExecute THEN
-        nHomeStateMachine := IDLE;
+    IF bBusy AND ftExec.Q THEN
+        nHomeStateMachine := ERROR;
+        bInterrupted := TRUE;
 	END_IF
     CASE nHomeStateMachine OF
         // Wait for a rising edge
@@ -98,6 +102,7 @@ IF bMove THEN
                 bBusy := TRUE;
                 bError := FALSE;
                 nErrorID := 0;
+                bInterrupted := FALSE;
             END_IF
         // Figure out whether to move forward, move backward, or give up
         NEXT_MOVE:
@@ -222,7 +227,11 @@ IF bMove THEN
             fbSetPos(
                 Axis:=stMotionStage.Axis,
                 Execute:=FALSE);
-            stMotionStage.sCustomErrorMessage := 'Homing failure';
+            IF bInterrupted THEN
+                stMotionStage.sCustomErrorMessage := 'Homing interrutped';
+            ELSE
+                stMotionStage.sCustomErrorMessage := 'Homing failure';
+			END_IF
 	END_CASE
 END_IF]]></ST>
     </Implementation>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -11,6 +11,8 @@ END_VAR
 VAR_OUTPUT
     bBusy: BOOL;
     bDone: BOOL;
+    bError: BOOL;
+    nErrorID: UDINT;
 END_VAR
 VAR
     fbSetPos: MC_SetPosition;
@@ -74,6 +76,9 @@ CASE stMotionStage.nHomingMode OF
 END_CASE
 
 IF bMove THEN
+    IF NOT bExecute THEN
+        nHomeStateMachine := IDLE;
+	END_IF
     CASE nHomeStateMachine OF
         // Wait for a rising edge
         IDLE:
@@ -91,6 +96,8 @@ IF bMove THEN
                 nMoves := 0;
                 bDone := FALSE;
                 bBusy := TRUE;
+                bError := FALSE;
+                nErrorID := 0;
             END_IF
         // Figure out whether to move forward, move backward, or give up
         NEXT_MOVE:
@@ -182,6 +189,15 @@ IF bMove THEN
                     JogBackwards:=bFirstDirection,
                     Mode:=E_JogMode.MC_JOGMODE_CONTINOUS,
                     Velocity:=stMotionStage.stAxisParameters.fRefVeloSync);
+            ELSIF fbJog.Error THEN
+                fbJog(
+                    Axis:=stMotionStage.Axis,
+                    JogForward:=FALSE,
+                    JogBackwards:=FALSE);
+                nErrCount := nErrCount + 1;
+                IF nErrCount >= 3 THEN
+                    nHomeStateMachine := ERROR;
+                END_IF
             ELSE
                 fbJog(
                     Axis:=stMotionStage.Axis,
@@ -200,7 +216,13 @@ IF bMove THEN
             nHomeStateMachine := IDLE;
             bDone := TRUE;
         ERROR:
-            nHomeStateMachine := IDLE;
+            bError := TRUE;
+            nErrorID := fbJog.ErrorID;
+            nHomeStateMachine := FINAL_SETPOS;
+            fbSetPos(
+                Axis:=stMotionStage.Axis,
+                Execute:=FALSE);
+            stMotionStage.sCustomErrorMessage := 'Homing failure';
 	END_CASE
 END_IF]]></ST>
     </Implementation>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -219,6 +219,7 @@ IF bMove THEN
                 Execute:=TRUE,
                 Position:=stMotionStage.fHomePosition);
             nHomeStateMachine := IDLE;
+            bBusy := FALSE;
             bDone := TRUE;
         ERROR:
             bError := TRUE;

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -35,7 +35,7 @@ VAR CONSTANT
     FINAL_MOVE: INT := 4;
     FINAL_SETPOS: INT := 5;
     ERROR: INT := 6;
-    
+
     FWD_START: LREAL := -99999999;
     BWD_START: LREAL :=  99999999;
 END_VAR]]></Declaration>
@@ -87,7 +87,7 @@ IF bMove THEN
     IF bBusy AND ftExec.Q THEN
         nHomeStateMachine := ERROR;
         bInterrupted := TRUE;
-	END_IF
+    END_IF
     CASE nHomeStateMachine OF
         // Wait for a rising edge
         IDLE:
@@ -133,7 +133,7 @@ IF bMove THEN
                     END_IF
                 ELSE
                     nHomeStateMachine := ERROR;
-			END_CASE
+            END_CASE
             nMoves := nMoves + 1;
             IF bAtHome THEN
                 nHomeStateMachine := FINAL_MOVE;
@@ -237,8 +237,8 @@ IF bMove THEN
                 stMotionStage.sCustomErrorMessage := 'Homing interrutped';
             ELSE
                 stMotionStage.sCustomErrorMessage := 'Homing failure';
-			END_IF
-	END_CASE
+            END_IF
+    END_CASE
 END_IF]]></ST>
     </Implementation>
   </POU>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -28,7 +28,7 @@ VAR CONSTANT
     CHECK_BWD: INT := 3;
     FINAL_MOVE: INT := 4;
     FINAL_SETPOS: INT := 5;
-    ERROR: INT := 5;
+    ERROR: INT := 6;
     
     FWD_START: LREAL := -99999999;
     BWD_START: LREAL :=  99999999;

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -9,6 +9,7 @@ VAR_INPUT
     bExecute: BOOL;
 END_VAR
 VAR_OUTPUT
+    bBusy: BOOL;
     bDone: BOOL;
 END_VAR
 VAR
@@ -60,10 +61,13 @@ CASE stMotionStage.nHomingMode OF
             Axis:=stMotionStage.Axis,
             Execute:=bExecute,
             Position:=stMotionStage.fHomePosition);
+        bBusy := fbSetPos.Busy;
+        bDone := fbSetPos.Done;
         bMove := FALSE;
     ENUM_EpicsHomeCmd.NONE:
         bMove := FALSE;
-        bDone := TRUE;
+        bBusy := NOT bExecute;
+        bDone := bExecute;
     ELSE
         bMove := FALSE;
 END_CASE
@@ -72,10 +76,12 @@ IF bMove THEN
     CASE nHomeStateMachine OF
         // Wait for a rising edge
         IDLE:
+            bBusy := FALSE;
             IF rtExec.Q THEN
                 nHomeStateMachine := NEXT_MOVE;
                 nMoves := 0;
                 bDone := FALSE;
+                bBusy := TRUE;
 			END_IF
         // Figure out whether to move forward, move backward, or give up
         NEXT_MOVE:

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -77,8 +77,8 @@ CASE stMotionStage.nHomingMode OF
         bMove := FALSE;
     ENUM_EpicsHomeCmd.NONE:
         bMove := FALSE;
-        bBusy := NOT bExecute;
-        bDone := bExecute;
+        bBusy := bExecute;
+        bDone := NOT bExecute;
     ELSE
         bMove := FALSE;
 END_CASE

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -124,11 +124,7 @@ IF bMove THEN
                 JogBackwards:=FALSE,
                 Mode:=E_JogMode.MC_JOGMODE_CONTINOUS,
                 Velocity:=stMotionStage.stAxisParameters.fRefVeloSearch);
-            IF fbJog.Error THEN
-                nHomeStateMachine := ERROR;
-            ELSIF bATHome THEN
-                nHomeStateMachine := FINAL_MOVE;
-            ELSIF NOT fbJog.JogForward THEN
+            IF NOT fbJog.JogForward THEN
                 nHomeStateMachine := NEXT_MOVE;
 			END_IF
         // Move backward until we find the home signal or reach end of travel
@@ -143,9 +139,7 @@ IF bMove THEN
                 JogBackwards:=stMotionStage.bLimitBackwardEnable AND NOT bATHome,
                 Mode:=E_JogMode.MC_JOGMODE_CONTINOUS,
                 Velocity:=stMotionStage.stAxisParameters.fRefVeloSearch);
-            IF fbJog.Error THEN
-                nHomeStateMachine := ERROR;
-            ELSIF NOT fbJog.JogBackwards THEN
+            IF NOT fbJog.JogBackwards THEN
                 nHomeStateMachine := NEXT_MOVE;
 			END_IF
         // Set position to get within soft lims, move slowly off signal

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -234,7 +234,7 @@ IF bMove THEN
                 Axis:=stMotionStage.Axis,
                 Execute:=FALSE);
             IF bInterrupted THEN
-                stMotionStage.sCustomErrorMessage := 'Homing interrutped';
+                stMotionStage.sCustomErrorMessage := 'Homing interrupted';
             ELSE
                 stMotionStage.sCustomErrorMessage := 'Homing failure';
             END_IF

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -80,13 +80,13 @@ CASE stMotionStage.nHomingMode OF
             Axis:=stMotionStage.Axis,
             Execute:=bExecute,
             Position:=stMotionStage.fHomePosition);
-        bBusy := fbSetPos.Busy;
-        bDone := fbSetPos.Done;
+        bBusy := rtExec.Q;
+        bDone := NOT rtExec.Q;
         bMove := FALSE;
     ENUM_EpicsHomeCmd.NONE:
         bMove := FALSE;
-        bBusy := bExecute;
-        bDone := NOT bExecute;
+        bBusy := rtExec.Q;
+        bDone := NOT rtExec.Q;
     ELSE
         bMove := FALSE;
 END_CASE

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -1,0 +1,173 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_MotionHoming" Id="{89795143-e01c-4e96-8d50-67b6176895fe}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_MotionHoming
+VAR_IN_OUT
+    stMotionStage: DUT_MotionStage;
+END_VAR
+VAR_INPUT
+    bExecute: BOOL;
+END_VAR
+VAR
+    fbSetPos: MC_SetPosition;
+    fbJog: MC_Jog;
+    rtExec: R_TRIG;
+    nHomeStateMachine: INT := IDLE;
+    nMoves: INT;
+    bFirstDirection: BOOL;
+    bAtHome: BOOL;
+    bMove: BOOL;
+END_VAR
+VAR CONSTANT
+    IDLE: INT := 0;
+    NEXT_MOVE: INT := 1;
+    CHECK_FWD: INT := 2;
+    CHECK_BWD: INT := 3;
+    FINAL_MOVE: INT := 4;
+    FINAL_SETPOS: INT := 5;
+    ERROR: INT := 5;
+    
+    FWD_START: LREAL := -99999999;
+    BWD_START: LREAL :=  99999999;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[
+fbSetPos.Options.ClearPositionLag := TRUE;
+rtExec(CLK:=bExecute);
+
+CASE stMotionStage.nHomingMode OF
+    ENUM_EpicsHomeCmd.LOW_LIMIT:
+        bFirstDirection := FALSE;
+        bAtHome := NOT stMotionStage.bLimitBackwardEnable;
+        bMove := TRUE;
+    ENUM_EpicsHomeCmd.HIGH_LIMIT:
+        bFirstDirection := TRUE;
+        bAtHome := NOT stMotionStage.bLimitForwardEnable;
+        bMove := TRUE;
+    ENUM_EpicsHomeCmd.HOME_VIA_LOW:
+        bFirstDirection := FALSE;
+        bAtHome := stMotionStage.bHome;
+        bMove := TRUE;
+    ENUM_EpicsHomeCmd.HOME_VIA_HIGH:
+        bFirstDirection := TRUE;
+        bAtHome := stMotionStage.bHome;
+        bMove := TRUE;
+    ENUM_EpicsHomeCmd.ABSOLUTE_SET:
+        fbSetPos(
+            Axis:=stMotionStage.Axis,
+            Execute:=bExecute,
+            Position:=stMotionStage.fHomePosition);
+        bMove := FALSE;
+    ELSE
+        bMove := FALSE;
+END_CASE
+
+IF bMove THEN
+    CASE nHomeStateMachine OF
+        // Wait for a rising edge
+        IDLE:
+            IF rtExec.Q THEN
+                nHomeStateMachine := NEXT_MOVE;
+                nMoves := 0;
+			END_IF
+        // Figure out whether to move forward, move backward, or give up
+        NEXT_MOVE:
+            fbSetPos(
+                Axis:=stMotionStage.Axis,
+                Execute:=FALSE);
+            fbJog(
+                Axis:=stMotionStage.Axis,
+                JogForward:=FALSE,
+                JogBackwards:=FALSE);
+            CASE nMoves OF
+                0:
+                    IF bFirstDirection THEN
+                        nHomeStateMachine := CHECK_FWD;
+                    ELSE
+                        nHomeStateMachine := CHECK_BWD;
+					END_IF
+                1:
+                    IF NOT bFirstDirection THEN
+                        nHomeStateMachine := CHECK_FWD;
+                    ELSE
+                        nHomeStateMachine := CHECK_BWD;
+					END_IF
+                ELSE
+                    nHomeStateMachine := ERROR;
+			END_CASE
+            nMoves := nMoves + 1;
+            IF bAtHome THEN
+                nHomeStateMachine := FINAL_MOVE;
+			END_IF
+        // Move forward until we find the home signal or reach end of travel
+        CHECK_FWD:
+            fbSetPos(
+                Axis:=stMotionStage.Axis,
+                Execute:=TRUE,
+                Position:=FWD_START);
+            fbJog(
+                Axis:=stMotionStage.Axis,
+                JogForward:=stMotionStage.bLimitForwardEnable AND NOT bATHome,
+                JogBackwards:=FALSE,
+                Mode:=E_JogMode.MC_JOGMODE_CONTINOUS,
+                Velocity:=stMotionStage.stAxisParameters.fRefVeloSearch);
+            IF fbJog.Error THEN
+                nHomeStateMachine := ERROR;
+            ELSIF bATHome THEN
+                nHomeStateMachine := FINAL_MOVE;
+            ELSIF NOT fbJog.JogForward THEN
+                nHomeStateMachine := NEXT_MOVE;
+			END_IF
+        // Move backward until we find the home signal or reach end of travel
+        CHECK_BWD:
+            fbSetPos(
+                Axis:=stMotionStage.Axis,
+                Execute:=TRUE,
+                Position:=BWD_START);
+            fbJog(
+                Axis:=stMotionStage.Axis,
+                JogForward:=FALSE,
+                JogBackwards:=stMotionStage.bLimitBackwardEnable AND NOT bATHome,
+                Mode:=E_JogMode.MC_JOGMODE_CONTINOUS,
+                Velocity:=stMotionStage.stAxisParameters.fRefVeloSearch);
+            IF fbJog.Error THEN
+                nHomeStateMachine := ERROR;
+            ELSIF NOT fbJog.JogBackwards THEN
+                nHomeStateMachine := NEXT_MOVE;
+			END_IF
+        // Set position to get within soft lims, move slowly off signal
+        FINAL_MOVE:
+            fbSetPos(
+                Axis:=stMotionStage.Axis,
+                Execute:=TRUE,
+                Position:=stMotionStage.fHomePosition);
+            IF bAtHome THEN
+                fbJog(
+                    Axis:=stMotionStage.Axis,
+                    JogForward:=NOT bFirstDirection,
+                    JogBackwards:=bFirstDirection,
+                    Mode:=E_JogMode.MC_JOGMODE_CONTINOUS,
+                    Velocity:=stMotionStage.stAxisParameters.fRefVeloSync);
+            ELSE
+                fbJog(
+                    Axis:=stMotionStage.Axis,
+                    JogForward:=FALSE,
+                    JogBackwards:=FALSE);
+                fbSetPos(
+                    Axis:=stMotionStage.Axis,
+                    Execute:=FALSE);
+                nHomeStateMachine := FINAL_SETPOS;
+            END_IF
+        FINAL_SETPOS:
+            fbSetPos(
+                Axis:=stMotionStage.Axis,
+                Execute:=TRUE,
+                Position:=stMotionStage.fHomePosition);
+            nHomeStateMachine := IDLE;
+        ERROR:
+            nHomeStateMachine := IDLE;
+	END_CASE
+END_IF]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -36,6 +36,14 @@ VAR CONSTANT
     FINAL_SETPOS: INT := 5;
     ERROR: INT := 6;
 
+    (*
+        This is a simpler way of disabling the soft limits that ends up being really obvious if something has gone wrong.
+        If you turn the limits off/on, not only do you need to keep track of if you had soft limits set,
+        but you need to always restore this properly or risk some issue.
+        Instead, I set position to a ridiculous value that can always move forward or backward.
+        If this gets stuck for any reason it's very clear that something has gone wrong,
+        rather than a silent failure of the soft limit marks.
+    *)
     FWD_START: LREAL := -99999999;
     BWD_START: LREAL :=  99999999;
 END_VAR]]></Declaration>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -45,6 +45,11 @@ fbSetPos.Options.ClearPositionLag := TRUE;
 rtExec(CLK:=bExecute);
 ftExec(CLK:=bExecute);
 
+bError R= NOT bExecute;
+IF NOT bError THEN
+    nErrorID := 0;
+END_IF
+
 CASE stMotionStage.nHomingMode OF
     ENUM_EpicsHomeCmd.LOW_LIMIT:
         bFirstDirection := FALSE;

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -21,6 +21,7 @@ VAR
     bFirstDirection: BOOL;
     bAtHome: BOOL;
     bMove: BOOL;
+    nErrCount: INT;
 END_VAR
 VAR CONSTANT
     IDLE: INT := 0;
@@ -77,12 +78,20 @@ IF bMove THEN
         // Wait for a rising edge
         IDLE:
             bBusy := FALSE;
+            nErrCount := 0;
+            fbSetPos(
+                Axis:=stMotionStage.Axis,
+                Execute:=FALSE);
+            fbJog(
+                Axis:=stMotionStage.Axis,
+                JogForward:=FALSE,
+                JogBackwards:=FALSE);
             IF rtExec.Q THEN
                 nHomeStateMachine := NEXT_MOVE;
                 nMoves := 0;
                 bDone := FALSE;
                 bBusy := TRUE;
-			END_IF
+            END_IF
         // Figure out whether to move forward, move backward, or give up
         NEXT_MOVE:
             fbSetPos(
@@ -98,20 +107,20 @@ IF bMove THEN
                         nHomeStateMachine := CHECK_FWD;
                     ELSE
                         nHomeStateMachine := CHECK_BWD;
-					END_IF
+                    END_IF
                 1:
                     IF NOT bFirstDirection THEN
                         nHomeStateMachine := CHECK_FWD;
                     ELSE
                         nHomeStateMachine := CHECK_BWD;
-					END_IF
+                    END_IF
                 ELSE
                     nHomeStateMachine := ERROR;
 			END_CASE
             nMoves := nMoves + 1;
             IF bAtHome THEN
                 nHomeStateMachine := FINAL_MOVE;
-			END_IF
+            END_IF
         // Move forward until we find the home signal or reach end of travel
         CHECK_FWD:
             fbSetPos(
@@ -126,7 +135,16 @@ IF bMove THEN
                 Velocity:=stMotionStage.stAxisParameters.fRefVeloSearch);
             IF NOT fbJog.JogForward THEN
                 nHomeStateMachine := NEXT_MOVE;
-			END_IF
+            ELSIF fbJog.Error THEN
+                fbJog(
+                    Axis:=stMotionStage.Axis,
+                    JogForward:=FALSE,
+                    JogBackwards:=FALSE);
+                nErrCount := nErrCount + 1;
+                IF nErrCount >= 3 THEN
+                    nHomeStateMachine := ERROR;
+                END_IF
+            END_IF
         // Move backward until we find the home signal or reach end of travel
         CHECK_BWD:
             fbSetPos(
@@ -141,7 +159,16 @@ IF bMove THEN
                 Velocity:=stMotionStage.stAxisParameters.fRefVeloSearch);
             IF NOT fbJog.JogBackwards THEN
                 nHomeStateMachine := NEXT_MOVE;
-			END_IF
+            ELSIF fbJog.Error THEN
+                fbJog(
+                    Axis:=stMotionStage.Axis,
+                    JogForward:=FALSE,
+                    JogBackwards:=FALSE);
+                nErrCount := nErrCount + 1;
+                IF nErrCount >= 3 THEN
+                    nHomeStateMachine := ERROR;
+                END_IF
+            END_IF
         // Set position to get within soft lims, move slowly off signal
         FINAL_MOVE:
             fbSetPos(

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -250,7 +250,7 @@ IF stMotionStage.bReset THEN
 END_IF
 
 // Override homing status with our custom FB
-stMotionStage.stAxisStatus.bHomed := fbMotionHome.bDone;
+stMotionStage.stAxisStatus.bHomed := fbMotionHome.bDone AND NOT fbMotionHome.bError;
 
 fbEncoderValue(stMotionStage:=stMotionStage);
 fbNCParams(

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -261,6 +261,7 @@ stMotionStage.stAxisStatus.bEnabled := stMotionStage.bEnableDone;
 stMotionStage.bHomed := fbMotionHome.bDone AND NOT fbMotionHome.bError;
 stMotionStage.stAxisStatus.bHomed := stMotionStage.bHomed;
 stMotionStage.stAxisStatus.bExecute := bExecute;
+stMotionStage.stAxisStatus.nCommand := 3; // If this is not 3, the IOC stops updating positions during homing
 
 // Reset everything when bReset is flagged
 IF stMotionStage.bReset THEN

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -257,6 +257,11 @@ END_IF
 stMotionStage.stAxisStatus := fbDriveVirtual.stAxisStatus;
 stMotionStage.stAxisStatus.bEnabled := stMotionStage.bEnableDone;
 
+// Override homing status, dmov as appropriate
+stMotionStage.bHomed := fbMotionHome.bDone AND NOT fbMotionHome.bError;
+stMotionStage.stAxisStatus.bHomed := stMotionStage.bHomed;
+stMotionStage.stAxisStatus.bExecute := bExecute;
+
 // Reset everything when bReset is flagged
 IF stMotionStage.bReset THEN
     stMotionStage.bEnable := FALSE;
@@ -268,10 +273,6 @@ IF stMotionStage.bReset THEN
     stMotionStage.sCustomErrorMessage := '';
     bExecute := FALSE;
 END_IF
-
-// Override homing status with our custom FB
-stMotionStage.bHomed := fbMotionHome.bDone AND NOT fbMotionHome.bError;
-stMotionStage.stAxisStatus.bHomed := stMotionStage.bHomed;
 
 fbEncoderValue(stMotionStage:=stMotionStage);
 fbNCParams(

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -147,6 +147,10 @@ IF NOT stMotionStage.bError THEN
     stMotionStage.bError := fbDriveVirtual.bError;
     stMotionStage.nErrorId := fbDriveVirtual.nErrorId;
 END_IF
+IF NOT stMotionStage.bError THEN
+    stMotionStage.bError := fbMotionHome.bError;
+    stMotionStage.nErrorId := fbMotionHome.nErrorId;
+END_IF
 
 // Set the error message if we have one
 IF stMotionStage.bError THEN

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -32,11 +32,34 @@ VAR
     bNewMoveReq: BOOL;
     bPrepareDisable: BOOL;
     bMoveCmd: BOOL;
+    rtMoveCmdShortcut: R_TRIG;
+    rtHomeCmdShortcut: R_TRIG;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Start with an accurate status
 stMotionStage.Axis.ReadStatus();
+
+// Check for the plc shortcut commands
+// Used for testing or to circumvent motor record issues
+rtMoveCmdShortcut(CLK:=stMotionStage.bMoveCmd);
+rtHomeCmdShortcut(CLK:=stMotionStage.bHomeCmd);
+IF rtMoveCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
+    stMotionStage.bMoveCmd := FALSE;
+    stMotionStage.bHomeCmd := FALSE;
+    stMotionStage.bExecute := TRUE;
+    stMotionStage.nCommand := ENUM_EpicsMotorCmd.MOVE_ABSOLUTE;
+ELSIF rtHomeCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
+    stMotionStage.bMoveCmd := FALSE;
+    stMotionStage.bHomeCmd := FALSE;
+    stMotionStage.bExecute := TRUE;
+    stMotionStage.nCommand := ENUM_EpicsMotorCmd.HOME;
+END_IF
+
+// Automatically fill the correct nCmdData for homing
+IF stMotionStage.nCommand = ENUM_EpicsMotorCmd.HOME THEN
+    stMotionStage.nCmdData := stMotionStage.nHomingMode;
+END_IF
 
 // Check if the command wants to cause a move
 bMoveCmd R= stMotionStage.nCmdData = ENUM_EpicsHomeCmd.ABSOLUTE_SET;
@@ -98,10 +121,7 @@ IF bExecute AND NOT stMotionStage.bError THEN
     stMotionStage.sErrorMessage := '';
 END_IF
 
-// Automatically fill the correct nCmdData for homing
-IF stMotionStage.nCommand = ENUM_EpicsMotorCmd.HOME THEN
-    stMotionStage.nCmdData := stMotionStage.nHomingMode;
-END_IF
+
 
 // Update all enable booleans
 fbSetEnables(stMotionStage:=stMotionStage);
@@ -250,7 +270,8 @@ IF stMotionStage.bReset THEN
 END_IF
 
 // Override homing status with our custom FB
-stMotionStage.stAxisStatus.bHomed := fbMotionHome.bDone AND NOT fbMotionHome.bError;
+stMotionStage.bHomed := fbMotionHome.bDone AND NOT fbMotionHome.bError;
+stMotionStage.stAxisStatus.bHomed := stMotionStage.bHomed;
 
 fbEncoderValue(stMotionStage:=stMotionStage);
 fbNCParams(

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -257,7 +257,7 @@ fbNCParams(
     stMotionStage:=stMotionStage,
     bEnable:=TRUE,
     tRefreshDelay:=T#1s);
-    
+
 // Save and restore as long as not an absolute encoder
 fbSaveRestore(
     stMotionStage:=stMotionStage,

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -31,14 +31,21 @@ VAR
     fbNCParams: FB_MotionStageNCParams;
     bNewMoveReq: BOOL;
     bPrepareDisable: BOOL;
+    bMoveCmd: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Start with an accurate status
 stMotionStage.Axis.ReadStatus();
 
+// Check if the command wants to cause a move
+bMoveCmd R= stMotionStage.nCmdData = ENUM_EpicsHomeCmd.ABSOLUTE_SET;
+bMoveCmd R= stMotionStage.nCmdData = ENUM_EpicsHomeCmd.NONE;
+bMoveCmd S= stMotionStage.nCommand <> ENUM_EpicsMotorCmd.HOME;
+
+// Handle main execs
 rtUserExec(CLK := stMotionStage.bExecute);
-bNewMoveReq S= rtUserExec.Q;
+bNewMoveReq S= rtUserExec.Q AND bMoveCmd;
 bNewMoveReq R= NOT stMotionStage.bExecute;
 bPrepareDisable R= bNewMoveReq;
 
@@ -78,7 +85,11 @@ CASE stMotionStage.nEnableMode OF
 END_CASE
 
 // Do not start the move until we have power and the safety system says it is OK
-bExecute := stMotionStage.bExecute AND stMotionStage.bEnableDone AND stMotionStage.bSafetyReady;
+IF bMoveCmd THEN
+    bExecute := stMotionStage.bExecute AND stMotionStage.bEnableDone AND stMotionStage.bSafetyReady;
+ELSE
+    bExecute := stMotionStage.bExecute;
+END_IF
 
 IF bExecute AND NOT stMotionStage.bError THEN
     // Reset local warnings if things are going well

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -162,7 +162,7 @@ END_IF
 // Check the limits and cancel execution if appropriate. Without this block we have infinite error spam
 bFwdHit := stMotionStage.Axis.Status.PositiveDirection AND NOT stMotionStage.bAllForwardEnable;
 bBwdHit := stMotionStage.Axis.Status.NegativeDirection AND NOT stMotionStage.bAllBackwardEnable;
-IF bFwdHit OR bBwdHit THEN
+IF bFwdHit OR bBwdHit  AND NOT fbMotionHome.bBusy THEN
     stMotionStage.bExecute := FALSE;
 END_IF
 

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -179,7 +179,7 @@ END_IF
 // Check the limits and cancel execution if appropriate. Without this block we have infinite error spam
 bFwdHit := stMotionStage.Axis.Status.PositiveDirection AND NOT stMotionStage.bAllForwardEnable;
 bBwdHit := stMotionStage.Axis.Status.NegativeDirection AND NOT stMotionStage.bAllBackwardEnable;
-IF bFwdHit OR bBwdHit  AND NOT fbMotionHome.bBusy THEN
+IF (bFwdHit OR bBwdHit) AND NOT fbMotionHome.bBusy THEN
     stMotionStage.bExecute := FALSE;
 END_IF
 

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -61,7 +61,9 @@ CASE stMotionStage.nEnableMode OF
         stMotionStage.bEnable := TRUE;
     ENUM_StageEnableMode.DURING_MOTION:
         IF bNewMoveReq THEN
-            IF bPosGoal THEN
+            IF stMotionStage.nCommand = ENUM_EpicsMotorCmd.HOME THEN
+                stMotionStage.bEnable := stMotionStage.bSafetyReady;
+            ELSIF bPosGoal THEN
                 IF stMotionStage.bAllForwardEnable THEN
                     stMotionStage.bEnable := stMotionStage.bSafetyReady;
                 ELSIF NOT stMotionStage.bError THEN

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -12,13 +12,18 @@ VAR_IN_OUT
 END_VAR
 VAR
     fbDriveVirtual: FB_DriveVirtual;
+    fbMotionHome: FB_MotionHoming;
+    fbSaveRestore: FB_EncSaveRestore;
     bExecute: BOOL;
+    bExecMove: BOOL;
+    bExecHome: BOOL;
     bFwdHit: BOOL;
     bBwdHit: BOOL;
     ftExec: F_TRIG;
     rtExec: R_TRIG;
     rtUserExec: R_TRIG;
     rtTarget: R_TRIG;
+    rtHomed: R_TRIG;
     fbSetEnables: FB_SetEnables;
     bPosGoal: BOOL;
     bNegGoal: BOOL;
@@ -93,11 +98,15 @@ IF stMotionStage.bError THEN
     bExecute := FALSE;
 END_IF
 
+
+bExecHome := bExecute AND stMotionStage.nCommand = 10;
+bExecMove := bExecute AND NOT bExecHome;
+
 // Handle standard commands using ESS's FB
 fbDriveVirtual(En:=TRUE,
     bEnable:=stMotionStage.bAllEnable,
     bReset:=stMotionStage.bReset,
-    bExecute:=bExecute,
+    bExecute:=bExecMove,
     nCommand:=INT_TO_UINT(stMotionStage.nCommand),
     nCmdData:=INT_TO_UINT(stMotionStage.nCmdData),
     fVelocity:=stMotionStage.fVelocity,
@@ -111,6 +120,11 @@ fbDriveVirtual(En:=TRUE,
     bPowerSelf:=stMotionStage.bPowerSelf,
     nMotionAxisID=>stMotionStage.nMotionAxisID,
     Axis:=stMotionStage.Axis);
+
+// Some custom home handling
+fbMotionHome(
+    stMotionStage:=stMotionStage,
+    bExecute:=bExecHome);
 
 // Update status again after the move starts or stops
 stMotionStage.Axis.ReadStatus();
@@ -152,10 +166,11 @@ IF bFwdHit OR bBwdHit THEN
     stMotionStage.bExecute := FALSE;
 END_IF
 
-// Check done moving via fbDriveVirtual and from Target Position Monitoring. Must satisfy both conditions.
+// Check done moving via user stop, fbDriveVirtual and Target Position Monitoring, or from homing.
 ftExec(CLK:=stMotionStage.bExecute);
-rtTarget(CLK:=stMotionStage.Axis.Status.InTargetPosition AND fbDriveVirtual.bDone);
-IF rtTarget.Q OR ftExec.Q THEN
+rtTarget(CLK:=(stMotionStage.Axis.Status.InTargetPosition AND fbDriveVirtual.bDone AND bExecMove));
+rtHomed(CLK:=fbMotionHome.bDone AND bExecHome);
+IF ftExec.Q OR rtTarget.Q OR rtHomed.Q THEN
     IF NOT stMotionStage.bDone THEN
         stMotionStage.bDone := TRUE;
         stMotionStage.bBusy := FALSE;
@@ -217,17 +232,19 @@ IF stMotionStage.bReset THEN
     bExecute := FALSE;
 END_IF
 
-// Ignore homing if we have the setting for it
-// e.g. for pre-calibrated absolute encoders
-IF stMotionStage.nHomingMode = ENUM_EpicsHomeCmd.NONE THEN
-    stMotionStage.stAxisStatus.bHomed := TRUE;
-END_IF
+// Override homing status with our custom FB
+stMotionStage.stAxisStatus.bHomed := fbMotionHome.bDone;
 
 fbEncoderValue(stMotionStage:=stMotionStage);
 fbNCParams(
     stMotionStage:=stMotionStage,
     bEnable:=TRUE,
-    tRefreshDelay:=T#1s);]]></ST>
+    tRefreshDelay:=T#1s);
+    
+// Save and restore as long as not an absolute encoder
+fbSaveRestore(
+    stMotionStage:=stMotionStage,
+    bEnable:=stMotionStage.nHomingMode <> ENUM_EpicsHomeCmd.NONE);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
Implements the following:
- 5 different homing strategies, accessible via the ~`.HOMF` and `.HOMR` fields~ `:PLC:bHomeCmd` PV
- position save/restore for motors with relative encoders

I'm going to do a writeup here and include much of the information that follows in the README.

To activate a homing routing, put 1 to the EPICS ~`.HOMF` or `.HOMR` fields. As far as the TwinCAT program is concerned, these both mean the same thing: "home using our internal configuration".~ `:PLC:bHomeCmd` PV.

To configure a homing routine, set the `fHomePosition` variable to the position to use after homing, and set the `nHomingMode` variable to pick a strategy. These strategies are stored in `ENUM_EpicsHomeCmd` enum. All homing motion strategies move towards their destinations using the "Homing Velocity (towards plc cam)" parameter , then off of the switch using the "Homing velocity (off plc cam)" parameter. The normal options are:
- `LOW_LIMIT`: Move to the low limit (backward) switch. Set home position at the first point we see as we leave the switch.
- `HIGH_LIMIT`: Move to the high limit (forward) switch. Set home position at the first point we see as we leave the switch.
- `HOME_VIA_LOW`: Move towards the low limit (backward) switch, seeking out the position where `bHome` is `TRUE`. If we reach the limit switch without finding `bHome`, reverse direction and try moving towards the high switch. Set home position to the point just above the `bHome` signal.
- `HOME_VIA_HIGH`: Move towards the high limit (forward) switch, seeking out the position where `bHome` is `TRUE`. If we reach the limit switch without finding `bHome`, reverse direction and try moving towards the low switch. Set home position to the point just below the `bHome` signal.

There are two additional special-case options:
- `ABSOLUTE_SET`: When we ask for a home, do not move the motor- simply declare the current position as "home". This is basically a manual homing routine.
- `None`: Do not home! Ever! This is actually the default value, and the only one "implemented" prior to this PR.

If the homing strategy is set to any value other than `None`, the library knows we have a motor that wants save/restore. In these cases, the last position of the motor will be saved on TwinCAT shutdown and restored on the first cycle of the PLC program. This prevents the location of your relatively encoded motor from being lost when the PLC is reconfigured.