### PR TITLE
ENH: add a motor power kill switch

### DIFF
--- a/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
@@ -115,6 +115,13 @@ STRUCT
         field: DESC Count from encoder hardware
     '}
     nEncoderCount: UDINT;
+    // PV entry point to kill motor power, do not write to this inside the PLC
+    {attribute 'pytmc' := '
+        pv: PLC:bKill
+        io: io
+        field: DESC Kill motor power
+    '}
+    bKill: BOOL;
 
     (* Settings *)
     // Name to use for log messages, fast faults, etc.

--- a/lcls-twincat-motion/Library/POUs/Motion/Utils/FB_SetEnables.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/Utils/FB_SetEnables.TcPOU
@@ -7,11 +7,14 @@ VAR_IN_OUT
     stMotionStage: DUT_MotionStage;
 END_VAR]]></Declaration>
     <Implementation>
-      <ST><![CDATA[stMotionStage.bAllForwardEnable := stMotionStage.bLimitForwardEnable AND (stMotionStage.bGantryForwardEnable OR NOT stMotionStage.bGantryAxis);
+      <ST><![CDATA[
+stMotionStage.bAllForwardEnable := stMotionStage.bLimitForwardEnable AND (stMotionStage.bGantryForwardEnable OR NOT stMotionStage.bGantryAxis);
 stMotionStage.bAllBackwardEnable := stMotionStage.bLimitBackwardEnable AND (stMotionStage.bGantryBackwardEnable OR NOT stMotionStage.bGantryAxis);
 
 stMotionStage.bAllEnable := stMotionStage.bEnable AND stMotionStage.bHardwareEnable;
-stMotionStage.bAllEnable R= NOT stMotionStage.bUserEnable;]]></ST>
+stMotionStage.bAllEnable R= NOT stMotionStage.bUserEnable;
+stMotionStage.bAllEnable R= stMotionStage.bKill;
+]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
- Add a pragma-d `bKill` element to `DUT_MotionStage`
- If `bKill` is `TRUE`, disable the motor

This allows someone to kill the motor power entirely in the event that something bad has happened, provided that the IOC is online.