### PR TITLE
MNT: fix issue where auto-enable block could disable

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -90,7 +90,7 @@ CASE stMotionStage.nEnableMode OF
                 stMotionStage.bEnable := stMotionStage.bSafetyReady;
             ELSIF bPosGoal THEN
                 IF stMotionStage.bAllForwardEnable THEN
-                    stMotionStage.bEnable := stMotionStage.bSafetyReady;
+                    stMotionStage.bEnable S= stMotionStage.bSafetyReady;
                 ELSIF NOT stMotionStage.bError THEN
                     // Not an error, just a warning
                     stMotionStage.sErrorMessage := 'Cannot move past positive limit.';
@@ -98,7 +98,7 @@ CASE stMotionStage.nEnableMode OF
                 END_IF
             ELSIF bNegGoal THEN
                 IF stMotionStage.bAllBackwardEnable THEN
-                    stMotionStage.bEnable := stMotionStage.bSafetyReady;
+                    stMotionStage.bEnable S= stMotionStage.bSafetyReady;
                 ELSIF NOT stMotionStage.bError THEN
                     // Not an error, just a warning
                     stMotionStage.sErrorMessage := 'Cannot move past negative limit.';


### PR DESCRIPTION
Follow-up to #125 
We check `bSafetyReady` on the start of a new move request to see if we should enable the motor yet.
However, if we were in the middle of an active move, then get a new move request, this block of code can actually disable the enabled motor, causing an error.
This PR changes the "moving" blocks here to only be able to enable the motor, not disable it.
This is the last piece needed for #123 

The homing enable is untouched because I don't want to test it during a PAMM.

There is other code later in this function block intended to handle the motor disabling.