### PR TITLE
ENH: fix issues with interrupting state moves

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -116,7 +116,7 @@ fbSetEnables(stMotionStage:=stMotionStage);
 
 // Do not start the move until we have power and the safety system says it is OK
 IF bMoveCmd THEN
-    bExecute := stMotionStage.bExecute AND stMotionStage.bAllEnable AND stMotionStage.bEnableDone AND stMotionStage.bSafetyReady;
+    bExecute := stMotionStage.bExecute AND stMotionStage.bAllEnable AND stMotionStage.bSafetyReady AND stMotionStage.bEnableDone AND stMotionStage.bSafetyReady;
 ELSE
     bExecute := stMotionStage.bExecute;
 END_IF

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -114,9 +114,12 @@ END_CASE
 // Update all enable booleans
 fbSetEnables(stMotionStage:=stMotionStage);
 
-// Do not start the move until we have power and the safety system says it is OK
-IF bMoveCmd THEN
-    bExecute := stMotionStage.bExecute AND stMotionStage.bAllEnable AND stMotionStage.bSafetyReady AND stMotionStage.bEnableDone AND stMotionStage.bSafetyReady;
+IF stMotionStage.stAxisStatus.bBusy AND NOT bExecute THEN
+    // Wait for the previous move to end
+    bExecute := FALSE;
+ELSIF bMoveCmd THEN
+    // Do not start the move until we have power and the safety system says it is OK
+    bExecute := stMotionStage.bExecute AND stMotionStage.bAllEnable AND stMotionStage.bEnableDone AND stMotionStage.bSafetyReady;
 ELSE
     bExecute := stMotionStage.bExecute;
 END_IF

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -111,9 +111,12 @@ CASE stMotionStage.nEnableMode OF
         END_IF
 END_CASE
 
+// Update all enable booleans
+fbSetEnables(stMotionStage:=stMotionStage);
+
 // Do not start the move until we have power and the safety system says it is OK
 IF bMoveCmd THEN
-    bExecute := stMotionStage.bExecute AND stMotionStage.bEnableDone AND stMotionStage.bSafetyReady;
+    bExecute := stMotionStage.bExecute AND stMotionStage.bAllEnable AND stMotionStage.bEnableDone AND stMotionStage.bSafetyReady;
 ELSE
     bExecute := stMotionStage.bExecute;
 END_IF
@@ -122,11 +125,6 @@ IF bExecute AND NOT stMotionStage.bError THEN
     // Reset local warnings if things are going well
     stMotionStage.sErrorMessage := '';
 END_IF
-
-
-
-// Update all enable booleans
-fbSetEnables(stMotionStage:=stMotionStage);
 
 // No moves allowed in error states
 IF stMotionStage.bError THEN

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS_Base.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS_Base.TcPOU
@@ -85,6 +85,7 @@ IF bInit OR nGoalState = 0 OR stMotionStage.bError THEN
     bInTransition := FALSE;
     stInvalidState.nRequestAssertionID := nUnknownAssertionID;
     stUnknownState.nRequestAssertionID := nUnknownAssertionID;
+    rtTransReq(CLK:=FALSE);
 END_IF
 
 // Request transition on rising edge

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS_Base.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS_Base.TcPOU
@@ -86,6 +86,8 @@ IF bInit OR nGoalState = 0 OR stMotionStage.bError THEN
     stInvalidState.nRequestAssertionID := nUnknownAssertionID;
     stUnknownState.nRequestAssertionID := nUnknownAssertionID;
     rtTransReq(CLK:=FALSE);
+    bTransitionAuthorized := FALSE;
+    bArbiterTimeout := FALSE;
 END_IF
 
 // Request transition on rising edge

--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateBase.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateBase.TcPOU
@@ -157,15 +157,16 @@ END_IF
 // Special move handling for error/enable state
 IF bError OR NOT bEnable THEN
     bInnerExec := FALSE;
-// Reset inner block this cycle if we were already moving but want a new move
-ELSIF bInnerExec AND bNewGoal THEN
-    bInnerExec := FALSE;
-    bInnerReset := TRUE;
-// If we hit this branch, we're starting a new move
 ELSIF bNewGoal THEN
-    bInnerExec := TRUE;
-    bInnerReset := FALSE;
-    bNewGoal := FALSE;
+    IF fbStateMove.bBusy THEN
+        // Stop previous move if we were already moving but want a new move
+        bInnerExec := FALSE;
+    ELSE
+        // If we hit this branch, we're ready to start a new move
+        bInnerExec := TRUE;
+        bInnerReset := FALSE;
+        bNewGoal := FALSE;
+    END_IF
 END_IF
 
 // Pick the correct goal structure or Unknown

--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateBase_WithPMPS_Test.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateBase_WithPMPS_Test.TcPOU
@@ -38,7 +38,7 @@ PMPSHandler();]]></ST>
         <ST><![CDATA[fbStatePMPS(
     stMotionStage:=stMotionStage,
     arrStates:=arrStates,
-    bRequestTransition:=bBusy,
+    bRequestTransition:=setState <> 0,
     setState:=setState,
     getState:=getState,
     stTransitionBeam:=stTransitionBeam,


### PR DESCRIPTION
There are at least ~2~ ~3~ 4 bugs right now related to #123 

This fixes all the known bugs (closes #123)

- If the axis is already moving when we ask for a move, wait for the previous move to truly end before starting again. Otherwise, the new move command just hangs forever.
- Do not start a move if we plan to disable the axis in the next cycle. Also stop a move in this scenario. Otherwise, this throws a confusing error instead of just... stopping.
- Reset missing variables in the bReset of PMPS state moves. Otherwise, these variables can get stuck in strange states after errors or when interrupting moves.
- Do not fully reset the state FB when we interrupt it with a new move, this actually breaks everything and causes confusing errors.

Also:
- Fix testing bug in the pmps tester fb