### PR TITLE
MNT: bump MAX_STATES to 9

### DIFF
--- a/lcls-twincat-motion/Library/GVLs/MOTION_GVL.TcGVL
+++ b/lcls-twincat-motion/Library/GVLs/MOTION_GVL.TcGVL
@@ -7,8 +7,8 @@ VAR_GLOBAL
     stInvalidState: DUT_PositionState;
 END_VAR
 VAR_GLOBAL CONSTANT
-    // Allocated space for 6 states besides Unknown (16 including Unknown is the max for an EPICS MBBI)
-    MAX_STATES: INT := 6;
+    // Allocated space for 9 states besides Unknown (16 including Unknown is the max for an EPICS MBBI)
+    MAX_STATES: INT := 9;
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>


### PR DESCRIPTION
As we don't have good support for pytmc pragmas that allow for partial inclusion of structures, I believe this is the quickest solution to support AT1K4, with its 8 filter states and 1 out state (and the implied unknown state).

Ref https://github.com/pcdshub/lcls-plc-tmo-motion/pull/39