### PR TITLE
FIX: set stIn/stOut names for in/out state positioners

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStateInOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStateInOut.TcPOU
@@ -35,6 +35,8 @@ END_VAR]]></Declaration>
     bInOutInit := TRUE;
     arrStates[1] := stOut;
     arrStates[2] := stIn;
+    stOut.sName := 'OUT';
+    stIn.sName := 'IN';
 END_IF
 setState := enumSet;
 Exec();

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStateInOut_WithPMPS.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStateInOut_WithPMPS.TcPOU
@@ -38,6 +38,8 @@ END_VAR
     bInOutInit := TRUE;
     arrStates[1] := stOut;
     arrStates[2] := stIn;
+    stOut.sName := 'OUT';
+    stIn.sName := 'IN';
 END_IF
 setState := enumSet;
 Exec();

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStateInOut_WithPMPS_Test.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStateInOut_WithPMPS_Test.TcPOU
@@ -38,6 +38,8 @@ END_VAR
     bInOutInit := TRUE;
     arrStates[1] := stOut;
     arrStates[2] := stIn;
+    stOut.sName := 'OUT';
+    stIn.sName := 'IN';
 END_IF
 setState := enumSet;
 Exec();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Sets in and out state names for the "example" state positioners (which are used in production).

## Motivation and Context
Closes #144 

## How Has This Been Tested?
Not yet tested.

## Where Has This Been Documented?
Issue and PR text.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
