### PR TITLE
DEV: Adding the option to auto reset FFO for pneumatic actuators.

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionPneumaticActuator.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionPneumaticActuator.TcPOU
@@ -13,7 +13,7 @@ VAR_INPUT
     ibCntrlHold:BOOL; (* Control Signal must retain its value, must be TRUE in the case of single acting*)
     ibOverrideInterlock:BOOL; (*if true interlocks are ignored*)
     // Reset fault
-	{attribute 'pytmc' := '
+    {attribute 'pytmc' := '
     pv: FFO_Reset
     '}
     i_xReset: BOOL;
@@ -157,7 +157,7 @@ stPneumaticActuator.bError R= stPneumaticActuator.bReset;
 
 (*FAST FAULT*)
 fbFF(i_xOK := xMPS_OK,
-	i_xReset := i_xReset,
+    i_xReset := i_xReset,
     i_xAutoReset := i_xAutoReset,
     io_fbFFHWO := io_fbFFHWO);
 

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionPneumaticActuator.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionPneumaticActuator.TcPOU
@@ -13,6 +13,10 @@ VAR_INPUT
     ibCntrlHold:BOOL; (* Control Signal must retain its value, must be TRUE in the case of single acting*)
     ibOverrideInterlock:BOOL; (*if true interlocks are ignored*)
     // Reset fault
+	{attribute 'pytmc' := '
+    pv: FFO_Reset
+    '}
+    i_xReset: BOOL;
     {attribute 'pytmc' := '
     pv: FFO_AutoReset
     '}
@@ -153,6 +157,7 @@ stPneumaticActuator.bError R= stPneumaticActuator.bReset;
 
 (*FAST FAULT*)
 fbFF(i_xOK := xMPS_OK,
+	i_xReset := i_xReset,
     i_xAutoReset := i_xAutoReset,
     io_fbFFHWO := io_fbFFHWO);
 

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionPneumaticActuator.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionPneumaticActuator.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.3">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <POU Name="FB_MotionPneumaticActuator" Id="{3965ca68-046c-4858-93f1-aaf5b6059f9e}" SpecialFunc="None">
     <Declaration><![CDATA[(*This function blcok implements a pnuematic actuator. That can be signle or double acting by setting the ibSingleCntrl accordingly*)
 (* with double acting ibCntrlHold signal should be false, while with single acting the signal should be true*)
@@ -14,9 +14,9 @@ VAR_INPUT
     ibOverrideInterlock:BOOL; (*if true interlocks are ignored*)
     // Reset fault
     {attribute 'pytmc' := '
-    pv: FF_Reset
+    pv: FFO_AutoReset
     '}
-    i_xReset: BOOL;
+    i_xAutoReset: BOOL;
 END_VAR
 VAR_OUTPUT
     {attribute 'pytmc' := '
@@ -153,7 +153,7 @@ stPneumaticActuator.bError R= stPneumaticActuator.bReset;
 
 (*FAST FAULT*)
 fbFF(i_xOK := xMPS_OK,
-    i_xReset := i_xReset,
+    i_xAutoReset := i_xAutoReset,
     io_fbFFHWO := io_fbFFHWO);
 
 (*Soft IO Mapping to Epics pvs*)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adding the option to auto reset FFO for pneumatic actuators.

## Motivation and Context
ST1K4 in TMO is a photon stopper that has a pneumatic actuator. The FFO is latching, so when the actuator is retracted, operators still need to go to the PMPS screen to Ack the fault. This way, when instantiating the function block and setting the i_xAutoreset bit to True, they don't need to Ack the fault from the PMPS diagnostics screen.

## How Has This Been Tested?


## Where Has This Been Documented?


## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
