### PR TITLE
BUG: Save/restore race condition

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_EncSaveRestore.TcPOU
@@ -65,14 +65,14 @@ END_VAR
             bWaitRetry := TRUE;
         END_IF
     END_IF
-    
+
     tonRetry(
         IN := bWaitRetry,
         PT := tRetryDelay);
-        
+
     bLoad S= tonRetry.Q;
     bWaitRetry R= tonRetry.Q;
-    
+
     // Check DUT_MotionStage for an encoder error (range 0x44nn)
     bEncError := stMotionStage.bError AND stMotionStage.nErrorId >= 16#4400 AND stMotionStage.nErrorId <= 16#44FF;
 


### PR DESCRIPTION
Under testing conditions (small project, boot into config mode, no auto-start boot project), the save/restore works great.

Under prod conditions (large project, boot into run mode, auto-start boot project), it's possible for it to fail.
My hypothesis is that the plc code starts running before all of the ADS/NC infrastructure is ready, and if the load is high then this can result in a race condition where the `MC_SetPosition` fails.

This PR simply adds 10 retries at 1 second intervals. This absolutely overkill, in testing this always worked on the second time if it failed on the first, but it seemed appropriate.