### PR TITLE
FIX: Fixes for soft-line deployment

### DIFF
--- a/lcls-twincat-motion/Library/GVLs/MOTION_GVL.TcGVL
+++ b/lcls-twincat-motion/Library/GVLs/MOTION_GVL.TcGVL
@@ -10,10 +10,6 @@ VAR_GLOBAL
     '}
     fbStandardPMPSDB: FB_Standard_PMPSDB;
 END_VAR
-VAR_GLOBAL CONSTANT
-    // Backcompat with the move of this constant to lcls-twincat-general
-    // Probably remove this later
-    MAX_STATES: INT := GeneralConstants.MAX_STATES;
-END_VAR]]></Declaration>
+]]></Declaration>
   </GVL>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -18,7 +18,7 @@
     <Company>SLAC</Company>
     <Released>false</Released>
     <Title>lcls-twincat-motion</Title>
-    <ProjectVersion>2.0.1</ProjectVersion>
+    <ProjectVersion>0.0.0</ProjectVersion>
     <!--    <OutputType>Exe</OutputType>
     <RootNamespace>MyApplication</RootNamespace>
     <AssemblyName>MyApplication</AssemblyName>-->

--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -17,7 +17,7 @@
     <CombineIds>false</CombineIds>
     <Company>SLAC</Company>
     <Released>false</Released>
-    <Title>lcls-twincat-motion</Title>
+    <Title>lcls-twincat-motion-zlentz</Title>
     <ProjectVersion>0.0.0</ProjectVersion>
     <!--    <OutputType>Exe</OutputType>
     <RootNamespace>MyApplication</RootNamespace>

--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -18,7 +18,7 @@
     <Company>SLAC</Company>
     <Released>false</Released>
     <Title>lcls-twincat-motion</Title>
-    <ProjectVersion>0.0.0</ProjectVersion>
+    <ProjectVersion>2.0.1</ProjectVersion>
     <!--    <OutputType>Exe</OutputType>
     <RootNamespace>MyApplication</RootNamespace>
     <AssemblyName>MyApplication</AssemblyName>-->

--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -17,7 +17,7 @@
     <CombineIds>false</CombineIds>
     <Company>SLAC</Company>
     <Released>false</Released>
-    <Title>lcls-twincat-motion-zlentz</Title>
+    <Title>lcls-twincat-motion</Title>
     <ProjectVersion>0.0.0</ProjectVersion>
     <!--    <OutputType>Exe</OutputType>
     <RootNamespace>MyApplication</RootNamespace>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
@@ -26,6 +26,7 @@ VAR
     nTransitionAssertionID: UDINT;
     fbReadPmpsDb: FB_JsonDocToSafeBP;
     ftDbBusy: F_TRIG;
+    rtReadDBExec: R_TRIG;
     ftRead: F_TRIG;
     bptm: BeamParameterTransitionManager;
     ffBeamParamsOk: FB_FastFault;
@@ -174,10 +175,13 @@ IF ftDbBusy.Q THEN
     bReadPmpsDb S= NOT MOTION_GVL.fbPmpsFileReader.bError;
 END_IF
 
-arrPMPS[0].sPmpsState := sTransitionKey;
-FOR nBPIndex := 1 TO GeneralConstants.MAX_STATES BY 1 DO
-    arrPMPS[nBPIndex] := arrStates[nBPIndex].stPMPS;
-END_FOR
+rtReadDBExec(CLK:=bReadPmpsDb);
+IF rtReadDBExec.Q THEN
+    arrPMPS[0].sPmpsState := sTransitionKey;
+    FOR nBPIndex := 1 TO GeneralConstants.MAX_STATES BY 1 DO
+        arrPMPS[nBPIndex] := arrStates[nBPIndex].stPMPS;
+    END_FOR
+END_IF
 
 fbReadPmpsDb(
     bExecute:=bReadPmpsDb,

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
@@ -164,7 +164,7 @@ ffMaint(
 
 // Trip the beam for unknown state
 ffUnknown(
-    i_xOK := getState <= 0 AND NOT bInTransition,
+    i_xOK := getState > 0 OR bInTransition,
     i_xAutoReset := TRUE,
     i_DevName := stMotionStage.sName,
     i_Desc := 'Unknown position between moves',

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
@@ -204,6 +204,7 @@ ftRead(CLK:=fbReadPmpsDb.bBusy);
 
 stTransitionState.sName := 'Transition';
 IF ftRead.Q AND NOT fbReadPmpsDb.bError THEN
+    stTransitionDb := arrPMPS[0];
     stTransitionBeam := arrPMPS[0].stBeamParams;
     nTransitionAssertionID := arrPMPS[0].nRequestAssertionID;
     stTransitionState.stPMPS := arrPMPS[0];

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS.TcPOU
@@ -24,6 +24,7 @@ VAR
     arrPMPS: ARRAY[0..GeneralConstants.MAX_STATES] OF ST_DbStateParams;
     nBPIndex: INT;
     nTransitionAssertionID: UDINT;
+    nLastReqAssertionID: UDINT;
     fbReadPmpsDb: FB_JsonDocToSafeBP;
     ftDbBusy: F_TRIG;
     rtReadDBExec: R_TRIG;
@@ -75,6 +76,12 @@ IF rtDoLateFinish.Q THEN
 END_IF
 
 IF stStateReq.stPMPS.nRequestAssertionID <> nTransitionAssertionID THEN
+    (*
+        Edge case: the request is swapped out without a move
+        Same as above: we need a rising edge of bTransDone, so cause a falling edge and the let the rising edge happen next cycle
+        This will already be false when we request a positional move
+    *)
+    bTransDone R= stStateReq.stPMPS.nRequestAssertionID <> nLastReqAssertionID;
     // Just normal bptm call
     bptm(fbArbiter:=fbArbiter,
          i_sDeviceName:=stMotionStage.sName,
@@ -86,6 +93,7 @@ IF stStateReq.stPMPS.nRequestAssertionID <> nTransitionAssertionID THEN
          stCurrentBeamParameters:=PMPS_GVL.stCurrentBeamParameters,
          q_xTransitionAuthorized=>bInternalAuth,
          bDone=>bBPTMDone);
+    nLastReqAssertionID := stStateReq.stPMPS.nRequestAssertionID;
 END_IF]]></ST>
       </Implementation>
     </Action>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS_Base.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS_Base.TcPOU
@@ -32,6 +32,10 @@ VAR_OUTPUT
     bArbiterTimeout: BOOL;
 END_VAR
 VAR
+    {attribute 'pytmc' := '
+        pv: TRANS:BP
+        io: i
+    '}
     stTransitionBeam: ST_BeamParams := PMPS_GVL.cst0RateBeam;
     stTransitionState: DUT_PositionState;
     bInit: BOOL := TRUE;

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS_Base.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS_Base.TcPOU
@@ -33,9 +33,10 @@ VAR_OUTPUT
 END_VAR
 VAR
     {attribute 'pytmc' := '
-        pv: TRANS:BP
+        pv: TRANS
         io: i
     '}
+    stTransitionDb: ST_DbStateParams;
     stTransitionBeam: ST_BeamParams := PMPS_GVL.cst0RateBeam;
     stTransitionState: DUT_PositionState;
     bInit: BOOL := TRUE;

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
@@ -46,7 +46,14 @@ rtEnable(CLK:=bEnable);
 rtRefresh(CLK:=bRefresh);
 bRefresh := FALSE;
 
-bExecute S= rtEnable.Q OR rtRefresh.Q;
+IF rtEnable.Q OR rtRefresh.Q THEN
+    // Make sure file reader gets a rising edge
+    MOTION_GVL.fbPmpsFileReader(
+        io_fbFFHWO:=io_fbFFHWO,
+        bExecute:=FALSE,
+    );
+    bExecute := TRUE;
+END_IF
 
 MOTION_GVL.fbPmpsFileReader(
     io_fbFFHWO:=io_fbFFHWO,
@@ -60,7 +67,7 @@ ftBusy(CLK:=MOTION_GVL.fbPmpsFileReader.bBusy);
 
 // Lifted from Arbiter PLCs: keep track of the time
 fbTime(sNetID:='');
-fbGetTimeZone(sNetID:='', bExecute:=True, tTimeout:=T#10S);
+fbGetTimeZone(sNetID:='', bExecute:=TRUE, tTimeout:=T#10S);
 fbTime_to_UTC(in:= fbTime.systemTime , tzInfo:=fbGetTimeZone.tzInfo);
 
 // Update the refresh time on successful read

--- a/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
+++ b/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <GVL Name="Global_Version" Id="{e584f020-617f-4164-a737-6e483df3aa38}">
     <Declaration><![CDATA[{attribute 'TcGenerated'}
+{attribute 'no-analysis'}
+{attribute 'linkalways'}
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
-    {attribute 'const_non_replaced'}
-    {attribute 'linkalways'}
-    stLibVersion_lcls_twincat_motion : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, sVersion := '0.0.0');
+	{attribute 'const_non_replaced'}
+	stLibVersion_lcls_twincat_motion : ST_LibVersion := (iMajor := 2, iMinor := 0, iBuild := 1, iRevision := 0, sVersion := '2.0.1');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
+++ b/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_lcls_twincat_motion : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, sVersion := '0.0.0');
+	stLibVersion_lcls_twincat_motion_zlentz : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
+++ b/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
@@ -6,8 +6,8 @@
 {attribute 'linkalways'}
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
-	{attribute 'const_non_replaced'}
-	stLibVersion_lcls_twincat_motion : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, sVersion := '0.0.0');
+    {attribute 'const_non_replaced'}
+    stLibVersion_lcls_twincat_motion : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
+++ b/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_lcls_twincat_motion_zlentz : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, sVersion := '0.0.0');
+	stLibVersion_lcls_twincat_motion : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
+++ b/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_lcls_twincat_motion : ST_LibVersion := (iMajor := 2, iMinor := 0, iBuild := 1, iRevision := 0, sVersion := '2.0.1');
+	stLibVersion_lcls_twincat_motion : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
1. Remove the deprecated MAX_STATES backcompat.
2. Allow a pmps state mover to swap out and transition to new pre-emptive beam states without a physical move, so long as the new beam state has a unique ID.
3. Fixed the inverted logic for the unknown state FFO.
4. Fix a bug where database reads would be immediately overwritten instead of used.
5. Add pytmc pragmas to let us inspect which specific parameters have been loaded for a state mover.
6. Style updates
7. Automatic build changes in Global_Version.TcGVL

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. The MAX_STATES backcompat was causing compilation problems on projects that did not explicitly refer to `lcls-twincat-general`.
2. Soon, we will need to implement "WFS" mode for certain imagers, which decreases the required beam level needed. This should happen in-place when the WFS goes in without needing to move the imager.
3. The logic was exactly backwards as implemented in the previous PR, oops!
4. This was preventing newer versions of the code from loading from the database
5. This lets the client transfer tool inspect live parameters
6. These either annoyed me or were required to make CI pass
7. This happened automatically and I don't really care to change it back

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively using plc-kfe-motion and plc-kfe-gatt

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This is mostly fixes that will be documented in the release notes.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
