### PR TITLE
BUG: inset -> insert

### DIFF
--- a/lcls-twincat-motion/Library/DUTs/DUT_MotionPneumaticActuator.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DUT_MotionPneumaticActuator.TcDUT
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.3">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <DUT Name="DUT_MotionPneumaticActuator" Id="{ee78164b-027c-4a52-afc0-269c58a42ceb}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 {attribute 'strict'}
@@ -36,7 +36,7 @@ STRUCT
     '}
     q_bRetract    :    BOOL;
     {attribute 'pytmc' := '
-    pv: bInsetDigitalOutput;
+    pv: bInsertDigitalOutput;
     io: i;
     field: ONAM FALSE
     field: ZNAM TRUE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`DUT_MotionPneumaticActuator` has a miss spelled pragma for the PV: bInsertDigitalOutput

typo, fix, insert 'r'

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
devices can't connect with this typo as the PV will be wrong.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/pcdshub/pcdsdevices/pull/1088

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This typo was found while testing `pneumatic.py` 

<!--- Include details of your testing environment, and the tests you ran to -->
The pneumatic device can access the PV with the typo.
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
