### PR TITLE
ENH: add option for auto clearing beam parameter mismatch fast faults

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
@@ -14,7 +14,7 @@ VAR_IN_OUT
 END_VAR
 VAR_INPUT
     stHighBeamThreshold: ST_BeamParams := PMPS_GVL.cstFullBeam;
-    bAutoReset: BOOL := False;
+    bBPOKAutoReset: BOOL := False;
 END_VAR
 VAR
     bptm: BeamParameterTransitionManager;
@@ -93,10 +93,7 @@ bAtSafeState := F_SafeBPCompare(stHighBeamThreshold, stBeamNeeded);
 ffBeamParamsOk.i_xOK := bFFOxOk;
 ffBeamParamsOk.i_xReset S= bFFOxOk AND bAtSafeState;
 ffBeamParamsOk.i_xReset R= NOT ffBeamParamsOk.i_xOK;
-
-IF bAutoReset THEN
-    ffBeamParamsOk.i_xAutoReset := True;
-END_IF
+ffBeamParamsOk.i_xAutoReset := bBPOKAutoReset;
 
 ffBeamParamsOk(
     i_DevName:=stMotionStage.sName,

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
@@ -14,6 +14,7 @@ VAR_IN_OUT
 END_VAR
 VAR_INPUT
     stHighBeamThreshold: ST_BeamParams := PMPS_GVL.cstFullBeam;
+    bAutoReset: BOOL := False;
 END_VAR
 VAR
     bptm: BeamParameterTransitionManager;
@@ -92,6 +93,11 @@ bAtSafeState := F_SafeBPCompare(stHighBeamThreshold, stBeamNeeded);
 ffBeamParamsOk.i_xOK := bFFOxOk;
 ffBeamParamsOk.i_xReset S= bFFOxOk AND bAtSafeState;
 ffBeamParamsOk.i_xReset R= NOT ffBeamParamsOk.i_xOK;
+
+IF bAutoReset THEN
+    ffBeamParamsOk.i_xAutoReset := True;
+END_IF
+
 ffBeamParamsOk(
     i_DevName:=stMotionStage.sName,
     i_Desc:='Beam parameter mismatch',

--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateBase_WithPMPS.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateBase_WithPMPS.TcPOU
@@ -23,6 +23,7 @@ VAR_INPUT
     tArbiterTimeout: TIME := T#1s;
     bMoveOnArbiterTimeout: BOOL := TRUE;
     fStateBoundaryDeadband: LREAL := 0;
+    bBPOKAutoReset: BOOL := False;
 END_VAR
 VAR
     {attribute 'pytmc' := 'pv: PMPS'}
@@ -65,7 +66,8 @@ PMPSHandler();]]></ST>
     bArbiterEnabled:=bArbiterEnabled,
     tArbiterTimeout:=tArbiterTimeout,
     bMoveOnArbiterTimeout:=bMoveOnArbiterTimeout,
-    fStateBoundaryDeadband:=fStateBoundaryDeadband);
+    fStateBoundaryDeadband:=fStateBoundaryDeadband,
+    bBPOKAutoReset:=bBPOKAutoReset);
 
 fbEncErrFFO(
     stMotionStage:=stMotionStage,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`FB_PositionStatePMPS(FB)` function block currently doesn't allow for  `i_xAutoReset` to be set to `True` causing all position state PMPS motion systems to require a manual reset. Here we add an input variable `bAutoReset` that defaults to `False`. PMPS states can now be implemented as FFO auto resetting.

## Motivation and Context
Users have to currently auto clear faults on MR1L0 and MR2L0 to permit beam.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Not tested yet.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
