### PR TITLE
ENH: increase MAX_STATES to the EPICS max for TMO spec

### DIFF
--- a/lcls-twincat-motion/Library/GVLs/MOTION_GVL.TcGVL
+++ b/lcls-twincat-motion/Library/GVLs/MOTION_GVL.TcGVL
@@ -7,8 +7,9 @@ VAR_GLOBAL
     stInvalidState: DUT_PositionState;
 END_VAR
 VAR_GLOBAL CONSTANT
-    // Allocated space for 9 states besides Unknown (16 including Unknown is the max for an EPICS MBBI)
-    MAX_STATES: INT := 9;
+    // 16 including "Unknown" is the max for an EPICS MBBI
+    // This is the max number of user-defined states (OUT, TARGET1, YAG...)
+    MAX_STATES: INT := 15;
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Allow all 15 states to be used (and create PVs for their configurations)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
TMO needs all of the states to handle the spectrometer
Previously, this was limited to reduce clutter on the typhos GUI (among other things). This is no longer an issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Right click project -> check all objects to ensure no syntax errors

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Comments + release notes

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
