### PR TITLE
ENH: EPS structures in DUT_MotionStage for interlock information and logic

### DIFF
--- a/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <DUT Name="DUT_MotionStage" Id="{10b5775d-5646-4d55-ad77-40abc3888de3}">
     <Declaration><![CDATA[TYPE DUT_MotionStage :
     // Defines the EPICS interface to moving a motor in TwinCAT
@@ -114,7 +114,28 @@ STRUCT
         io: i
         field: DESC Count from encoder hardware
     '}
-    nEncoderCount: UDINT;
+    nEncoderCount: UDINT;	
+	// Forward Enable EPS struct
+	{attribute 'pytmc' := '
+        pv: PLC:stEPSForwardEnable
+        io: i
+        field: DESC Forward Enable Interlocks
+    '}
+	stEPSForwardEnable: DUT_EPS;
+	// Backward Enable EPS struct
+	{attribute 'pytmc' := '
+        pv: PLC:stEPSBackwardEnable
+        io: i
+        field: DESC Backward Enable Interlocks
+    '}
+	stEPSBackwardEnable: DUT_EPS;
+	// Power Enable EPS struct
+	{attribute 'pytmc' := '
+        pv: PLC:stEPSPowerEnable
+        io: i
+        field: DESC Power Interlocks
+    '}
+	stEPSPowerEnable: DUT_EPS;
 
     (* Settings *)
     // Name to use for log messages, fast faults, etc.

--- a/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DUT_MotionStage.TcDUT
@@ -114,28 +114,28 @@ STRUCT
         io: i
         field: DESC Count from encoder hardware
     '}
-    nEncoderCount: UDINT;	
-	// Forward Enable EPS struct
-	{attribute 'pytmc' := '
+    nEncoderCount: UDINT;
+    // Forward Enable EPS struct
+    {attribute 'pytmc' := '
         pv: PLC:stEPSForwardEnable
         io: i
         field: DESC Forward Enable Interlocks
     '}
-	stEPSForwardEnable: DUT_EPS;
-	// Backward Enable EPS struct
-	{attribute 'pytmc' := '
+    stEPSForwardEnable: DUT_EPS;
+    // Backward Enable EPS struct
+    {attribute 'pytmc' := '
         pv: PLC:stEPSBackwardEnable
         io: i
         field: DESC Backward Enable Interlocks
     '}
-	stEPSBackwardEnable: DUT_EPS;
-	// Power Enable EPS struct
-	{attribute 'pytmc' := '
+    stEPSBackwardEnable: DUT_EPS;
+    // Power Enable EPS struct
+    {attribute 'pytmc' := '
         pv: PLC:stEPSPowerEnable
         io: i
         field: DESC Power Interlocks
     '}
-	stEPSPowerEnable: DUT_EPS;
+    stEPSPowerEnable: DUT_EPS;
 
     (* Settings *)
     // Name to use for log messages, fast faults, etc.

--- a/lcls-twincat-motion/Library/POUs/Motion/Utils/FB_SetEnables.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/Utils/FB_SetEnables.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="FB_SetEnables" Id="{9028a506-3476-4ab7-9f18-be1b77c07efa}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_SetEnables
 // Update the all enable booleans based on the booleans that make them up
@@ -7,10 +7,10 @@ VAR_IN_OUT
     stMotionStage: DUT_MotionStage;
 END_VAR]]></Declaration>
     <Implementation>
-      <ST><![CDATA[stMotionStage.bAllForwardEnable := stMotionStage.bLimitForwardEnable AND (stMotionStage.bGantryForwardEnable OR NOT stMotionStage.bGantryAxis);
-stMotionStage.bAllBackwardEnable := stMotionStage.bLimitBackwardEnable AND (stMotionStage.bGantryBackwardEnable OR NOT stMotionStage.bGantryAxis);
+      <ST><![CDATA[stMotionStage.bAllForwardEnable := stMotionStage.bLimitForwardEnable AND (stMotionStage.bGantryForwardEnable OR NOT stMotionStage.bGantryAxis) AND stMotionStage.stEPSForwardEnable.bEPS_OK;
+stMotionStage.bAllBackwardEnable := stMotionStage.bLimitBackwardEnable AND (stMotionStage.bGantryBackwardEnable OR NOT stMotionStage.bGantryAxis) AND stMotionStage.stEPSBackwardEnable.bEPS_OK;
 
-stMotionStage.bAllEnable := stMotionStage.bEnable AND stMotionStage.bHardwareEnable;
+stMotionStage.bAllEnable := stMotionStage.bEnable AND stMotionStage.bHardwareEnable AND stMotionStage.stEPSPowerEnable.bEPS_OK;
 stMotionStage.bAllEnable R= NOT stMotionStage.bUserEnable;]]></ST>
     </Implementation>
   </POU>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added EPS structures in DUT_MotionStage for Forward, Backward, and Power EPS interlock information and logic. In FB_SetEnables a new condition of EPS_OK is added for its respective structure instead of using limit switches.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[ Jira Issue
](https://jira.slac.stanford.edu/browse/LCLSPC-373)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A PLC Program was created using the modified motion library to test if bAllForward, bAllBackward Enable values changed when EPS structure was false.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
