### PR TITLE
FIX: Always reset command PVs

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -44,16 +44,18 @@ stMotionStage.Axis.ReadStatus();
 // Used for testing or to circumvent motor record issues
 rtMoveCmdShortcut(CLK:=stMotionStage.bMoveCmd);
 rtHomeCmdShortcut(CLK:=stMotionStage.bHomeCmd);
+// Execute on rising edge
 IF rtMoveCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
-    stMotionStage.bMoveCmd := FALSE;
-    stMotionStage.bHomeCmd := FALSE;
     stMotionStage.bExecute := TRUE;
     stMotionStage.nCommand := ENUM_EpicsMotorCmd.MOVE_ABSOLUTE;
 ELSIF rtHomeCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
-    stMotionStage.bMoveCmd := FALSE;
-    stMotionStage.bHomeCmd := FALSE;
     stMotionStage.bExecute := TRUE;
     stMotionStage.nCommand := ENUM_EpicsMotorCmd.HOME;
+END_IF
+// Always reset, even if not rising edge, so command can be issued again
+IF stMotionStage.bMoveCmd OR stMotionStage.bHomeCmd THEN
+    stMotionStage.bMoveCmd := FALSE;
+    stMotionStage.bHomeCmd := FALSE;
 END_IF
 
 // Automatically fill the correct nCmdData for homing


### PR DESCRIPTION
closes #121 

Sometimes, the IOC may send "set the cmd to True" twice via screen use- not sure if this is double-clicking with perfect timing, some sort of write queuing, or something else. This breaks the session because I was only resetting the homing command on rising edge.

This maintains the "start homing on rising edge" behavior, but it allows the command to reset and be re-issued even if this double-put happens.