### PR TITLE
Add VAR_OUTPUT triggered after a read of MOTION_GVL.fbPmpsFileReader

### DIFF
--- a/lcls-twincat-motion/Library/Library.tmc
+++ b/lcls-twincat-motion/Library/Library.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{81FD7EDC-6BFF-5B9D-D2FB-B0C64C5D8EDA}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{91F9B2CC-4D75-DEAF-7FA5-96CD225AE4BA}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
@@ -204,47 +204,36 @@
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Name>
-      <BitSize>2176</BitSize>
-      <SubItem>
-        <Name>____GETSRESULT__SVALUE</Name>
-        <Type>STRING(255)</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
+      <BitSize>128</BitSize>
       <PropertyItem>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>1197240</GetCodeOffs>
+        <GetCodeOffs>79580408</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>1197304</GetCodeOffs>
+        <GetCodeOffs>79580480</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>1197320</GetCodeOffs>
+        <GetCodeOffs>79580496</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>1197288</GetCodeOffs>
+        <GetCodeOffs>79580456</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>1197312</GetCodeOffs>
+        <GetCodeOffs>79580488</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -308,6 +297,11 @@
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>pEmpty</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
         <Properties>
           <Property>
             <Name>property</Name>
@@ -317,6 +311,9 @@
             <Value>call</Value>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="1">__getbError</Name>
@@ -350,17 +347,6 @@
           <Name>sResult</Name>
           <Type>STRING(255)</Type>
           <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>sValue</Name>
-          <Type>STRING(255)</Type>
-          <BitSize>2048</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>____GETSRESULT__SVALUE</Value>
-            </Property>
-          </Properties>
         </Local>
         <Properties>
           <Property>
@@ -629,7 +615,7 @@
             <Name>property</Name>
           </Property>
           <Property>
-            <Name>conditional_show</Name>
+            <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </Method>
@@ -1185,7 +1171,17 @@
             <Name>property</Name>
           </Property>
           <Property>
-            <Name>conditional_show</Name>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getnCount</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
           </Property>
         </Properties>
       </Method>
@@ -1242,6 +1238,16 @@
           <Name>value</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddEventReferenceEx</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>stEventEntry</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -1336,6 +1342,16 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddStringByValue</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddUDInt</Name>
         <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -1376,6 +1392,22 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddUtf8EncodedString</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddWord</Name>
         <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -1402,42 +1434,54 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddWStringByValue</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Clear</Name>
         <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
       </Method>
     </DataType>
     <DataType>
+      <Name GUID="{0D73E69C-2D9B-4B12-A5F7-3E8AE9DD2149}" TcBaseType="true" CName="ITcEventUniqueIdProvider*">ITcEventUniqueIdProvider</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>GetUniqueId</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>id</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Name>
-      <BitSize>6912</BitSize>
+      <BitSize>3008</BitSize>
       <Implements Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Implements>
       <PropertyItem>
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>1197120</GetCodeOffs>
-        <SetCodeOffs>1197168</SetCodeOffs>
+        <GetCodeOffs>79580288</GetCodeOffs>
+        <SetCodeOffs>79580336</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>1197200</GetCodeOffs>
-        <SetCodeOffs>1197224</SetCodeOffs>
+        <GetCodeOffs>79580368</GetCodeOffs>
+        <SetCodeOffs>79580392</SetCodeOffs>
       </PropertyItem>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
-        <Parameter>
-          <Name>bCutInstancePathByLastInst</Name>
-          <Type RpcDirection="in">BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
       <Method>
         <Name>ExtendName</Name>
         <ReturnType>BOOL</ReturnType>
@@ -1462,7 +1506,7 @@
             <Name>property</Name>
           </Property>
           <Property>
-            <Name>conditional_show</Name>
+            <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </Method>
@@ -1487,12 +1531,14 @@
       </Method>
       <Method>
         <Name>ResetToDefault</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>Clear</Name>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="11">__setnId</Name>
+        <Name RpcEnable="plc" VTableIndex="10">__setnId</Name>
         <Parameter>
           <Name>nId</Name>
           <Type RpcDirection="in">UDINT</Type>
@@ -1515,7 +1561,7 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="10">__setguid</Name>
+        <Name RpcEnable="plc" VTableIndex="9">__setguid</Name>
         <Parameter>
           <Name>guid</Name>
           <Type GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="in">GUID</Type>
@@ -1576,7 +1622,7 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="12">__setsName</Name>
+        <Name RpcEnable="plc" VTableIndex="11">__setsName</Name>
         <Parameter>
           <Name>sName</Name>
           <Type RpcDirection="in">STRING(255)</Type>
@@ -1619,19 +1665,13 @@
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.Tc3_EventLogger">FB_TcEventBase</Name>
-      <BitSize>12160</BitSize>
+      <BitSize>4096</BitSize>
       <Implements Namespace="LCLS_General.Tc3_EventLogger">I_ArgumentsChangeListener</Implements>
       <SubItem>
         <Name>fbSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Type>
-        <BitSize>6912</BitSize>
+        <BitSize>3008</BitSize>
         <BitOffs>512</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.bCutInstancePathByLastInst</Name>
-            <Value>1</Value>
-          </SubItem>
-        </Default>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -1641,8 +1681,8 @@
       <SubItem>
         <Name>__REQUESTEVENTCLASSNAME__FBRESULT</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
-        <BitSize>2176</BitSize>
-        <BitOffs>7680</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>3712</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -1653,7 +1693,7 @@
         <Name>__REQUESTEVENTCLASSNAME__BBUSY</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>9856</BitOffs>
+        <BitOffs>3840</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -1663,8 +1703,8 @@
       <SubItem>
         <Name>__REQUESTEVENTTEXT__FBRESULT</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
-        <BitSize>2176</BitSize>
-        <BitOffs>9920</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>3904</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -1675,7 +1715,7 @@
         <Name>__REQUESTEVENTTEXT__BBUSY</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>12096</BitOffs>
+        <BitOffs>4032</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -1686,31 +1726,37 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>1197416</GetCodeOffs>
+        <GetCodeOffs>79580592</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>1197376</GetCodeOffs>
+        <GetCodeOffs>79580552</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>1197544</GetCodeOffs>
+        <GetCodeOffs>79580728</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>nUniqueId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79580736</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>1197464</GetCodeOffs>
+        <GetCodeOffs>79580648</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>1197552</GetCodeOffs>
+        <GetCodeOffs>79580744</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -1770,7 +1816,7 @@
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
+        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -1813,6 +1859,9 @@
         <Properties>
           <Property>
             <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </Method>
@@ -1861,7 +1910,7 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="12">__getstEventEntry</Name>
+        <Name RpcEnable="plc" VTableIndex="13">__getstEventEntry</Name>
         <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" RpcDirection="out">TcEventEntry</ReturnType>
         <ReturnBitSize>192</ReturnBitSize>
         <Local>
@@ -1947,7 +1996,7 @@
         <Local>
           <Name>fbResult</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
-          <BitSize>2176</BitSize>
+          <BitSize>128</BitSize>
           <Properties>
             <Property>
               <Name>uselocation</Name>
@@ -1968,7 +2017,10 @@
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="10">__getsEventClassName</Name>
+        <Name>OnArgumentsChanged</Name>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="11">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Local>
@@ -2109,7 +2161,7 @@
         <Local>
           <Name>fbResult</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
-          <BitSize>2176</BitSize>
+          <BitSize>128</BitSize>
           <Properties>
             <Property>
               <Name>uselocation</Name>
@@ -2164,7 +2216,36 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="11">__getsEventText</Name>
+        <Name RpcEnable="plc" VTableIndex="10">__getnUniqueId</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nUniqueId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipProvider</Name>
+          <Type GUID="{0D73E69C-2D9B-4B12-A5F7-3E8AE9DD2149}">ITcEventUniqueIdProvider</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="12">__getsEventText</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Local>
@@ -2267,14 +2348,14 @@
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.Tc3_EventLogger">FB_TcMessage</Name>
-      <BitSize>12288</BitSize>
+      <BitSize>4224</BitSize>
       <ExtendsType Namespace="LCLS_General.Tc3_EventLogger">FB_TcEventBase</ExtendsType>
       <Implements Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Implements>
       <PropertyItem>
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>1197600</GetCodeOffs>
+        <GetCodeOffs>79580792</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -2320,6 +2401,11 @@
           <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
           <BitSize>64</BitSize>
         </Local>
+        <Local>
+          <Name>ipSourceInfo</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Local>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -2327,7 +2413,7 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="44">__getnTimeSent</Name>
+        <Name RpcEnable="plc" VTableIndex="46">__getnTimeSent</Name>
         <ReturnType RpcDirection="out">ULINT</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Local>
@@ -2408,6 +2494,9 @@
           <Property>
             <Name>property</Name>
           </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
         </Properties>
       </Method>
       <Method>
@@ -2419,12 +2508,6 @@
           <Comment> set 0 to get the current time automatically</Comment>
           <Type>ULINT</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>TcEncoding</Name>
-              <Value>FILETIME</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -2560,7 +2643,7 @@
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General">FB_LogMessage</Name>
-      <BitSize>130240</BitSize>
+      <BitSize>86016</BitSize>
       <SubItem>
         <Name>sMsg</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -2735,38 +2818,38 @@
           <LBound>0</LBound>
           <Elements>5</Elements>
         </ArrayInfo>
-        <BitSize>61440</BitSize>
+        <BitSize>21120</BitSize>
         <BitOffs>59008</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSource</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Type>
-        <BitSize>6912</BitSize>
-        <BitOffs>120448</BitOffs>
+        <BitSize>3008</BitSize>
+        <BitOffs>80128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ipResultMessage</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Type>
         <BitSize>64</BitSize>
-        <BitOffs>127360</BitOffs>
+        <BitOffs>83136</BitOffs>
       </SubItem>
       <SubItem>
         <Name>hr</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>127424</BitOffs>
+        <BitOffs>83200</BitOffs>
       </SubItem>
       <SubItem>
         <Name>hrLastInternalError</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>127456</BitOffs>
+        <BitOffs>83232</BitOffs>
       </SubItem>
       <SubItem>
         <Name>eTraceLevel</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <BitOffs>127488</BitOffs>
+        <BitOffs>83264</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -2775,7 +2858,7 @@
         <Name>bFirstCall</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>127504</BitOffs>
+        <BitOffs>83280</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -2784,7 +2867,7 @@
         <Name>sPath</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
         <BitSize>2048</BitSize>
-        <BitOffs>127512</BitOffs>
+        <BitOffs>83288</BitOffs>
         <Properties>
           <Property>
             <Name>instance-path</Name>
@@ -2799,62 +2882,62 @@
         <Type>UINT</Type>
         <Comment>////////////////////////////</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>129568</BitOffs>
+        <BitOffs>85344</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nTimesViolated</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>129584</BitOffs>
+        <BitOffs>85360</BitOffs>
       </SubItem>
       <SubItem>
         <Name>LastCallTime</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <BitOffs>129600</BitOffs>
+        <BitOffs>85376</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CurrentCallTime</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <BitOffs>129664</BitOffs>
+        <BitOffs>85440</BitOffs>
       </SubItem>
       <SubItem>
         <Name>DeltaSinceLastCall</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <BitOffs>129728</BitOffs>
+        <BitOffs>85504</BitOffs>
       </SubItem>
       <SubItem>
         <Name>WhenTripsCleared</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <BitOffs>129792</BitOffs>
+        <BitOffs>85568</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftTrippedReleased</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>129856</BitOffs>
+        <BitOffs>85632</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bLocalTrickleTripped</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>129952</BitOffs>
+        <BitOffs>85728</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bLocalTripped</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>129960</BitOffs>
+        <BitOffs>85736</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bTripped</Name>
         <Type>BOOL</Type>
         <Comment> Won't emit messages if true</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>129968</BitOffs>
+        <BitOffs>85744</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -2870,7 +2953,7 @@
         <Name>bResetBreaker</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>129976</BitOffs>
+        <BitOffs>85752</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -2886,13 +2969,13 @@
         <Name>rtResetBreaker</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>129984</BitOffs>
+        <BitOffs>85760</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtTripped</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>130112</BitOffs>
+        <BitOffs>85888</BitOffs>
       </SubItem>
       <Action>
         <Name>CircuitBreaker</Name>
@@ -3264,7 +3347,7 @@
       <SubItem>
         <Name>wMonth</Name>
         <Type>WORD</Type>
-        <Comment> Month: 1..12 (January = 1, February = 2 and so on )</Comment>
+        <Comment> Month: 1..12 (January = 1, February = 2 and so on) </Comment>
         <BitSize>16</BitSize>
         <BitOffs>16</BitOffs>
       </SubItem>
@@ -3292,7 +3375,7 @@
       <SubItem>
         <Name>wMinute</Name>
         <Type>WORD</Type>
-        <Comment> Munute: 0..59 </Comment>
+        <Comment> Minute: 0..59 </Comment>
         <BitSize>16</BitSize>
         <BitOffs>80</BitOffs>
       </SubItem>
@@ -3371,55 +3454,12 @@
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_General.TcUnit">I_TestResultFormatter</Name>
-      <BitSize>64</BitSize>
-      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
-      <Method>
-        <Name>Format</Name>
-        <Parameter>
-          <Name>NumberOfTestSuites</Name>
-          <Comment> The total number of test suites</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>NumberOfTestCases</Name>
-          <Comment> The total number of test cases (for all test suites)</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>NumberOfSuccessfulTestCases</Name>
-          <Comment> The total number of test cases that had all ASSERTS successful</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>NumberOfFailedTestCases</Name>
-          <Comment> The total number of test cases that had at least one ASSERT failed</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Busy</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Standard">TON</Name>
+      <Name Namespace="Tc2_Standard">TOF</Name>
       <BitSize>256</BitSize>
       <SubItem>
         <Name>IN</Name>
         <Type>BOOL</Type>
-        <Comment> starts timer with rising edge, resets timer with falling edge </Comment>
+        <Comment> starts timer with falling edge, resets timer with rising edge </Comment>
         <BitSize>8</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -3445,7 +3485,7 @@
       <SubItem>
         <Name>Q</Name>
         <Type>BOOL</Type>
-        <Comment> gets TRUE, delay time (PT) after a rising edge at IN </Comment>
+        <Comment> is FALSE, PT seconds after IN had a falling edge </Comment>
         <BitSize>8</BitSize>
         <BitOffs>128</BitOffs>
         <Properties>
@@ -3488,73 +3528,766 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_General.TcUnit">FB_ADSTestResultFormatter</Name>
-      <Comment>
-    This function block reports the results from the tests using the built-in ADSLOGSTR functionality
-    provided by the Tc2_System library. This sends the result using ADS, which is consumed by the error list
-    of Visual Studio.
-</Comment>
-      <BitSize>448</BitSize>
-      <Implements Namespace="LCLS_General.TcUnit">I_TestResultFormatter</Implements>
+      <Name>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>0</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>1000</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>0</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>100</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">E_AssertionType</Name>
+      <BitSize>8</BitSize>
+      <BaseType>BYTE</BaseType>
+      <EnumInfo>
+        <Text>Type_UNDEFINED</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_ANY</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_BOOL</Text>
+        <Enum>2</Enum>
+        <Comment> Primitive types </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_BYTE</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_DATE</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_DATE_AND_TIME</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_DINT</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_DWORD</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_INT</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_LINT</Text>
+        <Enum>9</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_LREAL</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_LTIME</Text>
+        <Enum>11</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_LWORD</Text>
+        <Enum>12</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_REAL</Text>
+        <Enum>13</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_SINT</Text>
+        <Enum>14</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_STRING</Text>
+        <Enum>15</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_TIME</Text>
+        <Enum>16</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_TIME_OF_DAY</Text>
+        <Enum>17</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_UDINT</Text>
+        <Enum>18</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_UINT</Text>
+        <Enum>19</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_ULINT</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_USINT</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_WORD</Text>
+        <Enum>22</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_WSTRING</Text>
+        <Enum>23</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array2D_LREAL</Text>
+        <Enum>24</Enum>
+        <Comment> Array types </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array2D_REAL</Text>
+        <Enum>25</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array3D_LREAL</Text>
+        <Enum>26</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array3D_REAL</Text>
+        <Enum>27</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_BOOL</Text>
+        <Enum>28</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_BYTE</Text>
+        <Enum>29</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_DINT</Text>
+        <Enum>30</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_DWORD</Text>
+        <Enum>31</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_INT</Text>
+        <Enum>32</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_LINT</Text>
+        <Enum>33</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_LREAL</Text>
+        <Enum>34</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_LWORD</Text>
+        <Enum>35</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_REAL</Text>
+        <Enum>36</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_SINT</Text>
+        <Enum>37</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_UDINT</Text>
+        <Enum>38</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_UINT</Text>
+        <Enum>39</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_ULINT</Text>
+        <Enum>40</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_USINT</Text>
+        <Enum>41</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Type_Array_WORD</Text>
+        <Enum>42</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">ST_TestCaseResult</Name>
+      <BitSize>6192</BitSize>
       <SubItem>
-        <Name>ADSDelayTimer</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
+        <Name>TestName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestClassName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>2048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestIsFailed</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4096</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestIsSkipped</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4104</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FailureMessage</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>4112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FailureType</Name>
+        <Type Namespace="LCLS_General.TcUnit">E_AssertionType</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>6160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfAsserts</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>6176</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">ST_TestSuiteResult</Name>
+      <BitSize>621296</BitSize>
+      <SubItem>
+        <Name>Name</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Full class name</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Identity</Name>
+        <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+        <Comment> Should be 0..GVL_Param_TcUnit.MaxNumberOfTestSuites-1 but gives unknown compiler error</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfTests</Name>
+        <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2064</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfFailedTests</Name>
+        <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestCaseResults</Name>
+        <Type Namespace="LCLS_General.TcUnit">ST_TestCaseResult</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>100</Elements>
+        </ArrayInfo>
+        <BitSize>619200</BitSize>
+        <BitOffs>2096</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">ST_TestSuiteResults</Name>
+      <BitSize>621296064</BitSize>
+      <SubItem>
+        <Name>NumberOfTestSuites</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of test suites</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfTestCases</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of test cases (for all test suites)</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfSuccessfulTestCases</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of test cases that had all ASSERTS successful</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfFailedTestCases</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of test cases that had at least one ASSERT failed</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>48</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestSuiteResults</Name>
+        <Type Namespace="LCLS_General.TcUnit">ST_TestSuiteResult</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <Comment> Test results for each individiual test suite </Comment>
+        <BitSize>621296000</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">I_TestResults</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>GetAreTestResultsAvailable</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTestSuiteResults</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>1</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>1000</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">FB_TestResults</Name>
+      <Comment> This function block holds results of the complete test run, i.e. results for all test suites </Comment>
+      <BitSize>621296384</BitSize>
+      <Implements Namespace="LCLS_General.TcUnit">I_TestResults</Implements>
+      <SubItem>
+        <Name>TestSuiteResults</Name>
+        <Type Namespace="LCLS_General.TcUnit">ST_TestSuiteResults</Type>
+        <Comment> Test results </Comment>
+        <BitSize>621296064</BitSize>
         <BitOffs>128</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.PT</Name>
-            <Value>300</Value>
-          </SubItem>
-        </Default>
       </SubItem>
       <SubItem>
-        <Name>LastPrintState</Name>
-        <Type>USINT</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
+        <Name>StoringTestSuiteResultNumber</Name>
+        <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+        <Comment> Misc variables </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>621296192</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>PrintState</Name>
-        <Type>USINT</Type>
+        <Name>StoringTestSuiteTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>621296256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StoredTestSuiteResults</Name>
+        <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>392</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
+        <BitOffs>621296352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StoredGeneralTestResults</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>621296360</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfTestsToAnalyse</Name>
+        <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>621296368</BitOffs>
       </SubItem>
       <Method>
-        <Name>Format</Name>
-        <Parameter>
-          <Name>NumberOfTestSuites</Name>
-          <Comment> The total number of test suites </Comment>
-          <Type>UINT</Type>
+        <Name>GetAreTestResultsAvailable</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTestSuiteResults</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">I_TestResultLogger</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>LogTestSuiteResults</Name>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>1</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>100</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">FB_AdsTestResultLogger</Name>
+      <Comment>
+    This function block reports the results from the tests using the built-in ADSLOGSTR functionality
+    provided by the Tc2_System library. This sends the result using ADS, which is consumed by the "Error List"
+    of Visual Studio (which can print Errors, Warnings and Messages).
+</Comment>
+      <BitSize>384</BitSize>
+      <Implements Namespace="LCLS_General.TcUnit">I_TestResultLogger</Implements>
+      <SubItem>
+        <Name>TestResults</Name>
+        <Type Namespace="LCLS_General.TcUnit">I_TestResults</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PrintingTestSuiteResultNumber</Name>
+        <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PrintingTestSuiteTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PrintedFinalTestResults</Name>
+        <Type>BOOL</Type>
+        <Comment> This flag is set once the final end result has printed </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PrintedTestSuitesResults</Name>
+        <Type>BOOL</Type>
+        <Comment> This flag is set once the test suites result have been printed </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>360</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>LogTestSuiteResults</Name>
+        <Local>
+          <Name>TcUnitTestResults</Name>
+          <Type Namespace="LCLS_General.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>StringToPrint</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>TestsInTestSuiteCounter</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
           <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>MaxNumberOfTestsToPrint</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_SKIP</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_PASS</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_FAIL</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</Name>
+      <BitSize>32</BitSize>
+      <BaseType>UDINT</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Name>
+      <BitSize>32</BitSize>
+      <BaseType>UDINT</BaseType>
+      <EnumInfo>
+        <Text>AM_READ</Text>
+        <Enum>0</Enum>
+        <Comment> Open an existing file with Read access. If file does not exist, Open fails</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AM_WRITE</Text>
+        <Enum>1</Enum>
+        <Comment> Create new file with Write access. If file does exist, content is discarded</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AM_APPEND</Text>
+        <Enum>2</Enum>
+        <Comment> Open an existing file with Append (only write) access. If file does not exist, Open fails</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AM_READ_PLUS</Text>
+        <Enum>3</Enum>
+        <Comment> Open an existing file with Read/Write access. If file does not exist, Open fails</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AM_WRITE_PLUS</Text>
+        <Enum>4</Enum>
+        <Comment> Create new file with Read/Write access. If file does exist, content is discarded</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AM_APPEND_PLUS</Text>
+        <Enum>5</Enum>
+        <Comment> Open an existing file with Append (read/write) access. If file does not exist, Open creates a new file</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_SIZE</Name>
+      <BitSize>64</BitSize>
+      <BaseType PointerTo="1">BYTE</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_HANDLE</Name>
+      <BitSize>64</BitSize>
+      <BaseType PointerTo="1">BYTE</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">FB_FileControl</Name>
+      <Comment>
+    This functionblock can open, close, read, write and delete files on the local filesystem
+</Comment>
+      <BitSize>192</BitSize>
+      <SubItem>
+        <Name>FileAccessMode</Name>
+        <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+        <Comment> Append_Plus creates the file if it doesn't exist yet. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>FileHandle</Name>
+        <Type Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_HANDLE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>Read</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>NumberOfTestCases</Name>
-          <Comment> The total number of test cases (for all test function blocks) </Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF(); </Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>NumberOfSuccessfulTestCases</Name>
-          <Comment> The total number of test cases that had all ASSERTS successful </Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Name>FileSize</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_SIZE</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Close</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>Open</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>NumberOfFailedTestCases</Name>
-          <Comment> The total number of test cases that had at least one ASSERT failed </Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Delete</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a forward slash (/) </Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Write</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Busy</Name>
-          <Type>BOOL</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">E_XmlError</Name>
+      <BitSize>8</BitSize>
+      <BaseType>BYTE</BaseType>
+      <EnumInfo>
+        <Text>Ok</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ErrorMaxBufferLen</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ErrorStringLen</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Error</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">FB_StreamBuffer</Name>
+      <Comment>
+    This functionblock acts as a stream buffer for use with FB_XmlControl
+</Comment>
+      <BitSize>192</BitSize>
+      <SubItem>
+        <Name>_PointerToStringBuffer</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>_BufferSize</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>_Length</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>CutOff</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>StartPos</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>CutLen</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>XmlError</Name>
+          <Type Namespace="LCLS_General.TcUnit">E_XmlError</Type>
           <BitSize>8</BitSize>
           <Properties>
             <Property>
@@ -3564,10 +4297,630 @@
           </Properties>
         </Parameter>
         <Local>
-          <Name>ErrorCode</Name>
-          <Type>DINT</Type>
+          <Name>Loop</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>PointerToByteToCut</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Find</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>SearchString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>StartPos</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Loop</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Search</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToSearch</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>FindBack</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>SearchString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Loop</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Search</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToSearch</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="3">__getLength</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>Length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type RpcDirection="in">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Copy</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>StartPos</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>EndPos</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>CopyLen</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>XmlError</Name>
+          <Type Namespace="LCLS_General.TcUnit">E_XmlError</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>Loop</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToByteToCopy</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>PointerToBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>CurPos</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">FB_XmlControl</Name>
+      <Comment>
+    Organizes parsing and composing of XML data. Data can be treated as STRING or char array.
+    Buffer size of file can be set via GVL_Param_TcUnit (xUnitBufferSize)
+</Comment>
+      <BitSize>6016</BitSize>
+      <SubItem>
+        <Name>XmlBuffer</Name>
+        <Type Namespace="LCLS_General.TcUnit">FB_StreamBuffer</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TagListBuffer</Name>
+        <Type Namespace="LCLS_General.TcUnit">FB_StreamBuffer</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Tags</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TagListSeekBuffer</Name>
+        <Type Namespace="LCLS_General.TcUnit">FB_StreamBuffer</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>2496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TagsSeek</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>2688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TagBuffer</Name>
+        <Type Namespace="LCLS_General.TcUnit">FB_StreamBuffer</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>3392</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Tag</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>3584</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TagOpen</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>5632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Select</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>5664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SearchPosition</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>5696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TAG_OPEN</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5728</BitOffs>
+        <Default>
+          <String>&lt;</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>TAG_CLOSE</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5744</BitOffs>
+        <Default>
+          <String>&gt;</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>END_TAG_CLOSE</Name>
+        <Type>STRING(2)</Type>
+        <BitSize>24</BitSize>
+        <BitOffs>5760</BitOffs>
+        <Default>
+          <String>/&gt;</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>SPACE</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5784</BitOffs>
+        <Default>
+          <String> </String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>EQUALS</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5800</BitOffs>
+        <Default>
+          <String>=</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>QUOTE</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5816</BitOffs>
+        <Default>
+          <String>"</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>BACK_SLASH</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5832</BitOffs>
+        <Default>
+          <String>\</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>FORWARD_SLASH</Name>
+        <Type>STRING(1)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>5848</BitOffs>
+        <Default>
+          <String>/</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>OPEN_COMMENT</Name>
+        <Type>STRING(5)</Type>
+        <BitSize>48</BitSize>
+        <BitOffs>5864</BitOffs>
+        <Default>
+          <String>&lt;!-- </String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>CLOSE_COMMENT</Name>
+        <Type>STRING(4)</Type>
+        <BitSize>40</BitSize>
+        <BitOffs>5912</BitOffs>
+        <Default>
+          <String> --&gt;</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>TAB</Name>
+        <Type>STRING(2)</Type>
+        <BitSize>24</BitSize>
+        <BitOffs>5952</BitOffs>
+        <Default>
+          <String>	</String>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>CR_LF</Name>
+        <Type>STRING(4)</Type>
+        <BitSize>40</BitSize>
+        <BitOffs>5976</BitOffs>
+        <Default>
+          <String>
+</String>
+        </Default>
+      </SubItem>
+      <Method>
+        <Name>NewParameter</Name>
+        <Parameter>
+          <Name>Name</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Value</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewTag</Name>
+        <Parameter>
+          <Name>Name</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CloseTag</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>ClosedTag</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>WriteDocumentHeader</Name>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Parameter>
+          <Name>Comment</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__getLength</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>Length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>NewTagData</Name>
+        <Parameter>
+          <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <Parameter>
+          <Name>PointerToBuffer</Name>
+          <Comment> ADR(..)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> SIZEOF(..)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ClearBuffer</Name>
+      </Method>
+      <Method>
+        <Name>ToStartBuffer</Name>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">FB_xUnitXmlPublisher</Name>
+      <Comment>
+    Publishes test results into an xUnit compatible Xml file
+</Comment>
+      <BitSize>530944</BitSize>
+      <Implements Namespace="LCLS_General.TcUnit">I_TestResultLogger</Implements>
+      <SubItem>
+        <Name>TestResults</Name>
+        <Type Namespace="LCLS_General.TcUnit">I_TestResults</Type>
+        <Comment> Dependancy Injection via FB_Init</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AccessMode</Name>
+        <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+        <Comment> File access mode</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <Value>4</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>File</Name>
+        <Type Namespace="LCLS_General.TcUnit">FB_FileControl</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Xml</Name>
+        <Type Namespace="LCLS_General.TcUnit">FB_XmlControl</Type>
+        <BitSize>6016</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>BufferInitialised</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>6464</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>Buffer</Name>
+        <Type>BYTE</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>65535</Elements>
+        </ArrayInfo>
+        <BitSize>524280</BitSize>
+        <BitOffs>6472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>WritingTestSuiteResultNumber</Name>
+        <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>530752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PublishTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>530816</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>DeleteOpenWriteClose</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>LogTestSuiteResults</Name>
+        <Local>
+          <Name>UnitTestResults</Name>
+          <Type Namespace="LCLS_General.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>CurrentSuiteNumber</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>CurrentTestCount</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_SKIP</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_PASS</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>TEST_STATUS_FAIL</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Initialised</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Properties>
         <Property>
@@ -3581,10 +4934,11 @@
       <Comment>
     This function block is responsible for holding track of the tests and executing them.
 </Comment>
-      <BitSize>768</BitSize>
+      <BitSize>621828352</BitSize>
       <SubItem>
         <Name>AllTestSuitesFinished</Name>
         <Type>BOOL</Type>
+        <Comment> Indication of whether all test suites have reported that they are finished </Comment>
         <BitSize>8</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
@@ -3592,67 +4946,123 @@
         </Default>
       </SubItem>
       <SubItem>
-        <Name>ADSTestResultFormatter</Name>
-        <Type Namespace="LCLS_General.TcUnit">FB_ADSTestResultFormatter</Type>
-        <BitSize>448</BitSize>
+        <Name>TestResults</Name>
+        <Type Namespace="LCLS_General.TcUnit">FB_TestResults</Type>
+        <Comment> Test result information </Comment>
+        <BitSize>621296384</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>TestResultPrinter</Name>
-        <Type Namespace="LCLS_General.TcUnit">I_TestResultFormatter</Type>
+        <Name>AdsTestResultLogger</Name>
+        <Type Namespace="LCLS_General.TcUnit">FB_AdsTestResultLogger</Type>
+        <Comment> Prints the results to ADS so that Visual Studio can display the results.
+       This test result formatter can be replaced with something else than ADS </Comment>
+        <BitSize>384</BitSize>
+        <BitOffs>621296512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>old_input_assignments</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TestResultLogger</Name>
+        <Type Namespace="LCLS_General.TcUnit">I_TestResultLogger</Type>
         <BitSize>64</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NumberOfTestSuitesFinished</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>640</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>NumberOfTestCases</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>656</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>NumberOfFailedTestCases</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>672</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>NumberOfSuccessfulTestCases</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>688</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>DonePrintingTestResults</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>704</BitOffs>
+        <BitOffs>621296896</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AbortRunningTestSuites</Name>
         <Type>BOOL</Type>
+        <Comment> If this flag is set, it means that some external event triggered the
+       request to abort running the test suites </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>712</BitOffs>
+        <BitOffs>621296960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xUnitXmlPublisher</Name>
+        <Type Namespace="LCLS_General.TcUnit">FB_xUnitXmlPublisher</Type>
+        <Comment> Publishes a xUnit compatible XML file </Comment>
+        <BitSize>530944</BitSize>
+        <BitOffs>621297024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>old_input_assignments</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>XmlTestResultPublisher</Name>
+        <Type Namespace="LCLS_General.TcUnit">I_TestResultLogger</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>621827968</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>__RUNTESTSUITETESTSINSEQUENCE__CURRENTLYRUNNINGTESTSUITE</Name>
+        <Type>UINT</Type>
+        <Comment> This variable holds which current test suite is being called, as we are running
+       each one in a sequence (one by one) </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>621828032</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>__RUNTESTSUITETESTSINSEQUENCE__TIMERBETWEENEXECUTIONOFTESTSUITES</Name>
+        <Type Namespace="Tc2_Standard">TOF</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>621828096</BitOffs>
       </SubItem>
       <Method>
         <Name>AbortRunningTestSuiteTests</Name>
+      </Method>
+      <Method>
+        <Name>RunTestSuiteTestsInSequence</Name>
+        <Parameter>
+          <Name>TimeBetweenTestSuitesExecution</Name>
+          <Comment> Time delay between a test suite is finished and the next test suite starts</Comment>
+          <Type>TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>BusyPrinting</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestSuitesFinished</Name>
+          <Comment> We need to hold a temporary state of the statistics 
+       as we don't consider the tests to be completely finished until all test suites have executed completely.
+       The reason we want to do it this way is because a test suite can run over several cycles. Only once all tests
+       are finished (which might take many cycles), do we gather correct statistics </Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>CurrentlyRunningTestSuite</Name>
+          <Comment> This variable holds which current test suite is being called, as we are running
+       each one in a sequence (one by one) </Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__RUNTESTSUITETESTSINSEQUENCE__CURRENTLYRUNNINGTESTSUITE</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>TimerBetweenExecutionOfTestSuites</Name>
+          <Type Namespace="Tc2_Standard">TOF</Type>
+          <BitSize>256</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__RUNTESTSUITETESTSINSEQUENCE__TIMERBETWEENEXECUTIONOFTESTSUITES</Value>
+            </Property>
+          </Properties>
+        </Local>
       </Method>
       <Method>
         <Name>RunTestSuiteTests</Name>
@@ -3667,22 +5077,11 @@
           <BitSize>8</BitSize>
         </Local>
         <Local>
-          <Name>NumberOfTestSuitesFinished_Temp</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestCases_Temp</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfFailedTestCases_Temp</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfSuccessfulTestCases_Temp</Name>
+          <Name>NumberOfTestSuitesFinished</Name>
+          <Comment> We need to hold a temporary state of the statistics 
+       as we don't consider the tests to be completely finished until all test suites have executed completely.
+       The reason we want to do it this way is because a test suite can run over several cycles. Only once all tests
+       are finished (which might take many cycles), do we gather correct statistics </Comment>
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
@@ -3691,6 +5090,180 @@
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">FB_Test</Name>
+      <Comment>
+    This function block holds all data that defines a test.
+</Comment>
+      <BitSize>4224</BitSize>
+      <SubItem>
+        <Name>TestName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestIsFinished</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestIsSkipped</Name>
+        <Type>BOOL</Type>
+        <Comment> This is set to true, if test is disabled (by putting the string "disabled_" in front of the test name</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2120</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfAssertions</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestOrderNumber</Name>
+        <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+        <Comment> In which order/sequence relative to the order tests should this test be executed/evaluated.
+       A value of 0 means it is not defined by TEST_ORDERED() but by un-ordered test (TEST()).
+       A value &lt;&gt; 0 tells in which order this test will be executed/evaluated. The lower the number, the earlier it will execute. </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestIsFailed</Name>
+        <Type>BOOL</Type>
+        <Comment> Indication of whether this test has at least one failed assert</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AssertionMessage</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Assertion message for the first assertion in this test</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>2168</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AssertionType</Name>
+        <Type Namespace="LCLS_General.TcUnit">E_AssertionType</Type>
+        <Comment> Assertion type for the first assertion in this test</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>4216</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>GetAssertionType</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit">E_AssertionType</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetFailed</Name>
+      </Method>
+      <Method>
+        <Name>SetName</Name>
+        <Parameter>
+          <Name>Name</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetName</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetTestOrder</Name>
+        <Parameter>
+          <Name>OrderNumber</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsSkipped</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetAssertionMessage</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetSkipped</Name>
+      </Method>
+      <Method>
+        <Name>SetAssertionMessage</Name>
+        <Parameter>
+          <Name>AssertMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetAssertionType</Name>
+        <Parameter>
+          <Name>AssertType</Name>
+          <Type Namespace="LCLS_General.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTestOrder</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>UINT (1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>1</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>100</Value>
         </Property>
       </Properties>
     </DataType>
@@ -3883,90 +5456,19 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_General.TcUnit">FB_AnyComparator</Name>
-      <Comment>
-    This FB compares two instances of any object type and returns whether they
-    are the same type, size and value or not. This is necessary for two reasons:
-    1. So that we can know exactly what differs between the two input parameters
-    2. It's not possible to do a comparison (= or &lt;&gt;) between two instances of ANY.
-</Comment>
-      <BitSize>384</BitSize>
+      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
+      <BitSize>96</BitSize>
       <SubItem>
-        <Name>AnyValueOne</Name>
-        <Type>AnyType</Type>
-        <BitSize>128</BitSize>
+        <Name>nIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>anytypeclass</Name>
-            <Value>ANY</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>AnyValueTwo</Name>
-        <Type>AnyType</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>anytypeclass</Name>
-            <Value>ANY</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>DataTypesNotEquals</Name>
-        <Type>BOOL</Type>
-        <Comment> The data type of the two ANY input parameters are not equal</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
             <Value>Output</Value>
           </Property>
         </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>DataSizeNotEquals</Name>
-        <Type>BOOL</Type>
-        <Comment> The data size of the two ANY input parameters are not equal</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>328</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>DataContentNotEquals</Name>
-        <Type>BOOL</Type>
-        <Comment> The data content of the two ANY input parameters are not equal</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>336</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>IteratorCounter</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>352</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -3974,7 +5476,45 @@
           <Value>FunctionBlock</Value>
         </Property>
         <Property>
-          <Name>hasanytype</Name>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
+      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>index</Name>
+        <Type>BYTE</Type>
+        <Comment> Returns the current task index of the calling task. </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIndex</Name>
+        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
         </Property>
       </Properties>
     </DataType>
@@ -4460,720 +6000,6 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
-      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
-      <BitSize>256</BitSize>
-      <SubItem>
-        <Name>index</Name>
-        <Type>BYTE</Type>
-        <Comment> Returns the current task index of the calling task. </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIndex</Name>
-        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.TcUnit">FB_Test</Name>
-      <Comment>
-    This function block holds all data that defines a test.
-</Comment>
-      <BitSize>2144</BitSize>
-      <SubItem>
-        <Name>TestName</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TestIsFailed</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2112</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TestIsFinished</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2120</BitOffs>
-      </SubItem>
-      <Method>
-        <Name>IsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetName</Name>
-        <Parameter>
-          <Name>Name</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFailed</Name>
-      </Method>
-      <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetName</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.TcUnit">U_ExpectedOrActual</Name>
-      <BitSize>2048</BitSize>
-      <SubItem>
-        <Name>boolExpectedOrActual</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bitExpectedOrActual</Name>
-        <Type>BIT</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>byteExpectedOrActual</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sintExpectedOrActual</Name>
-        <Type>SINT</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>usintExpectedOrActual</Name>
-        <Type>USINT</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>intExpectedOrActual</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>uintExpectedOrActual</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wordExpectedOrActual</Name>
-        <Type>WORD</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwordExpectedOrActual</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dateandtimeExpectedOrActual</Name>
-        <Type>DATE_AND_TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dintExpectedOrActual</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>realExpectedOrActual</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>timeExpectedOrActual</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dateExpectedOrActual</Name>
-        <Type>DATE</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>udintExpectedOrActual</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>timeofdayExpectedOrActual</Name>
-        <Type>TIME_OF_DAY</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>lwordExpectedOrActual</Name>
-        <Type>LWORD</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>lintExpectedOrActual</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ulintExpectedOrActual</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>lrealExpectedOrActual</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ltimeExpectedOrActual</Name>
-        <Type>LTIME</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wstringExpectedOrActual</Name>
-        <Type>WSTRING(80)</Type>
-        <BitSize>1296</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stringExpectedOrActual</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.TcUnit">ST_AssertResult</Name>
-      <BitSize>8192</BitSize>
-      <SubItem>
-        <Name>Expected</Name>
-        <Type Namespace="LCLS_General.TcUnit">U_ExpectedOrActual</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Actual</Name>
-        <Type Namespace="LCLS_General.TcUnit">U_ExpectedOrActual</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>2048</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Message</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>4096</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TestInstancePath</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>6144</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.TcUnit">ST_AssertResultInstances</Name>
-      <BitSize>8256</BitSize>
-      <SubItem>
-        <Name>AssertResult</Name>
-        <Type Namespace="LCLS_General.TcUnit">ST_AssertResult</Type>
-        <BitSize>8192</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DetectionCount</Name>
-        <Type>UINT</Type>
-        <Comment> Number of instances of the "AssertResult"</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>8192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DetectionCountThisCycle</Name>
-        <Type>UINT</Type>
-        <Comment> Number of instance of the "AssertResult" in this specific PLC-cycle</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>8208</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.TcUnit">FB_AssertResultStatic</Name>
-      <Comment>
-    This function block is responsible for keeping track of which asserts that have been made. The reason we need to
-    keep track of these is because if the user does the same assert twice (because of running a test suite over several
-    PLC-cycles) we want to know it so we don't print several times (if the assert fails).
-    An instance of an assert is keyed/identified with the following parameters as key:
-    - Value of expected
-    - Value of actual
-    - Message (string)
-    - Test instance path (string)
-</Comment>
-      <BitSize>8224448</BitSize>
-      <SubItem>
-        <Name>AssertResults</Name>
-        <Type Namespace="LCLS_General.TcUnit">ST_AssertResult</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>500</Elements>
-        </ArrayInfo>
-        <BitSize>4096000</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TotalAsserts</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>4096064</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>GetCurrentTaskIndex</Name>
-        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>4096128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AssertResultInstances</Name>
-        <Type Namespace="LCLS_General.TcUnit">ST_AssertResultInstances</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>500</Elements>
-        </ArrayInfo>
-        <BitSize>4128000</BitSize>
-        <BitOffs>4096384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CycleCount</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>8224384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>FirstCycleExecuted</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8224416</BitOffs>
-      </SubItem>
-      <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IncreaseDetectionCountThisCycleByOne</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetDetectionCount</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>ReportResult</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>LocationIndex</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>DataTypesNotEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>DataSizeNotEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>DataContentNotEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>CurrentCycleCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>DetectionCountTemp</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>FoundOne</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>AdditionalIdenticalAssert</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
@@ -5339,6 +6165,591 @@
       </EnumInfo>
     </DataType>
     <DataType>
+      <Name Namespace="LCLS_General.TcUnit">U_ExpectedOrActual</Name>
+      <BitSize>4096</BitSize>
+      <SubItem>
+        <Name>boolExpectedOrActual</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bitExpectedOrActual</Name>
+        <Type>BIT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>byteExpectedOrActual</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sintExpectedOrActual</Name>
+        <Type>SINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>usintExpectedOrActual</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>intExpectedOrActual</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>uintExpectedOrActual</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wordExpectedOrActual</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwordExpectedOrActual</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dateandtimeExpectedOrActual</Name>
+        <Type>DATE_AND_TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dintExpectedOrActual</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>realExpectedOrActual</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>timeExpectedOrActual</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dateExpectedOrActual</Name>
+        <Type>DATE</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>udintExpectedOrActual</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>timeofdayExpectedOrActual</Name>
+        <Type>TIME_OF_DAY</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lwordExpectedOrActual</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lintExpectedOrActual</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ulintExpectedOrActual</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lrealExpectedOrActual</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ltimeExpectedOrActual</Name>
+        <Type>LTIME</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stringExpectedOrActual</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wstringExpectedOrActual</Name>
+        <Type>WSTRING(255)</Type>
+        <BitSize>4096</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">ST_AssertResult</Name>
+      <BitSize>12288</BitSize>
+      <SubItem>
+        <Name>Expected</Name>
+        <Type Namespace="LCLS_General.TcUnit">U_ExpectedOrActual</Type>
+        <BitSize>4096</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Actual</Name>
+        <Type Namespace="LCLS_General.TcUnit">U_ExpectedOrActual</Type>
+        <BitSize>4096</BitSize>
+        <BitOffs>4096</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Message</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>8192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TestInstancePath</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>10240</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">ST_AssertResultInstances</Name>
+      <BitSize>12352</BitSize>
+      <SubItem>
+        <Name>AssertResult</Name>
+        <Type Namespace="LCLS_General.TcUnit">ST_AssertResult</Type>
+        <BitSize>12288</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DetectionCount</Name>
+        <Type>UINT</Type>
+        <Comment> Number of instances of the "AssertResult"</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>12288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DetectionCountThisCycle</Name>
+        <Type>UINT</Type>
+        <Comment> Number of instance of the "AssertResult" in this specific PLC-cycle</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>12304</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">FB_AssertResultStatic</Name>
+      <Comment>
+    This function block is responsible for keeping track of which asserts that have been made. The reason we need to
+    keep track of these is because if the user does the same assert twice (because of running a test suite over several
+    PLC-cycles) we want to know it so we don't print several times (if the assert fails).
+    An instance of an assert is keyed/identified with the following parameters as key:
+    - Value of expected
+    - Value of actual
+    - Message (string)
+    - Test instance path (string)
+</Comment>
+      <BitSize>24640448</BitSize>
+      <SubItem>
+        <Name>AssertResults</Name>
+        <Type Namespace="LCLS_General.TcUnit">ST_AssertResult</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <Comment> The total number of instances of each of the "AssertResults" </Comment>
+        <BitSize>12288000</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TotalAsserts</Name>
+        <Type>UINT</Type>
+        <Comment> The total number of unique asserts </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>12288064</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>GetCurrentTaskIndex</Name>
+        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+        <Comment> Function block to get the current task cycle </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>12288128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AssertResultInstances</Name>
+        <Type Namespace="LCLS_General.TcUnit">ST_AssertResultInstances</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <Comment> The total number of instances of each of the "AssertResults" </Comment>
+        <BitSize>12352000</BitSize>
+        <BitOffs>12288384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CycleCount</Name>
+        <Type>UDINT</Type>
+        <Comment> The last PLC cycle count </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>24640384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FirstCycleExecuted</Name>
+        <Type>BOOL</Type>
+        <Comment> Only run first cycle </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24640416</BitOffs>
+      </SubItem>
+      <Method>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfAssertsForTest</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetDetectionCount</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>ReportResult</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>LocationIndex</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>DataTypesNotEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>DataSizeNotEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>DataContentNotEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>CurrentCycleCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>DetectionCountTemp</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>FoundOne</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>AdditionalIdenticalAssert</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General.TcUnit">ST_AssertArrayResult</Name>
       <BitSize>4224</BitSize>
       <SubItem>
@@ -5420,22 +6831,24 @@
     - Message (string)
     - Test instance path (string)
 </Comment>
-      <BitSize>4240448</BitSize>
+      <BitSize>8480448</BitSize>
       <SubItem>
         <Name>AssertArrayResults</Name>
         <Type Namespace="LCLS_General.TcUnit">ST_AssertArrayResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
-          <Elements>500</Elements>
+          <Elements>1000</Elements>
         </ArrayInfo>
-        <BitSize>2112000</BitSize>
+        <Comment> The total number of instances of each of the "AssertArrayResults" </Comment>
+        <BitSize>4224000</BitSize>
         <BitOffs>64</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TotalArrayAsserts</Name>
         <Type>UINT</Type>
+        <Comment> The total number of unique asserts </Comment>
         <BitSize>16</BitSize>
-        <BitOffs>2112064</BitOffs>
+        <BitOffs>4224064</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -5443,69 +6856,35 @@
       <SubItem>
         <Name>GetCurrentTaskIndex</Name>
         <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+        <Comment> Function block to get the current task cycle </Comment>
         <BitSize>256</BitSize>
-        <BitOffs>2112128</BitOffs>
+        <BitOffs>4224128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertArrayResultInstances</Name>
         <Type Namespace="LCLS_General.TcUnit">ST_AssertArrayResultInstances</Type>
         <ArrayInfo>
           <LBound>1</LBound>
-          <Elements>500</Elements>
+          <Elements>1000</Elements>
         </ArrayInfo>
-        <BitSize>2128000</BitSize>
-        <BitOffs>2112384</BitOffs>
+        <Comment> The total number of instances of each of the "AssertArrayResults" </Comment>
+        <BitSize>4256000</BitSize>
+        <BitOffs>4224384</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CycleCount</Name>
         <Type>UDINT</Type>
+        <Comment> The last PLC cycle count </Comment>
         <BitSize>32</BitSize>
-        <BitOffs>4240384</BitOffs>
+        <BitOffs>8480384</BitOffs>
       </SubItem>
       <SubItem>
         <Name>FirstCycleExecuted</Name>
         <Type>BOOL</Type>
+        <Comment> Only run first cycle </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>4240416</BitOffs>
+        <BitOffs>8480416</BitOffs>
       </SubItem>
-      <Method>
-        <Name>IncreaseDetectionCountThisCycleByOne</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
         <Parameter>
@@ -5714,6 +7093,26 @@
         </Local>
       </Method>
       <Method>
+        <Name>GetNumberOfArrayAssertsForTest</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfArrayAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -5790,10 +7189,10 @@
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_General.TcUnit">FB_AdjustAssertFailureMessageToMax252CharLength</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Name>
       <Comment>
     This function block is responsible for making sure that the asserted test instance path and test message are not
-    loo long. The total printed message can not be more than 252 characters long.
+    loo long. The total printed message can not be more than 253 characters long.
 </Comment>
       <BitSize>11616</BitSize>
       <SubItem>
@@ -5873,10 +7272,11 @@
       <SubItem>
         <Name>MSG_FMT_STRING_MAX_NUMBER_OF_CHARACTERS</Name>
         <Type>INT</Type>
+        <Comment> This is actually 254, but if StrArg-argument is used (which it is in TcUnit) it is 253.</Comment>
         <BitSize>16</BitSize>
         <BitOffs>11600</BitOffs>
         <Default>
-          <Value>252</Value>
+          <Value>253</Value>
         </Default>
       </SubItem>
       <Properties>
@@ -5887,7 +7287,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_General.TcUnit">FB_ADSAssertMessageFormatter</Name>
+      <Name Namespace="LCLS_General.TcUnit">FB_AdsAssertMessageFormatter</Name>
       <Comment>
     This function block is responsible for printing the results of the assertions using the built-in
     ADSLOGSTR functionality provided by the Tc2_System library. This sends the result using ADS, which
@@ -5918,8 +7318,8 @@
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>AdjustAssertFailureMessageToMax252CharLength</Name>
-          <Type Namespace="LCLS_General.TcUnit">FB_AdjustAssertFailureMessageToMax252CharLength</Type>
+          <Name>AdjustAssertFailureMessageToMax253CharLength</Name>
+          <Type Namespace="LCLS_General.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Type>
           <BitSize>11616</BitSize>
         </Local>
         <Local>
@@ -5962,7 +7362,7 @@
    It's also responsible for providing all the assert-methods for asserting different data types.
    Only failed assertions are recorded.
 </Comment>
-      <BitSize>12694720</BitSize>
+      <BitSize>33558784</BitSize>
       <SubItem>
         <Name>InstancePath</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -5980,12 +7380,16 @@
       <SubItem>
         <Name>GetCurrentTaskIndex</Name>
         <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+        <Comment> We need to have access to specific information of the current task that this test suite
+       is executed in. This is for instance necessary when we need to know whether a test is
+       defined already. The definition of a test that is defined already is that we call on it
+       with the same name twice in the same cycle </Comment>
         <BitSize>256</BitSize>
         <BitOffs>2112</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NumberOfTests</Name>
-        <Type>UINT</Type>
+        <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
         <BitSize>16</BitSize>
         <BitOffs>2368</BitOffs>
         <Default>
@@ -5999,7 +7403,7 @@
           <LBound>1</LBound>
           <Elements>100</Elements>
         </ArrayInfo>
-        <BitSize>214400</BitSize>
+        <BitSize>422400</BitSize>
         <BitOffs>2432</BitOffs>
       </SubItem>
       <SubItem>
@@ -6009,8 +7413,10 @@
           <LBound>1</LBound>
           <Elements>100</Elements>
         </ArrayInfo>
+        <Comment> Rising trigger of whether we have already notified the user of that the test name pointed to by the current
+       position is a duplicate </Comment>
         <BitSize>9600</BitSize>
-        <BitOffs>216832</BitOffs>
+        <BitOffs>424832</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TestCycleCountIndex</Name>
@@ -6019,321 +7425,63 @@
           <LBound>1</LBound>
           <Elements>100</Elements>
         </ArrayInfo>
+        <Comment> Last cycle count index for a specific test. Used to detect whether this test has already been defined in the
+       current test suite </Comment>
         <BitSize>3200</BitSize>
-        <BitOffs>226432</BitOffs>
+        <BitOffs>434432</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertResults</Name>
         <Type Namespace="LCLS_General.TcUnit">FB_AssertResultStatic</Type>
-        <BitSize>8224448</BitSize>
-        <BitOffs>229632</BitOffs>
+        <BitSize>24640448</BitSize>
+        <BitOffs>437632</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>AssertArrayResult</Name>
+        <Name>AssertArrayResults</Name>
         <Type Namespace="LCLS_General.TcUnit">FB_AssertArrayResultStatic</Type>
-        <BitSize>4240448</BitSize>
-        <BitOffs>8454080</BitOffs>
+        <BitSize>8480448</BitSize>
+        <BitOffs>25078080</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>ADSAssertMessageFormatter</Name>
-        <Type Namespace="LCLS_General.TcUnit">FB_ADSAssertMessageFormatter</Type>
+        <Name>AdsAssertMessageFormatter</Name>
+        <Type Namespace="LCLS_General.TcUnit">FB_AdsAssertMessageFormatter</Type>
+        <Comment> Prints the failed asserts to ADS so that Visual Studio can display the assert message.
+       This assert formatter can be replaced with something else than ADS </Comment>
         <BitSize>128</BitSize>
-        <BitOffs>12694528</BitOffs>
+        <BitOffs>33558528</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertMessageFormatter</Name>
         <Type Namespace="LCLS_General.TcUnit">I_AssertMessageFormatter</Type>
         <BitSize>64</BitSize>
-        <BitOffs>12694656</BitOffs>
+        <BitOffs>33558656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>HasStartedRunning</Name>
+        <Type>BOOL</Type>
+        <Comment> Indication whether this test suite has started running its tests </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>33558720</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NumberOfOrderedTests</Name>
+        <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+        <Comment> Number of ordered tests (created by TEST_ORDERED()) that this test suite contains </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>33558736</BitOffs>
       </SubItem>
       <Method>
-        <Name>AssertArrayEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
+        <Name>AssertEquals_LINT</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_WORD</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> WORD array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">WORD</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> WORD array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">WORD</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedDWordString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualDWordString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_STRING</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
+          <Comment> LINT expected value</Comment>
+          <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
+          <Comment> LINT actual value</Comment>
+          <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
@@ -6351,259 +7499,12 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
         <Name>GetNumberOfSuccessfulTests</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_BYTE</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> BYTE array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> BYTE array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_WORD</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> WORD expected value</Comment>
-          <Type>WORD</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> WORD actual value</Comment>
-          <Type>WORD</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_ULINT</Name>
@@ -6660,13 +7561,13 @@
         </Local>
         <Local>
           <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>AlreadyReported</Name>
@@ -6705,17 +7606,550 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LINT</Name>
+        <Name>FindTestSuiteInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AssertEquals_TIME</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> LINT expected value</Comment>
-          <Type>LINT</Type>
+          <Comment> TIME expected value</Comment>
+          <Type>TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> TIME actual value</Comment>
+          <Type>TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_TIME_OF_DAY</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> TIME_OF_DAY expected value</Comment>
+          <Type>TIME_OF_DAY</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> TIME_OF_DAY actual value</Comment>
+          <Type>TIME_OF_DAY</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfFailedTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>FailedTestsCount</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestOverArrayLimit</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DATE_AND_TIME</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DATE_AND_TIME expected value</Comment>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DATE_AND_TIME actual value</Comment>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetTestByPosition</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit">FB_Test</ReturnType>
+        <ReturnBitSize>4224</ReturnBitSize>
+        <Parameter>
+          <Name>Position</Name>
+          <Type>UINT (1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_BOOL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> BOOL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BOOL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> BOOL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BOOL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_BYTE</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> BYTE array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> BYTE array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DATE</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DATE expected value</Comment>
+          <Type>DATE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DATE actual value</Comment>
+          <Type>DATE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_WORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> WORD expected value</Comment>
+          <Type>WORD</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> WORD actual value</Comment>
+          <Type>WORD</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LTIME</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LTIME expected value</Comment>
+          <Type>LTIME</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> LINT actual value</Comment>
-          <Type>LINT</Type>
+          <Comment> LTIME actual value</Comment>
+          <Type>LTIME</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
@@ -6733,6 +8167,251 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_UINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> UINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> UINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LREAL expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LREAL actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the absolute value of expected and actual for which both numbers are still considered equal</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LWORD</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LWORD array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LWORD</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LWORD array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LWORD</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedLWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualLWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -6774,13 +8453,13 @@
         </Local>
         <Local>
           <Name>ExpectedDataString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>ActualDataString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>TestInstancePath</Name>
@@ -6791,11 +8470,6 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>AnyComparator</Name>
-          <Type Namespace="LCLS_General.TcUnit">FB_AnyComparator</Type>
-          <BitSize>384</BitSize>
         </Local>
         <Local>
           <Name>boolExpected</Name>
@@ -6938,6 +8612,16 @@
           <BitSize>2048</BitSize>
         </Local>
         <Local>
+          <Name>wstringExpected</Name>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Local>
+        <Local>
+          <Name>wstringActual</Name>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Local>
+        <Local>
           <Name>timeExpected</Name>
           <Type>TIME</Type>
           <BitSize>32</BitSize>
@@ -7007,6 +8691,29 @@
           <Type>WORD</Type>
           <BitSize>16</BitSize>
         </Local>
+        <Local>
+          <Name>DataTypesNotEquals</Name>
+          <Comment> The data type of the two ANY input parameters are not equal</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>DataSizeNotEquals</Name>
+          <Comment> The data size of the two ANY input parameters are not equal</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>DataContentNotEquals</Name>
+          <Comment> The data content of the two ANY input parameters are not equal</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
         <Properties>
           <Property>
             <Name>hasanytype</Name>
@@ -7014,18 +8721,33 @@
         </Properties>
       </Method>
       <Method>
-        <Name>AssertEquals_TIME_OF_DAY</Name>
+        <Name>AssertFalse</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> TIME_OF_DAY expected value</Comment>
-          <Type>TIME_OF_DAY</Type>
-          <BitSize>32</BitSize>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> TIME_OF_DAY actual value</Comment>
-          <Type>TIME_OF_DAY</Type>
-          <BitSize>32</BitSize>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -7042,6 +8764,256 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7073,6 +9045,598 @@
           <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LWORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="LCLS_General.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_DWORD</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> DWORD array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DWORD</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> DWORD array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DWORD</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedDWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualDWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetHasStartedRunning</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_WSTRING</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> WSTRING expected value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> WSTRING actual value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7130,13 +9694,13 @@
         </Local>
         <Local>
           <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>AlreadyReported</Name>
@@ -7175,18 +9739,18 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_SINT</Name>
+        <Name>AssertEquals_STRING</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -7206,29 +9770,584 @@
         </Local>
       </Method>
       <Method>
-        <Name>GetNumberOfTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>SetTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LREAL</Name>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>256</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_WORD</Name>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> LREAL expected value</Comment>
-          <Type>LREAL</Type>
+          <Name>Expecteds</Name>
+          <Comment> WORD array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">WORD</Type>
           <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
-          <Name>Actual</Name>
-          <Comment> LREAL actual value</Comment>
-          <Type>LREAL</Type>
+          <Name>Actuals</Name>
+          <Comment> WORD array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">WORD</Type>
           <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedDWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualDWordString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray3dEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
           <Name>Delta</Name>
-          <Comment> The maximum delta between the absolute value of expected and actual for which both numbers are still considered equal</Comment>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
           <Type>LREAL</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_INT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> INT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">INT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> INT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">INT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CalculateAndSetNumberOfAssertsForTest</Name>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>TotalNumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfArrayAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfSkippedTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>SkippedTestsCount</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_INT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> INT expected value</Comment>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> INT actual value</Comment>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_UINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -7281,7 +10400,7 @@
         </Parameter>
         <Parameter>
           <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
           <Type>REAL</Type>
           <BitSize>32</BitSize>
         </Parameter>
@@ -7303,13 +10422,13 @@
         </Local>
         <Local>
           <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>AlreadyReported</Name>
@@ -7323,11 +10442,13 @@
         </Local>
         <Local>
           <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
           <Type>USINT</Type>
           <BitSize>8</BitSize>
         </Local>
         <Local>
           <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
           <Type>DINT</Type>
           <ArrayInfo>
             <LBound>1</LBound>
@@ -7337,6 +10458,7 @@
         </Local>
         <Local>
           <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
           <Type>DINT</Type>
           <ArrayInfo>
             <LBound>1</LBound>
@@ -7346,6 +10468,7 @@
         </Local>
         <Local>
           <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
           <Type>DINT</Type>
           <ArrayInfo>
             <LBound>1</LBound>
@@ -7355,6 +10478,7 @@
         </Local>
         <Local>
           <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
           <Type>DINT</Type>
           <ArrayInfo>
             <LBound>1</LBound>
@@ -7364,6 +10488,7 @@
         </Local>
         <Local>
           <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
           <Type>DINT</Type>
           <ArrayInfo>
             <LBound>1</LBound>
@@ -7373,6 +10498,7 @@
         </Local>
         <Local>
           <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
           <Type>DINT</Type>
           <ArrayInfo>
             <LBound>1</LBound>
@@ -7382,6 +10508,7 @@
         </Local>
         <Local>
           <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
           <Type>DINT</Type>
           <ArrayInfo>
             <LBound>1</LBound>
@@ -7391,6 +10518,7 @@
         </Local>
         <Local>
           <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
           <Type>DINT</Type>
           <ArrayInfo>
             <LBound>1</LBound>
@@ -7400,6 +10528,7 @@
         </Local>
         <Local>
           <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
           <Type>DINT</Type>
           <ArrayInfo>
             <LBound>1</LBound>
@@ -7409,13 +10538,282 @@
         </Local>
         <Local>
           <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
           <Type>REAL</Type>
           <BitSize>32</BitSize>
         </Local>
         <Local>
           <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
           <Type>REAL</Type>
           <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddTest</Name>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>IsTestOrdered</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>ErrorMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FunctionCallResult</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>CycleCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>TestWithThisNameAlreadyExists</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerCasedTestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>TrimmedTestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>IgnoreCurrentTestCase</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Comment> String formatter for output messages</Comment>
+          <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>8576</BitSize>
         </Local>
         <Local>
           <Name>__Index__0</Name>
@@ -7439,270 +10837,17 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertArray3dEquals_LREAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_INT</Name>
+        <Name>AssertEquals_UDINT</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> INT expected value</Comment>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> INT actual value</Comment>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DATE</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DATE expected value</Comment>
-          <Type>DATE</Type>
+          <Comment> UDINT expected value</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> DATE actual value</Comment>
-          <Type>DATE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
+          <Comment> UDINT actual value</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
@@ -7741,68 +10886,6 @@
           <Comment> The maximum delta between the absolute value of expected and actual for which both numbers are still considered equal</Comment>
           <Type>REAL</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_UDINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> UDINT expected value</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> UDINT actual value</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LTIME</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LTIME expected value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LTIME actual value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -7876,13 +10959,13 @@
         </Local>
         <Local>
           <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>AlreadyReported</Name>
@@ -7918,290 +11001,6 @@
           <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_TIME</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> TIME expected value</Comment>
-          <Type>TIME</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> TIME actual value</Comment>
-          <Type>TIME</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DATE_AND_TIME</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DATE_AND_TIME expected value</Comment>
-          <Type>DATE_AND_TIME</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DATE_AND_TIME actual value</Comment>
-          <Type>DATE_AND_TIME</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>8576</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -8259,1119 +11058,13 @@
         </Local>
         <Local>
           <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
           <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_INT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> INT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">INT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> INT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">INT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertFalse</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetNumberOfFailedTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>FailedTestsCount</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_LINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_LWORD</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LWORD array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LWORD</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LWORD array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LWORD</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedDWordString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualDWordString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LWORD</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_BOOL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> BOOL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BOOL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> BOOL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BOOL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>256</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddTest</Name>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>ErrorMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FunctionCallResult</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>CycleCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>TestWithThisNameAlreadyExists</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerCasedTestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>TrimmedTestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_DWORD</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> DWORD array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DWORD</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> DWORD array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DWORD</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedDWordString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualDWordString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_UINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_UINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> UINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> UINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
         </Local>
         <Local>
           <Name>AlreadyReported</Name>
@@ -9423,19 +11116,25 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_General.TcUnit">ST_ADSLogStringMessage</Name>
-      <BitSize>4096</BitSize>
+      <Name Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Name>
+      <BitSize>4128</BitSize>
+      <SubItem>
+        <Name>MsgCtrlMask</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
       <SubItem>
         <Name>MsgFmtStr</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
         <BitSize>2048</BitSize>
-        <BitOffs>0</BitOffs>
+        <BitOffs>32</BitOffs>
       </SubItem>
       <SubItem>
         <Name>StrArg</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
         <BitSize>2048</BitSize>
-        <BitOffs>2048</BitOffs>
+        <BitOffs>2080</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -9686,33 +11385,107 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_General.TcUnit">FB_ADSLogStringMessageFifoQueue</Name>
+      <Name Namespace="Tc2_Standard">TON</Name>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>IN</Name>
+        <Type>BOOL</Type>
+        <Comment> starts timer with rising edge, resets timer with falling edge </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PT</Name>
+        <Type>TIME</Type>
+        <Comment> time to pass, before Q is set </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> gets TRUE, delay time (PT) after a rising edge at IN </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ET</Name>
+        <Type>TIME</Type>
+        <Comment> elapsed time </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>M</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StartTime</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.TcUnit">FB_AdsLogStringMessageFifoQueue</Name>
       <Comment> This function block is responsible for making sure that the ADSLOGSTR-messages to the ADS-router are transmitted
    cyclically and not in a burst. The reason this is necessary is because that if too many messages are sent at the
    same time some get lost and are never printed to the error list output
 </Comment>
-      <BitSize>4129152</BitSize>
+      <BitSize>8321152</BitSize>
       <SubItem>
         <Name>ArrayBuffer</Name>
         <Type>BYTE</Type>
         <ArrayInfo>
           <LBound>0</LBound>
-          <Elements>516000</Elements>
+          <Elements>1040000</Elements>
         </ArrayInfo>
-        <BitSize>4128000</BitSize>
+        <BitSize>8320000</BitSize>
         <BitOffs>64</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MemRingBuffer</Name>
         <Type Namespace="Tc2_Utilities">FB_MemRingBuffer</Type>
         <BitSize>768</BitSize>
-        <BitOffs>4128064</BitOffs>
+        <BitOffs>8320064</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TimerBetweenMessages</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>256</BitSize>
-        <BitOffs>4128832</BitOffs>
+        <BitOffs>8320832</BitOffs>
         <Default>
           <SubItem>
             <Name>.IN</Name>
@@ -9720,24 +11493,15 @@
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <Value>50</Value>
+            <Value>10</Value>
           </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>RING_BUFFER_SIZE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>4129088</BitOffs>
-        <Default>
-          <Value>1000</Value>
         </Default>
       </SubItem>
       <SubItem>
         <Name>MEM_RING_BUFFER_INTERNAL_USE_PER_DATA_RECORD</Name>
         <Type>USINT</Type>
         <BitSize>8</BitSize>
-        <BitOffs>4129104</BitOffs>
+        <BitOffs>8321088</BitOffs>
         <Default>
           <Value>4</Value>
         </Default>
@@ -9746,9 +11510,9 @@
         <Name>TIME_BETWEEN_MESSAGES</Name>
         <Type>TIME</Type>
         <BitSize>32</BitSize>
-        <BitOffs>4129120</BitOffs>
+        <BitOffs>8321120</BitOffs>
         <Default>
-          <Value>50</Value>
+          <Value>10</Value>
         </Default>
       </SubItem>
       <Method>
@@ -9758,6 +11522,11 @@
       </Method>
       <Method>
         <Name>WriteLog</Name>
+        <Parameter>
+          <Name>MsgCtrlMask</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
         <Parameter>
           <Name>MsgFmtStr</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -9782,16 +11551,16 @@
         </Parameter>
         <Local>
           <Name>AdsLogStringMessage</Name>
-          <Type Namespace="LCLS_General.TcUnit">ST_ADSLogStringMessage</Type>
-          <BitSize>4096</BitSize>
+          <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
         </Local>
       </Method>
       <Method>
-        <Name>GetLog</Name>
+        <Name>GetAndRemoveLogFromQueue</Name>
         <Parameter>
           <Name>AdsLogStringMessage</Name>
-          <Type Namespace="LCLS_General.TcUnit">ST_ADSLogStringMessage</Type>
-          <BitSize>4096</BitSize>
+          <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
           <Properties>
             <Property>
               <Name>ItemType</Name>
@@ -9820,30 +11589,36 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name GUID="{D01709AA-9B4A-464A-B4D1-4BF476CFE7DE}">ST_PMPS_Attenuator_IO</Name>
-      <BitSize>32</BitSize>
+      <Name GUID="{7E016B85-166E-4B4F-AAC4-ECA8DDD44F13}">ST_PMPS_Attenuator_IO</Name>
+      <BitSize>64</BitSize>
       <SubItem>
         <Name>nTran</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
+        <Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
+        <BitSize>32</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
       <SubItem>
         <Name>xAttOK</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>16</BitOffs>
+        <BitOffs>32</BitOffs>
       </SubItem>
       <Hides>
         <Hide GUID="{76269EAC-36F0-4513-B811-3725FD02409A}"/>
         <Hide GUID="{E96BEA56-6301-4A6A-BF6A-F08340C87594}"/>
         <Hide GUID="{FE32F9A9-7E7A-413D-8D77-0C99C34D8CD9}"/>
+        <Hide GUID="{D01709AA-9B4A-464A-B4D1-4BF476CFE7DE}"/>
+        <Hide GUID="{D6F0EA12-B425-4603-9C4B-B4FD442416C3}"/>
+        <Hide GUID="{0FF3CAED-DFFA-453E-8BDC-2F6EE7142B14}"/>
+        <Hide GUID="{AC42932A-79BD-4670-8CF2-1DDEA2EE41C7}"/>
+        <Hide GUID="{EE241488-3DC7-4C48-A9D8-BB32379587BC}"/>
+        <Hide GUID="{EE241488-3DC7-4C48-A9D8-BB32379587BC}"/>
       </Hides>
     </DataType>
     <DataType>
       <Name Namespace="PMPS">ST_PMPS_Attenuator</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType GUID="{D01709AA-9B4A-464A-B4D1-4BF476CFE7DE}">ST_PMPS_Attenuator_IO</ExtendsType>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{7E016B85-166E-4B4F-AAC4-ECA8DDD44F13}">ST_PMPS_Attenuator_IO</ExtendsType>
     </DataType>
     <DataType>
       <Name GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Name>
@@ -9900,22 +11675,24 @@
     </DataType>
     <DataType>
       <Name Namespace="PMPS">ST_BeamParams</Name>
-      <BitSize>1216</BitSize>
+      <BitSize>1760</BitSize>
       <SubItem>
         <Name>nTran</Name>
-        <Type>UINT</Type>
+        <Type>REAL</Type>
         <Comment>  Requested pre-optic attenuation %  </Comment>
-        <BitSize>16</BitSize>
+        <BitSize>32</BitSize>
         <BitOffs>0</BitOffs>
         <Default>
-          <Value>100</Value>
+          <Value>0</Value>
         </Default>
         <Properties>
           <Property>
             <Name>pytmc</Name>
             <Value>pv: Transmission
             io: i
-            field: EGU %
+			field: HOPR 1;
+			field: LOPR 0;
+			field: PREC 2;
         </Value>
           </Property>
         </Properties>
@@ -9927,7 +11704,7 @@
         <BitSize>32</BitSize>
         <BitOffs>32</BitOffs>
         <Default>
-          <Value>120</Value>
+          <Value>0</Value>
         </Default>
         <Properties>
           <Property>
@@ -9940,44 +11717,97 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fPP_mJ</Name>
-        <Type>REAL</Type>
-        <Comment> Per pulse max energy (mJ) </Comment>
+        <Name>neVRange</Name>
+        <Type>DWORD</Type>
+        <Comment> Photon energy ranges </Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
-          <Value>20</Value>
+          <Value>0</Value>
         </Default>
         <Properties>
           <Property>
             <Name>pytmc</Name>
-            <Value>pv: PulseEnergy
-            io: i
-            field: EGU mJ
-            field: DESC This beam parameter is non-op for now.
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>neVRange</Name>
-        <Type>WORD</Type>
-        <Comment> Photon energy ranges </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Default>
-          <Value>65535</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: PhotonEnergyRanges
+            <Value>pv: eVRanges
             io: i
             field: EGU eV</Value>
           </Property>
           <Property>
             <Name>displaymode</Name>
             <Value>binary</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>neV</Name>
+        <Type>REAL</Type>
+        <Comment> Photon energy  </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: PhotonEnergy
+            io: i
+            field: EGU eV</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nBCRange</Name>
+        <Type>WORD</Type>
+        <Comment> Beamclass ranges </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: BeamClassRanges
+            io: i</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>binary</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nBeamClass</Name>
+        <Type>USINT</Type>
+        <Comment> Beamclass </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: BeamClass
+            io: i</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nMachineMode</Name>
+        <Type>USINT</Type>
+        <Comment> Machine Mode </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+        <Default>
+          <Value>3</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: MachineMode
+            io: i</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -9989,8 +11819,8 @@
           <Elements>16</Elements>
         </ArrayInfo>
         <Comment> Beamline attenuators </Comment>
-        <BitSize>512</BitSize>
-        <BitOffs>112</BitOffs>
+        <BitSize>1024</BitSize>
+        <BitOffs>160</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -10000,7 +11830,7 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>aStoppers</Name>
+        <Name>aVetoDevices</Name>
         <Type>BOOL</Type>
         <ArrayInfo>
           <LBound>1</LBound>
@@ -10008,11 +11838,11 @@
         </ArrayInfo>
         <Comment> Stoppers </Comment>
         <BitSize>128</BitSize>
-        <BitOffs>624</BitOffs>
+        <BitOffs>1184</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
-            <Value>pv: ST
+            <Value>pv: Veto
         io: i</Value>
           </Property>
         </Properties>
@@ -10026,21 +11856,62 @@
         </ArrayInfo>
         <Comment> Apertures </Comment>
         <BitSize>384</BitSize>
-        <BitOffs>768</BitOffs>
+        <BitOffs>1312</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>[1].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[1].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[2].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[2].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[3].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[3].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[4].Width</Name>
+            <Value>1000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[4].Height</Name>
+            <Value>1000</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: Apt
+        io: i</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
         <Name>xValidToggle</Name>
         <Type>BOOL</Type>
         <Comment> Toggle for watchdog</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>1152</BitOffs>
+        <BitOffs>1696</BitOffs>
       </SubItem>
       <SubItem>
         <Name>xValid</Name>
         <Type>BOOL</Type>
         <Comment> Beam parameter set is valid (if readback), or acknowledged (if request)</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>1160</BitOffs>
+        <BitOffs>1704</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -10054,7 +11925,7 @@
         <Type>UDINT</Type>
         <Comment> Cohort index. Identifies which cohort this BP set was included in arbitration</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>1184</BitOffs>
+        <BitOffs>1728</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -10080,7 +11951,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_General.Tc3_JsonXml">FB_JsonSaxWriter</Name>
+      <Name Namespace="Tc3_JsonXml">FB_JsonSaxWriter</Name>
       <Comment> | Provides the functionality to create a JSON document.
  | Steps of documentation creation:
  | 1. StartObject() to start a new object in the document.
@@ -10094,6 +11965,9 @@
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
+        <Default>
+          <Value>-1743714536</Value>
+        </Default>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -10275,6 +12149,8 @@
       </Method>
       <Method>
         <Name>ResetDocument</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>AddKeyLreal</Name>
@@ -10297,11 +12173,24 @@
       </Method>
       <Method>
         <Name>StartObject</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>GetDocumentLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
         <Local>
           <Name>n</Name>
           <Type>UDINT</Type>
@@ -10356,6 +12245,8 @@
       </Method>
       <Method>
         <Name>SetMaxDecimalPlaces</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>decimalPlaces</Name>
           <Type>DINT</Type>
@@ -10400,6 +12291,17 @@
         <Name>GetDocument</Name>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">SINT</Type>
@@ -10481,6 +12383,17 @@
           <Comment> size in bytes of the target string buffer</Comment>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -10576,12 +12489,18 @@
       </Method>
       <Method>
         <Name>EndArray</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>EndObject</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>StartArray</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>AddReal</Name>
@@ -12066,6 +13985,7 @@
       <SubItem>
         <Name>CREATETAB</Name>
         <Type>UDINT</Type>
+        <Comment> create table</Comment>
         <BitSize>32</BitSize>
         <BitOffs>0</BitOffs>
         <Default>
@@ -12075,6 +13995,7 @@
       <SubItem>
         <Name>CREATEMOTIONTAB</Name>
         <Type>UDINT</Type>
+        <Comment> create motion function table</Comment>
         <BitSize>32</BitSize>
         <BitOffs>32</BitOffs>
         <Default>
@@ -12084,6 +14005,7 @@
       <SubItem>
         <Name>DELETETAB</Name>
         <Type>UDINT</Type>
+        <Comment> delete tables </Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
@@ -12092,7 +14014,7 @@
       </SubItem>
       <Properties>
         <Property>
-          <Name>hide</Name>
+          <Name>conditionalshow</Name>
         </Property>
       </Properties>
     </DataType>
@@ -12283,10 +14205,12 @@
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_TCMCGLOBAL</Name>
+      <Comment>	Global constants and parameters </Comment>
       <BitSize>7104</BitSize>
       <SubItem>
         <Name>NCPORT_TCMC</Name>
         <Type>UINT</Type>
+        <Comment> 20110511 type changed from INT to UINT </Comment>
         <BitSize>16</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
@@ -12302,6 +14226,7 @@
       <SubItem>
         <Name>NCPORT_TCMC_COUPLING</Name>
         <Type>UINT</Type>
+        <Comment> 20110511 type changed from INT to UINT </Comment>
         <BitSize>16</BitSize>
         <BitOffs>80</BitOffs>
         <Default>
@@ -12332,6 +14257,7 @@
       <SubItem>
         <Name>NCPORT_TCMC_CAM</Name>
         <Type>UINT</Type>
+        <Comment> 20110511 type changed from INT to UINT </Comment>
         <BitSize>16</BitSize>
         <BitOffs>288</BitOffs>
         <Default>
@@ -12347,6 +14273,7 @@
       <SubItem>
         <Name>NCPORT_TCMC_CAM_FAST</Name>
         <Type>UINT</Type>
+        <Comment> 20150728 KSt added </Comment>
         <BitSize>16</BitSize>
         <BitOffs>304</BitOffs>
         <Default>
@@ -12377,10 +14304,27 @@
       <SubItem>
         <Name>NCPORT_TCMC_SUPERPOSITION</Name>
         <Type>UINT</Type>
+        <Comment> 20140930 KSt added </Comment>
         <BitSize>16</BitSize>
         <BitOffs>512</BitOffs>
         <Default>
           <Value>501</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>NCPORT_TCMC_RESET</Name>
+        <Type>UINT</Type>
+        <Comment> 20211019 KSt added </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>528</BitOffs>
+        <Default>
+          <Value>500</Value>
         </Default>
         <Properties>
           <Property>
@@ -12452,6 +14396,7 @@
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2">_ST_NCADS_Axis</Type>
+        <Comment> IDXGRP and IDXOFFS constants of axis parameter/status/functions </Comment>
         <BitSize>4320</BitSize>
         <BitOffs>832</BitOffs>
         <Properties>
@@ -12468,6 +14413,7 @@
       <SubItem>
         <Name>Table</Name>
         <Type Namespace="Tc2_MC2">_ST_NCADS_Table</Type>
+        <Comment> IDXGRP and IDXOFFS constants of table parameter/status/functions </Comment>
         <BitSize>352</BitSize>
         <BitOffs>5152</BitOffs>
         <Properties>
@@ -12553,7 +14499,7 @@
           <Value>FunctionBlock</Value>
         </Property>
         <Property>
-          <Name>hide</Name>
+          <Name>conditionalshow</Name>
         </Property>
       </Properties>
     </DataType>
@@ -14285,7 +16231,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">ST_DriveAddress</Name>
-      <BitSize>640</BitSize>
+      <BitSize>672</BitSize>
       <SubItem>
         <Name>NetID</Name>
         <Type Namespace="Tc2_System">T_AmsNetID</Type>
@@ -14394,10 +16340,33 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>608</BitOffs>
       </SubItem>
+      <SubItem>
+        <Name>TcAxisObjectId</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">_E_PhasingState</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>PhasingInactive</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhasingActivated</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhasingAborted</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_InternalAxisRefData</Name>
-      <BitSize>96</BitSize>
+      <BitSize>128</BitSize>
       <SubItem>
         <Name>NcCycleCounterAvailable</Name>
         <Type>BOOL</Type>
@@ -14426,6 +16395,13 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>80</BitOffs>
       </SubItem>
+      <SubItem>
+        <Name>PhasingState</Name>
+        <Type Namespace="Tc2_MC2">_E_PhasingState</Type>
+        <Comment> KSt 20190703 global handshake for phasing blocks</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
       <Properties>
         <Property>
           <Name>conditionalshow</Name>
@@ -14444,7 +16420,7 @@ External Setpoint Generation:
 	The user is supposed to use the AXIS_REF data type which internally
 	redirects the type to this function block definition (alias).
 </Comment>
-      <BitSize>9024</BitSize>
+      <BitSize>9088</BitSize>
       <SubItem>
         <Name>PlcToNc</Name>
         <Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</Type>
@@ -14504,7 +16480,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>DriveAddress</Name>
         <Type Namespace="Tc2_MC2">ST_DriveAddress</Type>
-        <BitSize>640</BitSize>
+        <BitSize>672</BitSize>
         <BitOffs>4160</BitOffs>
         <Properties>
           <Property>
@@ -14516,8 +16492,8 @@ External Setpoint Generation:
       <SubItem>
         <Name>_internal</Name>
         <Type Namespace="Tc2_MC2">_InternalAxisRefData</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>4800</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>4832</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -14532,7 +16508,7 @@ External Setpoint Generation:
           <Elements>128</Elements>
         </ArrayInfo>
         <BitSize>4096</BitSize>
-        <BitOffs>4896</BitOffs>
+        <BitOffs>4960</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -14551,6 +16527,73 @@ External Setpoint Generation:
           <Name>conditionalshow_all_locals</Name>
         </Property>
       </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">DUT_EPS</Name>
+      <BitSize>1344</BitSize>
+      <SubItem>
+        <Name>nFlags</Name>
+        <Type>UDINT</Type>
+        <Comment> Contains EPS flags</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>4294967295</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: nFlags
+        io: i
+        field: DESC Contains EPS flags
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sFlagDesc</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Desciption of values nFlags contains</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: sFlagDesc
+        io: i
+        field: DESC of nFlag variable, using </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Name to use for log messages.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>680</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: sMessage
+        io: i
+        field: DESC Message from EPS to usr
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEPS_OK</Name>
+        <Type>BOOL</Type>
+        <Comment> Keep Track if nFlags are all true</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1328</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
     </DataType>
     <DataType>
       <Name>ENUM_StageEnableMode</Name>
@@ -14639,7 +16682,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>nAxisType</Name>
-        <Type>DWORD</Type>
+        <Type Namespace="Tc2_MC2">E_NcAxisType</Type>
         <Comment> 0x00000003 </Comment>
         <BitSize>32</BitSize>
         <BitOffs>32</BitOffs>
@@ -14842,7 +16885,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>nEncType</Name>
-        <Type>DWORD</Type>
+        <Type Namespace="Tc2_MC2">E_NcEncoderType</Type>
         <Comment> 0x00010003 </Comment>
         <BitSize>32</BitSize>
         <BitOffs>2080</BitOffs>
@@ -15101,7 +17144,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>nDriveType</Name>
-        <Type>DWORD</Type>
+        <Type Namespace="Tc2_MC2">E_NcDriveType</Type>
         <Comment> 0x00030003 </Comment>
         <BitSize>32</BitSize>
         <BitOffs>4256</BitOffs>
@@ -15338,13 +17381,13 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name>DUT_MotionStage</Name>
-      <BitSize>21056</BitSize>
+      <BitSize>25280</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2">AXIS_REF</Type>
         <Comment> Hardware 
  PLC Axis Reference</Comment>
-        <BitSize>9024</BitSize>
+        <BitSize>9088</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
       <SubItem>
@@ -15352,7 +17395,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9024</BitOffs>
+        <BitOffs>9088</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15375,7 +17418,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9032</BitOffs>
+        <BitOffs>9096</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15398,7 +17441,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> NO Home Switch: TRUE if at home</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9040</BitOffs>
+        <BitOffs>9104</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15421,7 +17464,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> NC Brake Output: TRUE to release brake</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9048</BitOffs>
+        <BitOffs>9112</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15444,7 +17487,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> NC STO Input: TRUE if ok to move</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9056</BitOffs>
+        <BitOffs>9120</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15467,7 +17510,7 @@ External Setpoint Generation:
         <Type>ULINT</Type>
         <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>9088</BitOffs>
+        <BitOffs>9152</BitOffs>
         <Properties>
           <Property>
             <Name>TcAddressType</Name>
@@ -15480,7 +17523,7 @@ External Setpoint Generation:
         <Type>UINT</Type>
         <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9152</BitOffs>
+        <BitOffs>9216</BitOffs>
         <Properties>
           <Property>
             <Name>TcAddressType</Name>
@@ -15493,7 +17536,7 @@ External Setpoint Generation:
         <Type>INT</Type>
         <Comment> Raw encoder IO for INT (LVDT)</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9168</BitOffs>
+        <BitOffs>9232</BitOffs>
         <Properties>
           <Property>
             <Name>TcAddressType</Name>
@@ -15507,7 +17550,7 @@ External Setpoint Generation:
         <Comment> Psuedo-hardware 
  Forward enable EPS summary</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9184</BitOffs>
+        <BitOffs>9248</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15529,7 +17572,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Backward enable EPS summary</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9192</BitOffs>
+        <BitOffs>9256</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15551,7 +17594,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Enable EPS summary encapsulating emergency stop button and any additional motion preventive hardware</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9200</BitOffs>
+        <BitOffs>9264</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15573,7 +17616,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Forward virtual gantry limit switch</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9208</BitOffs>
+        <BitOffs>9272</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15595,7 +17638,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Backward virtual gantry limit switch</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9216</BitOffs>
+        <BitOffs>9280</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15617,7 +17660,7 @@ External Setpoint Generation:
         <Type>UDINT</Type>
         <Comment> Encoder count summary, if linked above</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>9248</BitOffs>
+        <BitOffs>9312</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15630,12 +17673,63 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>stEPSForwardEnable</Name>
+        <Type Namespace="LCLS_General">DUT_EPS</Type>
+        <Comment> Forward Enable EPS struct</Comment>
+        <BitSize>1344</BitSize>
+        <BitOffs>9344</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:stEPSForwardEnable
+        io: i
+        field: DESC Forward Enable Interlocks
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEPSBackwardEnable</Name>
+        <Type Namespace="LCLS_General">DUT_EPS</Type>
+        <Comment> Backward Enable EPS struct</Comment>
+        <BitSize>1344</BitSize>
+        <BitOffs>10688</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:stEPSBackwardEnable
+        io: i
+        field: DESC Backward Enable Interlocks
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEPSPowerEnable</Name>
+        <Type Namespace="LCLS_General">DUT_EPS</Type>
+        <Comment> Power Enable EPS struct</Comment>
+        <BitSize>1344</BitSize>
+        <BitOffs>12032</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:stEPSPowerEnable
+        io: i
+        field: DESC Power Interlocks
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>sName</Name>
         <Type>STRING(80)</Type>
         <Comment> Settings 
  Name to use for log messages, fast faults, etc.</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>9280</BitOffs>
+        <BitOffs>13376</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15652,7 +17746,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> If TRUE, we want to enable the motor independently of PMPS or other safety systems.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9928</BitOffs>
+        <BitOffs>14024</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15674,7 +17768,7 @@ External Setpoint Generation:
         <Type>ENUM_StageEnableMode</Type>
         <Comment> Determines when we automatically enable the motor</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9936</BitOffs>
+        <BitOffs>14032</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -15694,7 +17788,7 @@ External Setpoint Generation:
         <Type>ENUM_StageBrakeMode</Type>
         <Comment> Determines when we automatically disengage the brake</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9952</BitOffs>
+        <BitOffs>14048</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15714,7 +17808,7 @@ External Setpoint Generation:
         <Type>ENUM_EpicsHomeCmd</Type>
         <Comment> Determines our encoder homing strategy</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9968</BitOffs>
+        <BitOffs>14064</BitOffs>
         <Default>
           <Value>-1</Value>
         </Default>
@@ -15734,7 +17828,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Set true to activate gantry EPS</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9984</BitOffs>
+        <BitOffs>14080</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15756,7 +17850,7 @@ External Setpoint Generation:
         <Type>LINT</Type>
         <Comment> Set to gantry difference tolerance</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10048</BitOffs>
+        <BitOffs>14144</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15766,7 +17860,7 @@ External Setpoint Generation:
         <Type>ULINT</Type>
         <Comment> Encoder count at which this axis is aligned with other axis</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10112</BitOffs>
+        <BitOffs>14208</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15777,7 +17871,7 @@ External Setpoint Generation:
         <Comment> Commands 
  Used internally to request enables</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10176</BitOffs>
+        <BitOffs>14272</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15796,7 +17890,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Used internally to reset errors and other state</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10184</BitOffs>
+        <BitOffs>14280</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15815,7 +17909,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Used internally and by the IOC to start or stop a move</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10192</BitOffs>
+        <BitOffs>14288</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15830,12 +17924,69 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>bUserEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Used by the IOC to disable an axis</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>14296</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bUserEnable
+        io: io
+        field: ZNAM DISABLE
+        field: ONAM ENABLE
+        field: DESC Used to disable power entirely for an axis
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveCmd</Name>
+        <Type>BOOL</Type>
+        <Comment> Shortcut Commands 
+ Start a move to fPosition with fVelocity</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>14304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bMoveCmd
+        io: io
+        field: DESC Start a move
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHomeCmd</Name>
+        <Type>BOOL</Type>
+        <Comment> Start the homing routine</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>14312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bHomeCmd
+        io: io
+        field: DESC Start the homing routine
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>nCommand</Name>
         <Type>INT</Type>
         <Comment> Command Args 
  Used internally and by the IOC to pick what kind of move to do</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>10208</BitOffs>
+        <BitOffs>14320</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15852,7 +18003,7 @@ External Setpoint Generation:
         <Type>INT</Type>
         <Comment> Used internally and by the IOC to pass additional data to some commands</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>10224</BitOffs>
+        <BitOffs>14336</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15869,7 +18020,7 @@ External Setpoint Generation:
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a destination for the move</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10240</BitOffs>
+        <BitOffs>14400</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15886,7 +18037,7 @@ External Setpoint Generation:
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a move velocity</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10304</BitOffs>
+        <BitOffs>14464</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15903,7 +18054,7 @@ External Setpoint Generation:
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a move acceleration</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10368</BitOffs>
+        <BitOffs>14528</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15920,7 +18071,7 @@ External Setpoint Generation:
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a move deceleration</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10432</BitOffs>
+        <BitOffs>14592</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15937,7 +18088,7 @@ External Setpoint Generation:
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a home position</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10496</BitOffs>
+        <BitOffs>14656</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -15955,7 +18106,7 @@ External Setpoint Generation:
         <Comment> Info 
  Unique ID assigned to each axis in the NC</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>10560</BitOffs>
+        <BitOffs>14720</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15976,15 +18127,15 @@ External Setpoint Generation:
         <Comment> Returns 
  TRUE if done enabling</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10592</BitOffs>
+        <BitOffs>14752</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
             <Value>
         pv: PLC:bEnableDone
         io: i
-        field: ONAM FALSE
-        field: ZNAM TRUE
+        field: ZNAM FALSE
+        field: ONAM TRUE
         field: DESC TRUE if done enabling
     </Value>
           </Property>
@@ -15995,15 +18146,15 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> TRUE if in the middle of a command</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10600</BitOffs>
+        <BitOffs>14760</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
             <Value>
         pv: PLC:bBusy
         io: i
-        field: ONAM FALSE
-        field: ZNAM TRUE
+        field: ZNAM FALSE
+        field: ONAM TRUE
         field: DESC TRUE if in the middle of a command
     </Value>
           </Property>
@@ -16014,16 +18165,33 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> TRUE if we've done a command and it has finished</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10608</BitOffs>
+        <BitOffs>14768</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
             <Value>
         pv: PLC:bDone
         io: i
-        field: ONAM FALSE
-        field: ZNAM TRUE
+        field: ZNAM FALSE
+        field: ONAM TRUE
         field: DESC TRUE if command finished successfully
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHomed</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if the motor has been homed, or does not need to be homed</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>14776</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bHomed
+        io: i
+        field: DESC TRUE if the motor has been homed
     </Value>
           </Property>
         </Properties>
@@ -16033,15 +18201,15 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> TRUE if we have safety permission to move</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10616</BitOffs>
+        <BitOffs>14784</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
             <Value>
         pv: PLC:bSafetyReady
         io: i
-        field: ONAM FALSE
-        field: ZNAM TRUE
+        field: ZNAM FALSE
+        field: ONAM TRUE
         field: DESC TRUE if safe to start a move
     </Value>
           </Property>
@@ -16052,16 +18220,18 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> TRUE if we're in an error state</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10624</BitOffs>
+        <BitOffs>14792</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
             <Value>
         pv: PLC:bError
         io: i
-        field: ONAM FALSE
-        field: ZNAM TRUE
-        field: DESC TRUE if we</Value>
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if we are in an error state
+        update: 100Hz notify
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -16070,7 +18240,7 @@ External Setpoint Generation:
         <Type>UDINT</Type>
         <Comment> Error code if nonzero</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>10656</BitOffs>
+        <BitOffs>14816</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -16078,6 +18248,7 @@ External Setpoint Generation:
         pv: PLC:nErrorId
         io: i
         field: DESC Error code if nonzero
+        update: 100Hz notify
     </Value>
           </Property>
         </Properties>
@@ -16087,7 +18258,7 @@ External Setpoint Generation:
         <Type>STRING(80)</Type>
         <Comment> Message to identify the error state</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>10688</BitOffs>
+        <BitOffs>14848</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -16095,6 +18266,7 @@ External Setpoint Generation:
         pv: PLC:sErrorMessage
         io: i
         field: DESC Message to identify the error state
+        update: 100Hz notify
     </Value>
           </Property>
         </Properties>
@@ -16104,28 +18276,46 @@ External Setpoint Generation:
         <Type>STRING(80)</Type>
         <Comment> Internal hook for custom error messages</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>11336</BitOffs>
+        <BitOffs>15496</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stAxisParameters</Name>
         <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
         <Comment> MC_ReadParameterSet Output</Comment>
         <BitSize>8192</BitSize>
-        <BitOffs>12032</BitOffs>
+        <BitOffs>16192</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bAxisParamsInit</Name>
         <Type>BOOL</Type>
         <Comment> True if we've updated stAxisParameters at least once</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>20224</BitOffs>
+        <BitOffs>24384</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stAxisStatus</Name>
         <Type>DUT_AxisStatus_v0_01</Type>
         <Comment> Misc axis status information for the IOC</Comment>
         <BitSize>768</BitSize>
-        <BitOffs>20288</BitOffs>
+        <BitOffs>24448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fPosDiff</Name>
+        <Type>LREAL</Type>
+        <Comment> Other status information for users of the IOC 
+ Position lag difference</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>25216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:fPosDiff
+        io: i
+        field: DESC Position lag difference
+    </Value>
+          </Property>
+        </Properties>
       </SubItem>
     </DataType>
     <DataType>
@@ -16644,7 +18834,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">ST_MoveOptions</Name>
-      <BitSize>256</BitSize>
+      <BitSize>320</BitSize>
       <SubItem>
         <Name>EnableBlendingPosition</Name>
         <Type>BOOL</Type>
@@ -16671,6 +18861,22 @@ External Setpoint Generation:
         <BitSize>64</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
+      <SubItem>
+        <Name>IgnorePositionMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> PositionAreaMonitoring, TargetPositionMonitoring and StopMonitoring can be ignored using this flag - 20190311 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>EnableStopPositionMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> PositionAreaMonitoring, TargetPositionMonitoring can be enabled for MC_Stop and MC_Halt commands - 20191010 
+ Monitoring can just be enabled if the monitoring parameters of the axis are enabled as well 
+ The default is no monitoring for both commands even if monitoring options are enabled by axis parameters </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>264</BitOffs>
+      </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_E_TcNC_StartPosType</Name>
@@ -16679,83 +18885,119 @@ External Setpoint Generation:
       <EnumInfo>
         <Text>TCNC_START_ABSOLUTE</Text>
         <Enum>1</Enum>
+        <Comment>Start to absolute position</Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_RELATIVE</Text>
         <Enum>2</Enum>
+        <Comment>Start to relative position</Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESS_PLUS</Text>
         <Enum>3</Enum>
+        <Comment>Start to endless positive position</Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESS_MINUS</Text>
         <Enum>4</Enum>
+        <Comment>Start to endless negative position</Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_MODULO</Text>
         <Enum>5</Enum>
+        <Comment>Start to modulo position </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ADDITIVE</Text>
         <Enum>6</Enum>
+        <Comment>Start to a position relative to the last recent target position </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_MODULO_SHORT</Text>
         <Enum>261</Enum>
+        <Comment>Start to modulo position </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_MODULO_PLUS</Text>
         <Enum>517</Enum>
+        <Comment>Start to modulo position </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_MODULO_MINUS</Text>
         <Enum>773</Enum>
+        <Comment>Start to modulo position </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_MODULO_CURRENT</Text>
         <Enum>1029</Enum>
+        <Comment> start to modulo position in current direction </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ABS_INTERNAL</Text>
         <Enum>9</Enum>
+        <Comment>Start to absolute position, internal use</Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESSPLUS_SLOWMANUAL</Text>
         <Enum>272</Enum>
+        <Comment> manual jog mode </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESSMINUS_SLOWMANUAL</Text>
         <Enum>273</Enum>
+        <Comment> manual jog mode </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESSPLUS_FASTMANUAL</Text>
         <Enum>528</Enum>
+        <Comment> manual jog mode </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_ENDLESSMINUS_FASTMANUAL</Text>
         <Enum>529</Enum>
+        <Comment> manual jog mode </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_STOPANDLOCK</Text>
         <Enum>4096</Enum>
+        <Comment> stop axis and lock against any motion commands </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_HALT</Text>
         <Enum>8192</Enum>
+        <Comment> halt axis - can be interrupted by any motion commands </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_TORQUE_ABORT</Text>
         <Enum>12288</Enum>
+        <Comment> 20181210 Fap - halt torque control </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_TORQUE_ABSOLUTE</Text>
         <Enum>12289</Enum>
+        <Comment> 20181210 Fap - Start torque control absolute </Comment>
       </EnumInfo>
       <EnumInfo>
         <Text>TCNC_START_TORQUE_RELATIVE</Text>
         <Enum>12290</Enum>
+        <Comment> 20190108 Fap - Start torque control relative NOT IMPLEMENTED </Comment>
       </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_TorqueControlOptions</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>EnableManualTorqueStartValue</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ManualTorqueStartValue</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_ST_TcNC_UnversalAxisStartRequest</Name>
@@ -16843,6 +19085,92 @@ External Setpoint Generation:
         <Comment> optional: end velocity		(0 &lt;= fVeloEnd &lt;= fVeloRequ)	Frage: erstmal weglassen ??? </Comment>
         <BitSize>64</BitSize>
         <BitOffs>576</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">_ST_TcNC_UniversalAxisTorqueStartRequest</Name>
+      <BitSize>576</BitSize>
+      <SubItem>
+        <Name>nStartType</Name>
+        <Type>UDINT</Type>
+        <Comment> axis start TYPE (TORQUECONTINUOUS) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nControlMask</Name>
+        <Type>UDINT</Type>
+        <Comment> optional: control mask </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nMode</Name>
+        <Type>UDINT</Type>
+        <Comment> optional: mode (ENUM) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nBufferMode</Name>
+        <Type>UDINT</Type>
+        <Comment> 'buffer mode' OR 'activation mode' FOR 'buffered commands' (first Only ABORTING) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTorque</Name>
+        <Type>LREAL</Type>
+        <Comment> target torque [signed]</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTorqueRamp</Name>
+        <Type>LREAL</Type>
+        <Comment> nc torque ramp </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVelocityLimitHigh</Name>
+        <Type>LREAL</Type>
+        <Comment> velocity limit high [signed]</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVelocityLimitLow</Name>
+        <Type>LREAL</Type>
+        <Comment> velocity limit low [signed]</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fAcceleration</Name>
+        <Type>LREAL</Type>
+        <Comment> acceleration (&gt;= 0) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDeceleration</Name>
+        <Type>LREAL</Type>
+        <Comment> deceleration (&gt;= 0) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fManualTorque</Name>
+        <Type>LREAL</Type>
+        <Comment> optional: manual torque (sync value) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -16966,6 +19294,9 @@ External Setpoint Generation:
             <Name>ItemType</Name>
             <Value>Input</Value>
           </Property>
+          <Property>
+            <Name>TcIgnorePersistent</Name>
+          </Property>
         </Properties>
       </SubItem>
       <SubItem>
@@ -16978,6 +19309,9 @@ External Setpoint Generation:
           <Property>
             <Name>ItemType</Name>
             <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>TcIgnorePersistent</Name>
           </Property>
         </Properties>
       </SubItem>
@@ -17150,10 +19484,11 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Name>
-      <BitSize>7296</BitSize>
+      <BitSize>8448</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -17190,6 +19525,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>StartType</Name>
         <Type Namespace="Tc2_MC2">_E_TcNC_StartPosType</Type>
+        <Comment> 20110511 KSt type changed for Tc3 </Comment>
         <BitSize>16</BitSize>
         <BitOffs>208</BitOffs>
         <Properties>
@@ -17212,7 +19548,7 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>Velocity</Name>
+        <Name>Torque</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
         <BitOffs>320</BitOffs>
@@ -17224,7 +19560,7 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>Acceleration</Name>
+        <Name>TorqueRamp</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
         <BitOffs>384</BitOffs>
@@ -17236,7 +19572,7 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>Deceleration</Name>
+        <Name>Velocity</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
         <BitOffs>448</BitOffs>
@@ -17248,7 +19584,7 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>Jerk</Name>
+        <Name>VelocityLimitHigh</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
         <BitOffs>512</BitOffs>
@@ -17260,10 +19596,60 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>VelocityLimitLow</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Acceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Deceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Jerk</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>BufferMode</Name>
         <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
+        <Comment>	Direction			:	MC_Direction := MC_Positive_Direction;	
+ E </Comment>
         <BitSize>16</BitSize>
-        <BitOffs>576</BitOffs>
+        <BitOffs>832</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17274,8 +19660,20 @@ External Setpoint Generation:
       <SubItem>
         <Name>Options</Name>
         <Type Namespace="Tc2_MC2">ST_MoveOptions</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>640</BitOffs>
+        <BitSize>320</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>OptionsTorque</Name>
+        <Type Namespace="Tc2_MC2">ST_TorqueControlOptions</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1216</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17286,8 +19684,9 @@ External Setpoint Generation:
       <SubItem>
         <Name>Reset</Name>
         <Type>BOOL</Type>
+        <Comment> for internal use only </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitOffs>1344</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17298,8 +19697,22 @@ External Setpoint Generation:
       <SubItem>
         <Name>GotoRunState</Name>
         <Type>BOOL</Type>
+        <Comment> for internal use only </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>904</BitOffs>
+        <BitOffs>1352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ContinuousUpdate</Name>
+        <Type>BOOL</Type>
+        <Comment> for internal use only (TorqueControl) </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1360</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17310,8 +19723,9 @@ External Setpoint Generation:
       <SubItem>
         <Name>Done</Name>
         <Type>BOOL</Type>
+        <Comment> Same meaning as InVelocity for continous motion commands </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>912</BitOffs>
+        <BitOffs>1368</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17323,7 +19737,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>920</BitOffs>
+        <BitOffs>1376</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17335,7 +19749,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>928</BitOffs>
+        <BitOffs>1384</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17347,7 +19761,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>936</BitOffs>
+        <BitOffs>1392</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17359,7 +19773,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>944</BitOffs>
+        <BitOffs>1400</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17371,7 +19785,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>960</BitOffs>
+        <BitOffs>1408</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17387,7 +19801,7 @@ External Setpoint Generation:
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>992</BitOffs>
+        <BitOffs>1440</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17399,7 +19813,19 @@ External Setpoint Generation:
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1008</BitOffs>
+        <BitOffs>1456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>InTorque</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1464</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17411,7 +19837,7 @@ External Setpoint Generation:
         <Name>iState</Name>
         <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
         <BitSize>16</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitOffs>1472</BitOffs>
         <Default>
           <Value>100</Value>
         </Default>
@@ -17420,175 +19846,199 @@ External Setpoint Generation:
         <Name>sStartRequest</Name>
         <Type Namespace="Tc2_MC2">_ST_TcNC_UnversalAxisStartRequest</Type>
         <BitSize>640</BitSize>
-        <BitOffs>1088</BitOffs>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sTorqueStartRequest</Name>
+        <Type Namespace="Tc2_MC2">_ST_TcNC_UniversalAxisTorqueStartRequest</Type>
+        <BitSize>576</BitSize>
+        <BitOffs>2176</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sStartResponse</Name>
         <Type Namespace="Tc2_MC2">_ST_TcNC_UnversalAxisStartResponse</Type>
         <BitSize>32</BitSize>
-        <BitOffs>1728</BitOffs>
+        <BitOffs>2752</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbAdsReadWrite</Name>
         <Type Namespace="Tc2_System">ADSRDWRTEX</Type>
         <BitSize>1792</BitSize>
-        <BitOffs>1792</BitOffs>
+        <BitOffs>2816</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ContinousMode</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3584</BitOffs>
+        <BitOffs>4608</BitOffs>
       </SubItem>
       <SubItem>
         <Name>InVelocity</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3592</BitOffs>
+        <BitOffs>4616</BitOffs>
       </SubItem>
       <SubItem>
         <Name>DiffCycleCounter</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>3616</BitOffs>
+        <BitOffs>4640</BitOffs>
       </SubItem>
       <SubItem>
         <Name>EmptyStartResponse</Name>
         <Type Namespace="Tc2_MC2">_ST_TcNC_UnversalAxisStartResponse</Type>
         <BitSize>32</BitSize>
-        <BitOffs>3648</BitOffs>
+        <BitOffs>4672</BitOffs>
       </SubItem>
       <SubItem>
         <Name>COUNT_R</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>3680</BitOffs>
+        <BitOffs>4704</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CounterCmdNoZero</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3712</BitOffs>
+        <BitOffs>4736</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CounterCmdNotStarted</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3720</BitOffs>
+        <BitOffs>4744</BitOffs>
       </SubItem>
       <SubItem>
         <Name>DiffCmdNo</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>3728</BitOffs>
+        <BitOffs>4752</BitOffs>
       </SubItem>
       <SubItem>
         <Name>InitialNcToPlcCmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>3744</BitOffs>
+        <BitOffs>4768</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NcCycleCounter</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3760</BitOffs>
+        <BitOffs>4784</BitOffs>
       </SubItem>
       <SubItem>
         <Name>LastNcCycleCounter</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3768</BitOffs>
+        <BitOffs>4792</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NcMappingCounter</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3776</BitOffs>
+        <BitOffs>4800</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NcCycleCounterAvailable</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3784</BitOffs>
+        <BitOffs>4808</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NcCycleCounterNotAvailable</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3792</BitOffs>
+        <BitOffs>4816</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NcCyclicFeedbackExpected</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3800</BitOffs>
+        <BitOffs>4824</BitOffs>
       </SubItem>
       <SubItem>
         <Name>PlcDebugCode</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>3808</BitOffs>
+        <BitOffs>4832</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AxisIsSlave</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3840</BitOffs>
+        <BitOffs>4864</BitOffs>
       </SubItem>
       <SubItem>
         <Name>GetTaskIndex</Name>
         <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
         <BitSize>256</BitSize>
-        <BitOffs>3904</BitOffs>
+        <BitOffs>4928</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CycleCounter</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>4160</BitOffs>
+        <BitOffs>5184</BitOffs>
       </SubItem>
       <SubItem>
         <Name>BusyCounter</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>4192</BitOffs>
+        <BitOffs>5216</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbTimeOut</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>256</BitSize>
-        <BitOffs>4224</BitOffs>
+        <BitOffs>5248</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbStopMonitoringTimeOut</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>256</BitSize>
-        <BitOffs>4480</BitOffs>
+        <BitOffs>5504</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbTimeOutMappingCounter</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>256</BitSize>
-        <BitOffs>4736</BitOffs>
+        <BitOffs>5760</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbOnTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>4992</BitOffs>
+        <BitOffs>6016</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sTempMsg</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <BitOffs>5088</BitOffs>
+        <BitOffs>6112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AccDecreasing</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AccOld</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>8192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iContinuousUpdate</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>OpMode</Name>
         <Type Namespace="Tc2_MC2">_ST_TcNc_OperationModes</Type>
         <BitSize>128</BitSize>
-        <BitOffs>7136</BitOffs>
+        <BitOffs>8288</BitOffs>
         <Properties>
           <Property>
             <Name>suppress_warning_0</Name>
@@ -17597,22 +20047,28 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <Action>
+        <Name>ActMonitorStop</Name>
+      </Action>
+      <Action>
+        <Name>ActMonitorAbortTorque</Name>
+      </Action>
+      <Action>
         <Name>ActMonitorContinousMotion</Name>
-      </Action>
-      <Action>
-        <Name>ActErrorMessage</Name>
-      </Action>
-      <Action>
-        <Name>ActNcCycleCounter</Name>
       </Action>
       <Action>
         <Name>ActMonitorDiscreteMotion</Name>
       </Action>
       <Action>
-        <Name>ActMonitorStop</Name>
+        <Name>ActErrorMessage</Name>
+      </Action>
+      <Action>
+        <Name>ActMonitorContinuousTorque</Name>
       </Action>
       <Action>
         <Name>ActCalcDiffCmdNo</Name>
+      </Action>
+      <Action>
+        <Name>ActNcCycleCounter</Name>
       </Action>
       <Properties>
         <Property>
@@ -17620,13 +20076,13 @@ External Setpoint Generation:
           <Value>FunctionBlock</Value>
         </Property>
         <Property>
-          <Name>hide</Name>
+          <Name>conditionalshow</Name>
         </Property>
       </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_Halt</Name>
-      <BitSize>8256</BitSize>
+      <BitSize>9472</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -17692,7 +20148,7 @@ External Setpoint Generation:
         <Name>Options</Name>
         <Type Namespace="Tc2_MC2">ST_MoveOptions</Type>
         <Comment> optional parameters </Comment>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>384</BitOffs>
         <Properties>
           <Property>
@@ -17705,7 +20161,7 @@ External Setpoint Generation:
         <Name>Done</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>640</BitOffs>
+        <BitOffs>704</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17717,7 +20173,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>648</BitOffs>
+        <BitOffs>712</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17729,7 +20185,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>656</BitOffs>
+        <BitOffs>720</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17741,7 +20197,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>664</BitOffs>
+        <BitOffs>728</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17753,7 +20209,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>672</BitOffs>
+        <BitOffs>736</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17765,7 +20221,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>704</BitOffs>
+        <BitOffs>768</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17781,25 +20237,25 @@ External Setpoint Generation:
         <Name>LastExecutionResult</Name>
         <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>736</BitOffs>
+        <BitOffs>800</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>896</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitSize>8448</BitSize>
+        <BitOffs>960</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8192</BitOffs>
+        <BitOffs>9408</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -17865,7 +20321,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_MoveVelocity</Name>
-      <BitSize>8384</BitSize>
+      <BitSize>9600</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -17971,7 +20427,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>Options</Name>
         <Type Namespace="Tc2_MC2">ST_MoveOptions</Type>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>512</BitOffs>
         <Properties>
           <Property>
@@ -17985,7 +20441,7 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Commanded velocity reached </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>768</BitOffs>
+        <BitOffs>832</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -17997,7 +20453,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>776</BitOffs>
+        <BitOffs>840</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18009,7 +20465,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>784</BitOffs>
+        <BitOffs>848</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18021,7 +20477,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>792</BitOffs>
+        <BitOffs>856</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18033,7 +20489,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>800</BitOffs>
+        <BitOffs>864</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18045,7 +20501,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18061,25 +20517,25 @@ External Setpoint Generation:
         <Name>LastExecutionResult</Name>
         <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>928</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>960</BitOffs>
+        <BitOffs>1024</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitSize>8448</BitSize>
+        <BitOffs>1088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8320</BitOffs>
+        <BitOffs>9536</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -18126,11 +20582,17 @@ External Setpoint Generation:
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
       </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_MoveAbsolute</Name>
-      <BitSize>8448</BitSize>
+      <BitSize>9664</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -18240,7 +20702,7 @@ External Setpoint Generation:
         <Name>Options</Name>
         <Type Namespace="Tc2_MC2">ST_MoveOptions</Type>
         <Comment> optional parameters </Comment>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>576</BitOffs>
         <Properties>
           <Property>
@@ -18253,7 +20715,7 @@ External Setpoint Generation:
         <Name>Done</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18265,7 +20727,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>840</BitOffs>
+        <BitOffs>904</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18277,7 +20739,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
+        <BitOffs>912</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18289,7 +20751,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>856</BitOffs>
+        <BitOffs>920</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18301,7 +20763,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>928</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18313,7 +20775,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitOffs>960</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18329,25 +20791,25 @@ External Setpoint Generation:
         <Name>LastExecutionResult</Name>
         <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>928</BitOffs>
+        <BitOffs>992</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitOffs>1088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>1088</BitOffs>
+        <BitSize>8448</BitSize>
+        <BitOffs>1152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8384</BitOffs>
+        <BitOffs>9600</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -18358,7 +20820,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_MoveRelative</Name>
-      <BitSize>8448</BitSize>
+      <BitSize>9664</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -18461,7 +20923,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>Options</Name>
         <Type Namespace="Tc2_MC2">ST_MoveOptions</Type>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>576</BitOffs>
         <Properties>
           <Property>
@@ -18474,7 +20936,7 @@ External Setpoint Generation:
         <Name>Done</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18486,7 +20948,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>840</BitOffs>
+        <BitOffs>904</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18498,7 +20960,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
+        <BitOffs>912</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18510,7 +20972,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>856</BitOffs>
+        <BitOffs>920</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18522,7 +20984,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>928</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18534,7 +20996,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitOffs>960</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -18550,25 +21012,25 @@ External Setpoint Generation:
         <Name>LastExecutionResult</Name>
         <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>928</BitOffs>
+        <BitOffs>992</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitOffs>1088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>1088</BitOffs>
+        <BitSize>8448</BitSize>
+        <BitOffs>1152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8384</BitOffs>
+        <BitOffs>9600</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -18579,7 +21041,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_Jog</Name>
-      <BitSize>42496</BitSize>
+      <BitSize>48512</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -18792,122 +21254,122 @@ External Setpoint Generation:
       <SubItem>
         <Name>MoveVelocity</Name>
         <Type Namespace="Tc2_MC2">MC_MoveVelocity</Type>
-        <BitSize>8384</BitSize>
+        <BitSize>9600</BitSize>
         <BitOffs>768</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveVelocityOut</Name>
         <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>9152</BitOffs>
+        <BitOffs>10368</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Direction</Name>
         <Type Namespace="Tc2_MC2">MC_Direction</Type>
         <BitSize>16</BitSize>
-        <BitOffs>9248</BitOffs>
+        <BitOffs>10464</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteHalt</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>9264</BitOffs>
+        <BitOffs>10480</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Halt</Name>
         <Type Namespace="Tc2_MC2">MC_Halt</Type>
-        <BitSize>8256</BitSize>
-        <BitOffs>9280</BitOffs>
+        <BitSize>9472</BitSize>
+        <BitOffs>10496</BitOffs>
       </SubItem>
       <SubItem>
         <Name>HaltOut</Name>
         <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>17536</BitOffs>
+        <BitOffs>19968</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteMoveAbsolute</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>17632</BitOffs>
+        <BitOffs>20064</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveAbsolute</Name>
         <Type Namespace="Tc2_MC2">MC_MoveAbsolute</Type>
-        <BitSize>8448</BitSize>
-        <BitOffs>17664</BitOffs>
+        <BitSize>9664</BitSize>
+        <BitOffs>20096</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveAbsoluteOut</Name>
         <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>26112</BitOffs>
+        <BitOffs>29760</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteMoveRelative</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>26208</BitOffs>
+        <BitOffs>29856</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveRelative</Name>
         <Type Namespace="Tc2_MC2">MC_MoveRelative</Type>
-        <BitSize>8448</BitSize>
-        <BitOffs>26240</BitOffs>
+        <BitSize>9664</BitSize>
+        <BitOffs>29888</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveRelativeOut</Name>
         <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>34688</BitOffs>
+        <BitOffs>39552</BitOffs>
       </SubItem>
       <SubItem>
         <Name>JogMove</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>34816</BitOffs>
+        <BitSize>8448</BitSize>
+        <BitOffs>39680</BitOffs>
       </SubItem>
       <SubItem>
         <Name>LastJogMoveResult</Name>
         <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>42112</BitOffs>
+        <BitOffs>48128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteJogMove</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>42208</BitOffs>
+        <BitOffs>48224</BitOffs>
       </SubItem>
       <SubItem>
         <Name>StartType</Name>
         <Type Namespace="Tc2_MC2">_E_TcNC_StartPosType</Type>
         <BitSize>16</BitSize>
-        <BitOffs>42224</BitOffs>
+        <BitOffs>48240</BitOffs>
       </SubItem>
       <SubItem>
         <Name>JogMoveOut</Name>
         <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>42240</BitOffs>
+        <BitOffs>48256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>JogEnd</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>42336</BitOffs>
+        <BitOffs>48352</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TargetPosition</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>42368</BitOffs>
+        <BitOffs>48384</BitOffs>
       </SubItem>
       <SubItem>
         <Name>modulo</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>42432</BitOffs>
+        <BitOffs>48448</BitOffs>
       </SubItem>
       <Action>
         <Name>ActJogMove</Name>
@@ -18924,7 +21386,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_MoveModulo</Name>
-      <BitSize>8576</BitSize>
+      <BitSize>9792</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -19039,7 +21501,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>Options</Name>
         <Type Namespace="Tc2_MC2">ST_MoveOptions</Type>
-        <BitSize>256</BitSize>
+        <BitSize>320</BitSize>
         <BitOffs>576</BitOffs>
         <Properties>
           <Property>
@@ -19052,7 +21514,7 @@ External Setpoint Generation:
         <Name>Done</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -19064,7 +21526,7 @@ External Setpoint Generation:
         <Name>Busy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>840</BitOffs>
+        <BitOffs>904</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -19076,7 +21538,7 @@ External Setpoint Generation:
         <Name>Active</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
+        <BitOffs>912</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -19088,7 +21550,7 @@ External Setpoint Generation:
         <Name>CommandAborted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>856</BitOffs>
+        <BitOffs>920</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -19100,7 +21562,7 @@ External Setpoint Generation:
         <Name>Error</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>928</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -19112,7 +21574,7 @@ External Setpoint Generation:
         <Name>ErrorID</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitOffs>960</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -19128,37 +21590,37 @@ External Setpoint Generation:
         <Name>LastExecutionResult</Name>
         <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>928</BitOffs>
+        <BitOffs>992</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ADSbusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitOffs>1088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>7296</BitSize>
-        <BitOffs>1088</BitOffs>
+        <BitSize>8448</BitSize>
+        <BitOffs>1152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>StartType</Name>
         <Type Namespace="Tc2_MC2">_E_TcNC_StartPosType</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8384</BitOffs>
+        <BitOffs>9600</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>8400</BitOffs>
+        <BitOffs>9616</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TriggerExecute</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>8448</BitOffs>
+        <BitOffs>9664</BitOffs>
       </SubItem>
       <Action>
         <Name>MC_MoveModuloCall</Name>
@@ -19391,6 +21853,9 @@ External Setpoint Generation:
             <Name>ItemType</Name>
             <Value>Input</Value>
           </Property>
+          <Property>
+            <Name>TcIgnorePersistent</Name>
+          </Property>
         </Properties>
       </SubItem>
       <SubItem>
@@ -19550,6 +22015,9 @@ External Setpoint Generation:
           <Property>
             <Name>ItemType</Name>
             <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>TcIgnorePersistent</Name>
           </Property>
         </Properties>
       </SubItem>
@@ -22242,7 +24710,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name>FB_HomeVirtual</Name>
-      <BitSize>60288</BitSize>
+      <BitSize>61504</BitSize>
       <SubItem>
         <Name>En</Name>
         <Type>BOOL</Type>
@@ -22451,32 +24919,32 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbMoveVelocity</Name>
         <Type Namespace="Tc2_MC2">MC_MoveVelocity</Type>
-        <BitSize>8384</BitSize>
+        <BitSize>9600</BitSize>
         <BitOffs>27008</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHomePrepare</Name>
         <Type>FB_HomePrepare</Type>
         <BitSize>20480</BitSize>
-        <BitOffs>35392</BitOffs>
+        <BitOffs>36608</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHomeFinish</Name>
         <Type>FB_HomeFinish</Type>
         <BitSize>4224</BitSize>
-        <BitOffs>55872</BitOffs>
+        <BitOffs>57088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>60096</BitOffs>
+        <BitOffs>61312</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nHomingState</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>60192</BitOffs>
+        <BitOffs>61408</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -22485,7 +24953,7 @@ External Setpoint Generation:
         <Name>bExecuteHomeToSwitch</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60208</BitOffs>
+        <BitOffs>61424</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -22494,7 +24962,7 @@ External Setpoint Generation:
         <Name>bExecuteMoveVelocity</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60216</BitOffs>
+        <BitOffs>61432</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -22503,7 +24971,7 @@ External Setpoint Generation:
         <Name>bExecutePrepare</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60224</BitOffs>
+        <BitOffs>61440</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -22512,7 +24980,7 @@ External Setpoint Generation:
         <Name>bExecuteFinish</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60232</BitOffs>
+        <BitOffs>61448</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -22521,20 +24989,20 @@ External Setpoint Generation:
         <Name>bExecuteHomeDirect</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60240</BitOffs>
+        <BitOffs>61456</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nCmdDataLocal</Name>
         <Type>UINT</Type>
         <Comment>Ensure that nCmdData is not changed during sequence</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>60256</BitOffs>
+        <BitOffs>61472</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bSequenceReady</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60272</BitOffs>
+        <BitOffs>61488</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -22543,7 +25011,7 @@ External Setpoint Generation:
         <Name>bRestoreNCDataNeeded</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>60280</BitOffs>
+        <BitOffs>61496</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -23076,7 +25544,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name>FB_DriveVirtual</Name>
-      <BitSize>167488</BitSize>
+      <BitSize>180864</BitSize>
       <SubItem>
         <Name>sVersion</Name>
         <Type>STRING(80)</Type>
@@ -23317,7 +25785,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>MasterAxis</Name>
         <Type Namespace="Tc2_MC2">AXIS_REF</Type>
-        <BitSize>9024</BitSize>
+        <BitSize>9088</BitSize>
         <BitOffs>1408</BitOffs>
         <Properties>
           <Property>
@@ -23330,7 +25798,7 @@ External Setpoint Generation:
         <Name>bPowerSelf</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>10432</BitOffs>
+        <BitOffs>10496</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23342,7 +25810,7 @@ External Setpoint Generation:
         <Name>EnO</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>10440</BitOffs>
+        <BitOffs>10504</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23354,7 +25822,7 @@ External Setpoint Generation:
         <Name>bEnabled</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>10448</BitOffs>
+        <BitOffs>10512</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23366,7 +25834,7 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>10456</BitOffs>
+        <BitOffs>10520</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23378,7 +25846,7 @@ External Setpoint Generation:
         <Name>bDone</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>10464</BitOffs>
+        <BitOffs>10528</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23390,7 +25858,7 @@ External Setpoint Generation:
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>10472</BitOffs>
+        <BitOffs>10536</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23402,7 +25870,7 @@ External Setpoint Generation:
         <Name>bHomed</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>10480</BitOffs>
+        <BitOffs>10544</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23414,7 +25882,7 @@ External Setpoint Generation:
         <Name>nErrorId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>10496</BitOffs>
+        <BitOffs>10560</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23427,7 +25895,7 @@ External Setpoint Generation:
         <Type>UDINT</Type>
         <Comment>Axis id in Motion (NC)</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>10528</BitOffs>
+        <BitOffs>10592</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -23442,7 +25910,7 @@ External Setpoint Generation:
         <Name>Status</Name>
         <Type Namespace="Tc2_MC2">ST_AxisStatus</Type>
         <BitSize>768</BitSize>
-        <BitOffs>10560</BitOffs>
+        <BitOffs>10624</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23454,7 +25922,7 @@ External Setpoint Generation:
         <Name>fActVelocity</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>11328</BitOffs>
+        <BitOffs>11392</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23466,7 +25934,7 @@ External Setpoint Generation:
         <Name>fActPosition</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>11392</BitOffs>
+        <BitOffs>11456</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23478,7 +25946,7 @@ External Setpoint Generation:
         <Name>fActDiff</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>11456</BitOffs>
+        <BitOffs>11520</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23490,7 +25958,7 @@ External Setpoint Generation:
         <Name>sErrorMessage</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>11520</BitOffs>
+        <BitOffs>11584</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23502,7 +25970,7 @@ External Setpoint Generation:
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
         <BitSize>64</BitSize>
-        <BitOffs>12224</BitOffs>
+        <BitOffs>12288</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -23514,19 +25982,19 @@ External Setpoint Generation:
         <Name>nCommandLocal</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>12288</BitOffs>
+        <BitOffs>12352</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nCmdDataLocal</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>12304</BitOffs>
+        <BitOffs>12368</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bFirstScan</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>12320</BitOffs>
+        <BitOffs>12384</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -23535,79 +26003,529 @@ External Setpoint Generation:
         <Name>fbReset</Name>
         <Type Namespace="Tc2_MC2">MC_Reset</Type>
         <BitSize>1920</BitSize>
-        <BitOffs>12352</BitOffs>
+        <BitOffs>12416</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbPower</Name>
         <Type Namespace="Tc2_MC2">MC_Power</Type>
         <BitSize>896</BitSize>
-        <BitOffs>14272</BitOffs>
+        <BitOffs>14336</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHalt</Name>
         <Type Namespace="Tc2_MC2">MC_Halt</Type>
-        <BitSize>8256</BitSize>
-        <BitOffs>15168</BitOffs>
+        <BitSize>9472</BitSize>
+        <BitOffs>15232</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbJog</Name>
         <Type Namespace="Tc2_MC2">MC_Jog</Type>
-        <BitSize>42496</BitSize>
-        <BitOffs>23424</BitOffs>
+        <BitSize>48512</BitSize>
+        <BitOffs>24704</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveVelocity</Name>
         <Type Namespace="Tc2_MC2">MC_MoveVelocity</Type>
-        <BitSize>8384</BitSize>
-        <BitOffs>65920</BitOffs>
+        <BitSize>9600</BitSize>
+        <BitOffs>73216</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveRelative</Name>
         <Type Namespace="Tc2_MC2">MC_MoveRelative</Type>
-        <BitSize>8448</BitSize>
-        <BitOffs>74304</BitOffs>
+        <BitSize>9664</BitSize>
+        <BitOffs>82816</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveAbsolute</Name>
         <Type Namespace="Tc2_MC2">MC_MoveAbsolute</Type>
-        <BitSize>8448</BitSize>
-        <BitOffs>82752</BitOffs>
+        <BitSize>9664</BitSize>
+        <BitOffs>92480</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveModulo</Name>
         <Type Namespace="Tc2_MC2">MC_MoveModulo</Type>
-        <BitSize>8576</BitSize>
-        <BitOffs>91200</BitOffs>
+        <BitSize>9792</BitSize>
+        <BitOffs>102144</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHomeVirtual</Name>
         <Type>FB_HomeVirtual</Type>
-        <BitSize>60288</BitSize>
-        <BitOffs>99776</BitOffs>
+        <BitSize>61504</BitSize>
+        <BitOffs>111936</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbGearInDyn</Name>
         <Type Namespace="Tc2_MC2">MC_GearInDyn</Type>
         <BitSize>4416</BitSize>
-        <BitOffs>160064</BitOffs>
+        <BitOffs>173440</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbGearOut</Name>
         <Type Namespace="Tc2_MC2">MC_GearOut</Type>
         <BitSize>2112</BitSize>
-        <BitOffs>164480</BitOffs>
+        <BitOffs>177856</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>166592</BitOffs>
+        <BitOffs>179968</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stAxisStatus</Name>
         <Type>DUT_AxisStatus_v0_01</Type>
         <BitSize>768</BitSize>
-        <BitOffs>166720</BitOffs>
+        <BitOffs>180096</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>FB_MotionHoming</Name>
+      <BitSize>51584</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type ReferenceTo="true">DUT_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbSetPos</Name>
+        <Type Namespace="Tc2_MC2">MC_SetPosition</Type>
+        <BitSize>2240</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbJog</Name>
+        <Type Namespace="Tc2_MC2">MC_Jog</Type>
+        <BitSize>48512</BitSize>
+        <BitOffs>2432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>50944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftExec</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>51072</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nHomeStateMachine</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51168</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nStateAfterStop</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nMoves</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51200</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstDirection</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>51216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAtHome</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>51224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>51232</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nErrCount</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51248</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInterrupted</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>51264</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>IDLE</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51280</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>NEXT_MOVE</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51296</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>CHECK_FWD</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51312</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>CHECK_BWD</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51328</BitOffs>
+        <Default>
+          <Value>3</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>FINAL_MOVE</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51344</BitOffs>
+        <Default>
+          <Value>4</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>FINAL_SETPOS</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51360</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ERROR</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51376</BitOffs>
+        <Default>
+          <Value>6</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_STOP</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>51392</BitOffs>
+        <Default>
+          <Value>7</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>FWD_START</Name>
+        <Type>LREAL</Type>
+        <Comment>
+        This is a simpler way of disabling the soft limits that ends up being really obvious if something has gone wrong.
+        If you turn the limits off/on, not only do you need to keep track of if you had soft limits set,
+        but you need to always restore this properly or risk some issue.
+        Instead, I set position to a ridiculous value that can always move forward or backward.
+        If this gets stuck for any reason it's very clear that something has gone wrong,
+        rather than a silent failure of the soft limit marks.
+    </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>51456</BitOffs>
+        <Default>
+          <Value>-99999999</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>BWD_START</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>51520</BitOffs>
+        <Default>
+          <Value>99999999</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>FB_EncSaveRestore</Name>
+      <BitSize>3264</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type ReferenceTo="true">DUT_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbSetPos</Name>
+        <Type Namespace="Tc2_MC2">MC_SetPosition</Type>
+        <BitSize>2240</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>timer</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>2432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLoad</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLatchError</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2720</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tRetryDelay</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2784</BitOffs>
+        <Default>
+          <Value>1000</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nMaxRetries</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2816</BitOffs>
+        <Default>
+          <Value>10</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrTries</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2832</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bWaitRetry</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2848</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonRetry</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>2880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bSaved</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosition</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>3200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcPersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>FB_LogMotionError</Name>
+      <BitSize>87360</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type ReferenceTo="true">DUT_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbLogMessage</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>86016</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtNewError</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>86208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bChangedError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>86304</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sPrevErr</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>86312</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbJson</Name>
+        <Type Namespace="Tc3_JsonXml">FB_JsonSaxWriter</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>86976</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -23882,7 +26800,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name>FB_MotionStage</Name>
-      <BitSize>171072</BitSize>
+      <BitSize>327040</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type ReferenceTo="true">DUT_MotionStage</Type>
@@ -23898,92 +26816,146 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbDriveVirtual</Name>
         <Type>FB_DriveVirtual</Type>
-        <BitSize>167488</BitSize>
+        <BitSize>180864</BitSize>
         <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionHome</Name>
+        <Type>FB_MotionHoming</Type>
+        <BitSize>51584</BitSize>
+        <BitOffs>180992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbSaveRestore</Name>
+        <Type>FB_EncSaveRestore</Type>
+        <BitSize>3264</BitSize>
+        <BitOffs>232576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbLogError</Name>
+        <Type>FB_LogMotionError</Type>
+        <BitSize>87360</BitSize>
+        <BitOffs>235840</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecute</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>167616</BitOffs>
+        <BitOffs>323200</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>323208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecHome</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>323216</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bFwdHit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>167624</BitOffs>
+        <BitOffs>323224</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bBwdHit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>167632</BitOffs>
+        <BitOffs>323232</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftExec</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>167680</BitOffs>
+        <BitOffs>323264</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtExec</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>167808</BitOffs>
+        <BitOffs>323392</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtUserExec</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>167936</BitOffs>
+        <BitOffs>323520</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtTarget</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>168064</BitOffs>
+        <BitOffs>323648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtHomed</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>323776</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSetEnables</Name>
         <Type>FB_SetEnables</Type>
         <BitSize>128</BitSize>
-        <BitOffs>168192</BitOffs>
+        <BitOffs>323904</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bPosGoal</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>168320</BitOffs>
+        <BitOffs>324032</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bNegGoal</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>168328</BitOffs>
+        <BitOffs>324040</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbEncoderValue</Name>
         <Type>FB_EncoderValue</Type>
         <BitSize>128</BitSize>
-        <BitOffs>168384</BitOffs>
+        <BitOffs>324096</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbNCParams</Name>
         <Type>FB_MotionStageNCParams</Type>
         <BitSize>2496</BitSize>
-        <BitOffs>168512</BitOffs>
+        <BitOffs>324224</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bNewMoveReq</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>171008</BitOffs>
+        <BitOffs>326720</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bPrepareDisable</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>171016</BitOffs>
+        <BitOffs>326728</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveCmd</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>326736</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtMoveCmdShortcut</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>326784</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtHomeCmdShortcut</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>326912</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -23994,7 +26966,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name>FB_MotionStageSim</Name>
-      <BitSize>171328</BitSize>
+      <BitSize>327296</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type ReferenceTo="true">DUT_MotionStage</Type>
@@ -24025,14 +26997,14 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbMotionStage</Name>
         <Type>FB_MotionStage</Type>
-        <BitSize>171072</BitSize>
+        <BitSize>327040</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>171264</BitOffs>
+        <BitOffs>327232</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -24042,8 +27014,79 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="PMPS">ST_DbStateParams</Name>
+      <BitSize>2496</BitSize>
+      <SubItem>
+        <Name>sPmpsState</Name>
+        <Type>STRING(80)</Type>
+        <Comment> PMPS database lookup name for this state</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS_STATE
+        io: i
+        field: DESC PMPS Database Lookup Key
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stBeamParams</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment> Beam parameters associated with this state</Comment>
+        <BitSize>1760</BitSize>
+        <BitOffs>672</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BP
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBeamParamsLoaded</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE once the PMPS library has loaded a valid state from the database</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS_LOADED
+        io: i
+        field: DESC TRUE if PMPS loaded parameters from the database.
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nRequestAssertionID</Name>
+        <Type>UDINT</Type>
+        <Comment> Transition ID associated with this state</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS_ID
+        io: i
+        field: DESC Assertion Request ID
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
       <Name>DUT_PositionState</Name>
-      <BitSize>2432</BitSize>
+      <BitSize>3648</BitSize>
       <SubItem>
         <Name>sName</Name>
         <Type>STRING(80)</Type>
@@ -24238,36 +27281,19 @@ External Setpoint Generation:
         <BitOffs>1120</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>stBeamParams</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <Comment> Beam parameters associated with this state</Comment>
-        <BitSize>1216</BitSize>
+        <Name>stPMPS</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> We give this a state name and it is used to load parameters from the pmps database.</Comment>
+        <BitSize>2496</BitSize>
         <BitOffs>1152</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.nTran</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.fPP_mJ</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.neVRange</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.nRate</Name>
-            <Value>0</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nRequestAssertionID</Name>
-        <Type>UDINT</Type>
-        <Comment> Transition ID associated with this state</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2368</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv:
+    </Value>
+          </Property>
+        </Properties>
       </SubItem>
     </DataType>
     <DataType>
@@ -24847,6 +27873,6030 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="PMPS">ST_FFInfo</Name>
+      <Comment> These elements should be set at init and never changed.</Comment>
+      <BitSize>6832</BitSize>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Full PLC path to FF object</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Path
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Desc</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Set at instantiation to a helpful description of the fast fault purpose</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>2048</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Desc
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>DevName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Component name, used in diagnostic to help narrow down where beam faults are coming from</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>4096</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DevName
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TypeCode</Name>
+        <Type>UINT</Type>
+        <Comment> Set at instantiation to fault class code</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>6144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: TypeCode
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>InUse</Name>
+        <Type>BOOL</Type>
+        <Comment>////////////////////////////////////////
+////////////////////////////////////////</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>6160</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: InUse
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>AutoReset</Name>
+        <Type>BOOL</Type>
+        <Comment>////////////////////////////////////////</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>6168</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Vetoable</Name>
+        <Type>BOOL</Type>
+        <Comment> Can this fast fault be masked by the veto device input?</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>6176</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>InfoString</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>6184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: InfoString
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">ST_FFOverride</Name>
+      <BitSize>768</BitSize>
+      <SubItem>
+        <Name>Duration</Name>
+        <Type>DINT</Type>
+        <Comment> DINT to be compatible with EPICS </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Duration
+        io: o
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Expiration</Name>
+        <Type>DINT</Type>
+        <Comment> DINT to be compatible with EPICS </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Expiration
+        io: o
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>StartDT</Name>
+        <Type>DINT</Type>
+        <Comment> DINT to be compatible with EPICS </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: StartDT
+        io: o
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Activate</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Activate
+        io: o
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Deactivate</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Deactivate
+        io: o
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ElapsedTime</Name>
+        <Type>DINT</Type>
+        <Comment> DINT to be compatible with EPICS </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ElapsedTime
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RemainingTime</Name>
+        <Type>DINT</Type>
+        <Comment> DINT to be compatible with EPICS </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RemainingTime
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Active</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Active
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Timer</Name>
+        <Type Namespace="Tc2_Standard">TP</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OvrdActLogAck</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OvrdExpLogAck</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>488</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tOvrdActivate</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tOvrdExpiring</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Standard">RS</Name>
+      <BitSize>96</BitSize>
+      <SubItem>
+        <Name>SET</Name>
+        <Type>BOOL</Type>
+        <Comment> Input to set Q1</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RESET1</Name>
+        <Type>BOOL</Type>
+        <Comment> Input to reset Q1 (reset dominant)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q1</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">ST_FF</Name>
+      <BitSize>8064</BitSize>
+      <SubItem>
+        <Name>Info</Name>
+        <Type Namespace="PMPS">ST_FFInfo</Type>
+        <BitSize>6832</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Info
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Ovrd</Name>
+        <Type Namespace="PMPS">ST_FFOverride</Type>
+        <BitSize>768</BitSize>
+        <BitOffs>6848</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Ovrd
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>OK</Name>
+        <Type>BOOL</Type>
+        <Comment> Fault logic state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>7616</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: OK
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>FaultAck</Name>
+        <Type>BOOL</Type>
+        <Comment> Set when faulted, reset by logger.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>7624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ClearAck</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>7632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>BeamPermitted</Name>
+        <Type>BOOL</Type>
+        <Comment> Result of reset, veto, and fault logic, true beam off boolean</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>7640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BeamPermitted
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Reset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>7648</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Reset
+        io: o
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bsFF</Name>
+        <Type Namespace="Tc2_Standard">RS</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>7680</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>7808</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftCountFault</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>7936</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name>DWORD (1..86400)</Name>
+      <BitSize>32</BitSize>
+      <BaseType>DWORD</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>1</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>86400</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">E_TimeZoneID</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>eTimeZoneID_Invalid</Text>
+        <Enum>-1</Enum>
+        <Comment> Invalid time zone </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eTimeZoneID_Unknown</Text>
+        <Enum>0</Enum>
+        <Comment> Unknown time zone </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eTimeZoneID_Standard</Text>
+        <Enum>1</Enum>
+        <Comment> Standard time (Winterzeit) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eTimeZoneID_Daylight</Text>
+        <Enum>2</Enum>
+        <Comment> Daylight saving time (Sommerzeit) </Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">NT_GetTime</Name>
+      <Comment> Reads local windows system time (struct) </Comment>
+      <BitSize>1920</BitSize>
+      <SubItem>
+        <Name>NETID</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> TwinCAT network address (ams net id) </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>START</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge on this input activates the fb execution </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TMOUT</Name>
+        <Type>TIME</Type>
+        <Comment> Max fb execution time </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <Value>5000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>BUSY</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ERR</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ERRID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TIMESTR</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <Comment> Local windows system time </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsRead</Name>
+        <Type Namespace="Tc2_System">ADSREAD</Type>
+        <BitSize>1408</BitSize>
+        <BitOffs>512</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PORT</Name>
+            <Value>10000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.IDXGRP</Name>
+            <Value>400</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.IDXOFFS</Name>
+            <Value>1</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">ST_AmsGetTimeZoneInformation</Name>
+      <BitSize>896</BitSize>
+      <SubItem>
+        <Name>tzInfo</Name>
+        <Type Namespace="Tc2_Utilities">ST_TimeZoneInformation</Type>
+        <Comment> GetTimeZoneInformation return data  </Comment>
+        <BitSize>864</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>apiResult</Name>
+        <Type>DWORD</Type>
+        <Comment> api call result </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>864</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Name>
+      <Comment> Reads time zone information </Comment>
+      <BitSize>3712</BitSize>
+      <SubItem>
+        <Name>sNetID</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> TwinCAT network address (ams net id) </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge on this input activates the fb execution </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> Max fb execution time </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <Value>5000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tzID</Name>
+        <Type Namespace="Tc2_Utilities">E_TimeZoneID</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tzInfo</Name>
+        <Type Namespace="Tc2_Utilities">ST_TimeZoneInformation</Type>
+        <BitSize>864</BitSize>
+        <BitOffs>416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsRead</Name>
+        <Type Namespace="Tc2_System">ADSREAD</Type>
+        <BitSize>1408</BitSize>
+        <BitOffs>1280</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PORT</Name>
+            <Value>10000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.IDXGRP</Name>
+            <Value>400</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.IDXOFFS</Name>
+            <Value>6</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>2688</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>state</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2784</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>res</Name>
+        <Type Namespace="Tc2_Utilities">ST_AmsGetTimeZoneInformation</Type>
+        <BitSize>896</BitSize>
+        <BitOffs>2816</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">ST_HKeySrvRead</Name>
+      <BitSize>4096</BitSize>
+      <SubItem>
+        <Name>sSub</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sVal</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>2048</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">FB_RegQueryValue</Name>
+      <Comment> Reads windows registry value </Comment>
+      <BitSize>10880</BitSize>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> TwinCAT network address (ams net id) </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sSubKey</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> HKEY_LOCAL_MACHINE \ sub key name </Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sValName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Value name </Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>2304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbData</Name>
+        <Type>UDINT</Type>
+        <Comment> Number of data bytes to read </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>4352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pData</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <Comment> Points to registry key data buffer </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge on this input activates the fb execution </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>4480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeOut</Name>
+        <Type>TIME</Type>
+        <Comment> Max fb execution time </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>4512</BitOffs>
+        <Default>
+          <Value>5000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4544</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4552</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>4576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbRead</Name>
+        <Type>UDINT</Type>
+        <Comment> Number of succesfully read data bytes </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>4608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsRdWrtEx</Name>
+        <Type Namespace="Tc2_System">ADSRDWRTEX</Type>
+        <BitSize>1792</BitSize>
+        <BitOffs>4672</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PORT</Name>
+            <Value>10000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.IDXGRP</Name>
+            <Value>200</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.IDXOFFS</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>6464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>state</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>6560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>s1Len</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>6592</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>s2Len</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>6624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ptr</Name>
+        <Type PointerTo="1">BYTE</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>6656</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbBuff</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>6720</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tmpBuff</Name>
+        <Type Namespace="Tc2_Utilities">ST_HKeySrvRead</Type>
+        <BitSize>4096</BitSize>
+        <BitOffs>6752</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">NT_SetTimeToRTCTime</Name>
+      <BitSize>12800</BitSize>
+      <SubItem>
+        <Name>NETID</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> TwinCAT network address (ams net id) </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SET</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge on this input activates the fb execution </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TMOUT</Name>
+        <Type>TIME</Type>
+        <Comment> Max fb execution time </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <Value>5000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>BUSY</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ERR</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ERRID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsWrite</Name>
+        <Type Namespace="Tc2_System">ADSWRITE</Type>
+        <BitSize>1344</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PORT</Name>
+            <Value>10000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.IDXGRP</Name>
+            <Value>4</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.IDXOFFS</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbRegQuery</Name>
+        <Type Namespace="Tc2_Utilities">FB_RegQueryValue</Type>
+        <BitSize>10880</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.sSubKey</Name>
+            <String>Software\Beckhoff\TwinCAT3\System</String>
+          </SubItem>
+          <SubItem>
+            <Name>.sValName</Name>
+            <String>NumOfCPUs</String>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>12608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bTmp</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>12704</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>state</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>12736</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>12744</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>numOfCPUs</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>12768</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">FW_GetCpuCounter</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>dwCpuCntLo</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>dwCpuCntHi</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">GETCPUCOUNTER</Name>
+      <Comment>	The CPU cycle counter can be read with this function block. 
+	The numerical value is a relative 64 bit integer, which, independently of the CPUs internal clock rate, is output in a form converted into 100ns ticks. 
+	The number is refreshed to a precision of 100ns with every call by the PLC system, and can be used, for instance, for timing tasks. 
+	One unit is equivalent to 100 ns. </Comment>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>cpuCntLoDW</Name>
+        <Type>UDINT</Type>
+        <Comment> Contains the low-value 4 bytes of the numerical value </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cpuCntHiDW</Name>
+        <Type>UDINT</Type>
+        <Comment> Contains the high-value 4 bytes of the numerical value </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCpuCounter</Name>
+        <Type Namespace="Tc2_System">FW_GetCpuCounter</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">RTC_EX2</Name>
+      <Comment> Software RTC (real time clock), returns time in structured system time format + microseconds (microsecond resolution) </Comment>
+      <BitSize>1024</BitSize>
+      <SubItem>
+        <Name>EN</Name>
+        <Type>BOOL</Type>
+        <Comment> Enable/set clock </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PDT</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <Comment> Preset/set time in system time format (struct) </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PMICRO</Name>
+        <Type>DWORD</Type>
+        <Comment> Preset microseconds </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE =&gt; Output time is valid, FALSE =&gt; Output time is invalid </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>CDT</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <Comment> Current time in system time format (struct) </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>272</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.wYear</Name>
+            <Value>1970</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.wMonth</Name>
+            <Value>1</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.wDay</Name>
+            <Value>1</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.wDayOfWeek</Name>
+            <Value>4</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>CMICRO</Name>
+        <Type>DWORD</Type>
+        <Comment> Current microseconds </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCpuCounter</Name>
+        <Type Namespace="Tc2_System">GETCPUCOUNTER</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>risingEdge</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>oldTick</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>800</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>currTick</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nanoDiff</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>864</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nanoRest</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>secDiff</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>928</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>dateTime</Name>
+        <Type>DATE_AND_TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bInitialized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>992</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">FB_LocalSystemTime</Name>
+      <Comment> This function block synchronizes cyclically to and returns the Local Windows System Time. </Comment>
+      <BitSize>20480</BitSize>
+      <SubItem>
+        <Name>sNetID</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> The target TwinCAT system network address </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Enable/start cyclic time synchronisation (output is synchronized to Local Windows System Time) </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>dwCycle</Name>
+        <Type>DWORD (1..86400)</Type>
+        <Comment> Time synchronisation cycle (seconds) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>dwOpt</Name>
+        <Type>DWORD</Type>
+        <Comment> Additional option flags: If bit 0 is set =&gt; Synchronize Windows Time to RTC time </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> Max. ADS function block execution time (internal communication timeout). </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+        <Default>
+          <Value>5000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE =&gt; The systemTime and tzID output is valid, FALSE =&gt; systemTime and tzID is not valid </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>systemTime</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <Comment> Local Windows System Time struct </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tzID</Name>
+        <Type Namespace="Tc2_Utilities">E_TimeZoneID</Type>
+        <Comment> Daylight/standard time zone information </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>528</BitOffs>
+        <Default>
+          <Value>-1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtrig</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>state</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>672</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbNT</Name>
+        <Type Namespace="Tc2_Utilities">NT_GetTime</Type>
+        <BitSize>1920</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbTZ</Name>
+        <Type Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Type>
+        <BitSize>3712</BitSize>
+        <BitOffs>2624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbSET</Name>
+        <Type Namespace="Tc2_Utilities">NT_SetTimeToRTCTime</Type>
+        <BitSize>12800</BitSize>
+        <BitOffs>6336</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbRTC</Name>
+        <Type Namespace="Tc2_Utilities">RTC_EX2</Type>
+        <BitSize>1024</BitSize>
+        <BitOffs>19136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>timer</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>20160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nSync</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>20416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bNotSup</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>20448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">T_FILETIME</Name>
+      <Comment> The FILETIME structure is a 64-bit value representing the number of 100-nanosecond intervals since January 1, 1601 (UTC). </Comment>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>dwLowDateTime</Name>
+        <Type>DWORD</Type>
+        <Comment> Specifies the low-order 32 bits of the file time. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwHighDateTime</Name>
+        <Type>DWORD</Type>
+        <Comment> Specifies the high-order 32 bits of the file time. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">FB_TranslateLocalTimeToUtcByZoneID</Name>
+      <Comment> Internal helper function block. Detects time zone ID, bias and B time flag and translates the local file time to UTC file time time </Comment>
+      <BitSize>2432</BitSize>
+      <SubItem>
+        <Name>in</Name>
+        <Type Namespace="Tc2_Utilities">T_FILETIME</Type>
+        <Comment> Time to be converted (Local file time format) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tzInfo</Name>
+        <Type Namespace="Tc2_Utilities">ST_TimeZoneInformation</Type>
+        <Comment> Time zone information </Comment>
+        <BitSize>864</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>wDldYear</Name>
+        <Type>WORD</Type>
+        <Comment> Optional daylightDate.wYear value. If 0 =&gt; not used (default) else used only if tzInfo.daylightDate.wYear = 0. </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>992</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>wStdYear</Name>
+        <Type>WORD</Type>
+        <Comment> Optional standardDate.wYear value. If 0 =&gt; not used (default) else used only if tzInfo.standardDate.wYear = 0. </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1008</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>out</Name>
+        <Type Namespace="Tc2_Utilities">T_FILETIME</Type>
+        <Comment> Converted time (UTC file time format) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eTzID</Name>
+        <Type Namespace="Tc2_Utilities">E_TimeZoneID</Type>
+        <Comment> Detected daylight saving time information </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bB</Name>
+        <Type>BOOL</Type>
+        <Comment> FALSE =&gt; A time, TRUE =&gt; B time</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bias</Name>
+        <Type>DINT</Type>
+        <Comment> Bias value in minutes </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>inLocal</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tziSommer</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tziWinter</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tziLocalSommer</Name>
+        <Type Namespace="Tc2_Utilities">T_FILETIME</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tziLocalWinter</Name>
+        <Type Namespace="Tc2_Utilities">T_FILETIME</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tziLocalSommerJump</Name>
+        <Type Namespace="Tc2_Utilities">T_FILETIME</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tziLocalWinterJump</Name>
+        <Type Namespace="Tc2_Utilities">T_FILETIME</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1728</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ui64LocalIn</Name>
+        <Type Namespace="Tc2_Utilities">T_ULARGE_INTEGER</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ui64LocalSommer</Name>
+        <Type Namespace="Tc2_Utilities">T_ULARGE_INTEGER</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ui64LocalWinter</Name>
+        <Type Namespace="Tc2_Utilities">T_ULARGE_INTEGER</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>in_to_s</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>in_to_w</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2016</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>s_to_w</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>in_to_s_jump</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>in_to_w_jump</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iStandardBias</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iDaylightBias</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2176</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ui64PreviousIn</Name>
+        <Type Namespace="Tc2_Utilities">T_ULARGE_INTEGER</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>2208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ui64FallDiff</Name>
+        <Type Namespace="Tc2_Utilities">T_ULARGE_INTEGER</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>2272</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFallDiff</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2336</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dtSommerJump</Name>
+        <Type>DATE_AND_TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2368</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dtWinterJump</Name>
+        <Type>DATE_AND_TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2400</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">FB_TzSpecificLocalTimeToSystemTime</Name>
+      <Comment> Converts time zone's specific local system time to Coordinated Universal Time (UTC) system time </Comment>
+      <BitSize>3648</BitSize>
+      <SubItem>
+        <Name>in</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <Comment> Time zone's specific local system time. Structure that specifies the system time since January 1, 1601</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tzInfo</Name>
+        <Type Namespace="Tc2_Utilities">ST_TimeZoneInformation</Type>
+        <Comment> Time zone settings </Comment>
+        <BitSize>864</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>out</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <Comment> Coordinated Universal Time (UTC) in system time format </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>1056</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eTzID</Name>
+        <Type Namespace="Tc2_Utilities">E_TimeZoneID</Type>
+        <Comment> Daylight saving time information </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1184</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bB</Name>
+        <Type>BOOL</Type>
+        <Comment> FALSE =&gt; A time, TRUE =&gt; B time</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbBase</Name>
+        <Type Namespace="Tc2_Utilities">FB_TranslateLocalTimeToUtcByZoneID</Type>
+        <BitSize>2432</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">FB_HardwareFFOutput</Name>
+      <BitSize>520576</BitSize>
+      <SubItem>
+        <Name>FF_ARRAY_UPPER_BOUND</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>50</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>i_xReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ClearFault
+        io: o
+        field: DESC Might be overidden by PLC writes
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xVeto</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>88</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: EnableVeto
+        io: o
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAutoReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Set true for the FFO to automatically permit beam again after all fast faults are cleared</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_sNetID</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment>Set to the Arbiter AmsNetID to be used for the synchronisation. An empty string means the system will sue local time</Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>104</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xFastFaultOut</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>296</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FaultHWO
+        io: i
+        field: DESC Hardware Output Status
+     </Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_xValidSyncTime</Name>
+        <Type>BOOL</Type>
+        <Comment> system time bValid output True when sync is successful</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astFF</Name>
+        <Type Namespace="PMPS">ST_FF</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>50</Elements>
+        </ArrayInfo>
+        <BitSize>403200</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FF
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xFastFaultRegFail</Name>
+        <Type>BOOL</Type>
+        <Comment> Set true if a fast fault fails to register. Holds beam off.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>403520</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RegistrationFailure
+        io: io
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tFFRegFail</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>403584</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>403680</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>noinit</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xOK</Name>
+        <Type>BOOL</Type>
+        <Comment> Current internal state of FFO, indicates if FFO will accept a reset</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>405728</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: OK
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>405760</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtResetandOK</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>405888</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>405984</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>IdxOK</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>406000</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbTime</Name>
+        <Type Namespace="Tc2_Utilities">FB_LocalSystemTime</Type>
+        <Comment>Get current system time, used for override</Comment>
+        <BitSize>20480</BitSize>
+        <BitOffs>406016</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.bEnable</Name>
+            <Value>1</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.dwCycle</Name>
+            <Value>1</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbTime_to_UTC</Name>
+        <Type Namespace="Tc2_Utilities">FB_TzSpecificLocalTimeToSystemTime</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>426496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetTimeZone</Name>
+        <Type Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Type>
+        <BitSize>3712</BitSize>
+        <BitOffs>430144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbJson</Name>
+        <Type Namespace="Tc3_JsonXml">FB_JsonSaxWriter</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>433856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>pmpsTypeCode</Name>
+        <Type>UDINT</Type>
+        <Comment> shows up in json as pmps_typecode</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>434240</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbLogger</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>86016</BitSize>
+        <BitOffs>434304</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.eSevr</Name>
+            <Value>4</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.eSubsystem</Name>
+            <Value>2</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nMinTimeViolationAcceptable</Name>
+            <Value>50</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>__EXECUTELOGGING__HELLOTIMER</Name>
+        <Type Namespace="Tc2_Standard">TOF</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>520320</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PT</Name>
+            <Value>86400000</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>ExecuteNoLog</Name>
+      </Action>
+      <Action>
+        <Name>EvaluateOutput</Name>
+      </Action>
+      <Action>
+        <Name>Execute</Name>
+      </Action>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EvaluateOverrides</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>FF</Name>
+          <Type Namespace="PMPS" ReferenceTo="true">ST_FF</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>EvalIdx</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>MaxTime</Name>
+          <Comment>49.7 days</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>ExecuteLogging</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>FF</Name>
+          <Type Namespace="PMPS" ReferenceTo="true">ST_FF</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>logIdx</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>HelloTimer</Name>
+          <Type Namespace="Tc2_Standard">TOF</Type>
+          <BitSize>256</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__EXECUTELOGGING__HELLOTIMER</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Register</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>stFFInfo</Name>
+          <Type Namespace="PMPS">ST_FFInfo</Type>
+          <BitSize>6832</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>FFOName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>IdxCheckIn</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>OK</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Reset</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>stFF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8064</BitSize>
+        </Local>
+        <Local>
+          <Name>BeamPermitted</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
+        <Parameter>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8064</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
+        </Property>
+        <Property>
+          <Name>no_check</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">FB_GetLocalAmsNetId</Name>
+      <Comment> Reads the local AmsNetId (local TwinCAT-specific network address) </Comment>
+      <BitSize>11520</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge on this input activates the fb execution </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeOut</Name>
+        <Type>TIME</Type>
+        <Comment> Max fb execution time </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>5000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>AddrString</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> TwinCAT -specific network address as string </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <String>0.0.0.0.0.0</String>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>AddrBytes</Name>
+        <Type Namespace="Tc2_System">T_AmsNetIdArr</Type>
+        <Comment> TwinCAT-specific network address as array of byte </Comment>
+        <BitSize>48</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>[0]</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[1]</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[2]</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[3]</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[4]</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>[5]</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbRegQueryValue</Name>
+        <Type Namespace="Tc2_Utilities">FB_RegQueryValue</Type>
+        <BitSize>10880</BitSize>
+        <BitOffs>448</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.sNetId</Name>
+            <String/>
+          </SubItem>
+          <SubItem>
+            <Name>.sSubKey</Name>
+            <String>SOFTWARE\Beckhoff\TwinCAT3\System</String>
+          </SubItem>
+          <SubItem>
+            <Name>.sValName</Name>
+            <String>AmsNetId</String>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>11328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>state</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>11424</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tmpBytes</Name>
+        <Type Namespace="Tc2_System">T_AmsNetIdArr</Type>
+        <BitSize>48</BitSize>
+        <BitOffs>11432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc3_JsonXml">FB_JsonDomParserBase</Name>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>ipDom</Name>
+        <Type GUID="{7E23DC07-F23F-5198-9983-6C86F8E33DF7}">ITcJsonDomParser</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ipDom2</Name>
+        <Type GUID="{81F923C8-1950-4CE3-A6EC-D0BE05D3E316}">ITcJsonDomParser2</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ipXFA</Name>
+        <Type GUID="{85D12012-7AC0-487F-A49D-154DB46E728C}">ITcDomParserFileAccess</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>HasMember</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetDateTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetBool</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetJson</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsNull</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackFileTimeValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackIntValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddFileTimeMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RemoveMemberByName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddArrayMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetString</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberEnd</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackUintValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ParseDocument</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddIntMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ArrayEnd</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetDouble</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackBoolValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddHexBinaryMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetBase64</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetMemberValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDateTimeMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetInt</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackUint64Value</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ClearArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RemoveAllMembers</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ExceptionRaised</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsISO8601TimeFormat</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetInt64</Name>
+        <ReturnType>LINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsBool</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddInt64Member</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>FindMemberPath</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Comment> member of v seperatet by '/' without leading '/' ('/' in a member name will be encoded as "~1" and '~' as "~0")</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetDcTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetArray</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetFileTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetStringLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SaveDocumentToFile</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sFile</Name>
+          <Comment> file path</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>bExec</Name>
+          <Comment> a rising edge triggers the saving.</Comment>
+          <Type ReferenceTo="true">BOOL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackBase64Value</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsBase64</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsTrue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsInt</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocumentRoot</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>CopyDocument</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of target string buffer</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetType</Name>
+        <ReturnType GUID="{7D39EFFF-B065-4D24-89FF-E2456B774213}">EJsonType</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackDcTimeValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetMemberName</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsNumber</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddObjectMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsInt64</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsUint64</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CopyString</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pStr</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nStr</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetBase64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Swap</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsHexBinary</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUint64Member</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewDocument</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetString</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(255)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsUint</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NextMember</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ArrayBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsString</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PopbackValue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddJsonMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>LoadDocumentFromFile</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sFile</Name>
+          <Comment> file path</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>bExec</Name>
+          <Comment> a rising edge triggers the load.</Comment>
+          <Type ReferenceTo="true">BOOL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsObject</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackStringValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RemoveMember</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RemoveArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDcTimeMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetMaxDecimalPlaces</Name>
+        <Parameter>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>FindMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackDateTimeValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackInt64Value</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBase64Member</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDoubleMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackNullValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBoolMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUintMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CopyJson</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of target string buffer</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetInt64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CopyFrom</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetBool</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDouble</Name>
+        <ReturnType>LREAL</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetArrayValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NextArray</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetInt</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackDoubleValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddNullMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc3_JsonXml">FB_JsonDomParser</Name>
+      <BitSize>448</BitSize>
+      <ExtendsType Namespace="Tc3_JsonXml">FB_JsonDomParserBase</ExtendsType>
+      <SubItem>
+        <Name>initStatus</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>-1743714536</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>CLSID_TcJsonDomParser</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000024}">CLSID</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.Data1</Name>
+            <Value>1337382113</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data2</Name>
+            <Value>45876</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data3</Name>
+            <Value>23182</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[0]</Name>
+            <Value>166</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[1]</Name>
+            <Value>151</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[2]</Name>
+            <Value>186</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[3]</Name>
+            <Value>40</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[4]</Name>
+            <Value>25</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[5]</Name>
+            <Value>175</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[6]</Name>
+            <Value>202</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.Data4[7]</Name>
+            <Value>216</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">E_OpenPath</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>PATH_GENERIC</Text>
+        <Enum>1</Enum>
+        <Comment> Search/open/create files in selected/generic folder </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_BOOTPRJ</Text>
+        <Enum>2</Enum>
+        <Comment> Search/open/create files in TwinCAT boot project folder and adds the *.wbp extension </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_BOOTDATA</Text>
+        <Enum>3</Enum>
+        <Comment> Reserved for future use</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_BOOTPATH</Text>
+        <Enum>4</Enum>
+        <Comment> Refers to the TwinCAT/Boot directory without adding an extension (.wbp) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_USERPATH1</Text>
+        <Enum>11</Enum>
+        <Comment> Reserved for future use </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_USERPATH2</Text>
+        <Enum>12</Enum>
+        <Comment> Reserved for future use </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_USERPATH3</Text>
+        <Enum>13</Enum>
+        <Comment> Reserved for future use </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_USERPATH4</Text>
+        <Enum>14</Enum>
+        <Comment> Reserved for future use </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_USERPATH5</Text>
+        <Enum>15</Enum>
+        <Comment> Reserved for future use </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_USERPATH6</Text>
+        <Enum>16</Enum>
+        <Comment> Reserved for future use </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_USERPATH7</Text>
+        <Enum>17</Enum>
+        <Comment> Reserved for future use </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_USERPATH8</Text>
+        <Enum>18</Enum>
+        <Comment> Reserved for future use </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PATH_USERPATH9</Text>
+        <Enum>19</Enum>
+        <Comment> Reserved for future use </Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">FB_FileOpen</Name>
+      <Comment> Open and/or create a file. </Comment>
+      <BitSize>3712</BitSize>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> Ams net id </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPathName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Max filename length = 255 </Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nMode</Name>
+        <Type>DWORD</Type>
+        <Comment> Open mode flags </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ePath</Name>
+        <Type Namespace="Tc2_System">E_OpenPath</Type>
+        <Comment> Default: Open generic file </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2336</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge starts command execution </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> Maximum time allowed for the execution of this ADS command </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2368</BitOffs>
+        <Default>
+          <Value>5000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> Busy flag </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> Error flag </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2408</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrId</Name>
+        <Type>UDINT</Type>
+        <Comment> ADS error code </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>hFile</Name>
+        <Type>UINT</Type>
+        <Comment> File handle </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>hide_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">FB_FileClose</Name>
+      <Comment> Closes a file stream. </Comment>
+      <BitSize>1408</BitSize>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> Ams net id </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>hFile</Name>
+        <Type>UINT</Type>
+        <Comment> File handle obtained through 'open' </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge starts command execution </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> Maximum time allowed for the execution of this ADS command </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <Value>5000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> Busy flag </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> Error flag </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrId</Name>
+        <Type>UDINT</Type>
+        <Comment> ADS error code </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>hide_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">FB_FileRead</Name>
+      <Comment> Reads data from a stream. </Comment>
+      <BitSize>1792</BitSize>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> Ams net id </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>hFile</Name>
+        <Type>UINT</Type>
+        <Comment> File handle </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pReadBuff</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Buffer address for read </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>TcIgnorePersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbReadLen</Name>
+        <Type>UDINT</Type>
+        <Comment> Count of bytes for read </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge starts command execution </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> Maximum time allowed for the execution of this ADS command </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>448</BitOffs>
+        <Default>
+          <Value>5000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> Busy flag </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> Error flag </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>488</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrId</Name>
+        <Type>UDINT</Type>
+        <Comment> ADS error code </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbRead</Name>
+        <Type>UDINT</Type>
+        <Comment> Count of bytes actually read </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEOF</Name>
+        <Type>BOOL</Type>
+        <Comment> End of file </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>hide_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">FB_FastFault</Name>
+      <Comment> Fast Fault
+2019-9-13 A. Wallace
+
+Use this block to generate a beam-off fault. Connects to a fast fault hardware output 
+function block to contribute to the state of the fast fault output (FFO).
+
+If the i_xOK goes false, the associated FFO will go false, despite the state of any other
+contributing fast faults, unless the FFO is currently vetoed.
+
+</Comment>
+      <BitSize>25920</BitSize>
+      <SubItem>
+        <Name>i_xOK</Name>
+        <Type>BOOL</Type>
+        <Comment> Connect to fast-fault condition (false produces fault)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Resets when i_xOK is true and this is true</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xAutoReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Automatically clear fast fault (latching vs non-latching)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_xVetoable</Name>
+        <Type>BOOL</Type>
+        <Comment> Mask this fast fault if the FFO veto device is true</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>88</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_DevName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Device name for diagnostic</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_Desc</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Description of fast fault (you should set at init)</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>2144</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i_TypeCode</Name>
+        <Type>UINT</Type>
+        <Comment> Error code for classifying fast faults</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>4192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>o_xFFLine</Name>
+        <Type>BOOL</Type>
+        <Comment>Connect to HW output or another FF input if you like (Optional)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>4208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>io_fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment>Point to FB_HardwareFFOutput of your choice</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>4288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>noinit</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>FFInfo</Name>
+        <Type Namespace="PMPS">ST_FFInfo</Type>
+        <BitSize>6832</BitSize>
+        <BitOffs>6336</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>RegistrationIdx</Name>
+        <Type>UINT</Type>
+        <Comment> The index this FF was registered in the FFO</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>13168</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>xInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>13184</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>InfoStringFmtr</Name>
+        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+        <BitSize>8576</BitSize>
+        <BitOffs>13248</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>InUse</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>21824</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AutoReset</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>23872</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">FB_JsonFileToJsonDoc</Name>
+      <BitSize>935360</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment>Rising Edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPLCName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sSrcNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>720</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sSrcPathName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>912</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PMPS_jsonDoc</Name>
+        <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>3008</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHasPLC</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3072</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3080</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>3104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrMsg</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>3136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>io_fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>3840</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fb_GetLocalAmsNetId</Name>
+        <Type Namespace="Tc2_Utilities">FB_GetLocalAmsNetId</Type>
+        <Comment>Get AMS Net ID</Comment>
+        <BitSize>11520</BitSize>
+        <BitOffs>3904</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbJson</Name>
+        <Type Namespace="Tc3_JsonXml">FB_JsonDomParser</Type>
+        <Comment> JSON </Comment>
+        <BitSize>448</BitSize>
+        <BitOffs>15424</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>jsonDoc</Name>
+        <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>15872</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>jsonProp</Name>
+        <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>15936</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbFileOpen</Name>
+        <Type Namespace="Tc2_System">FB_FileOpen</Type>
+        <Comment>File</Comment>
+        <BitSize>3712</BitSize>
+        <BitOffs>16000</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbFileClose</Name>
+        <Type Namespace="Tc2_System">FB_FileClose</Type>
+        <BitSize>1408</BitSize>
+        <BitOffs>19712</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbFileRead</Name>
+        <Type Namespace="Tc2_System">FB_FileRead</Type>
+        <BitSize>1792</BitSize>
+        <BitOffs>21120</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>hSrcFile</Name>
+        <Type>UINT</Type>
+        <Comment> File handle of the source file </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>22912</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>Step</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>22928</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>index</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>22944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>RisingEdge</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>22976</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sbuffRead</Name>
+        <Type>STRING(100000)</Type>
+        <Comment> Buffer </Comment>
+        <BitSize>800008</BitSize>
+        <BitOffs>23072</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>cbReadLength</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>823104</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nFileLength</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>823136</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bfbJsonExceptionRaised</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>823168</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeOut</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>823200</BitOffs>
+        <Default>
+          <Value>5000</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>823232</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tNewMessage</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <Comment>Logger</Comment>
+        <BitSize>96</BitSize>
+        <BitOffs>823296</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbLogger</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>86016</BitSize>
+        <BitOffs>823424</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.eSubsystem</Name>
+            <Value>2</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nMinTimeViolationAcceptable</Name>
+            <Value>10</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>FFO</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment>FFO</Comment>
+        <BitSize>25920</BitSize>
+        <BitOffs>909440</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.i_Desc</Name>
+            <String>Fault occurs when there is an error reading json file</String>
+          </SubItem>
+          <SubItem>
+            <Name>.i_TypeCode</Name>
+            <Value>65299</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>ACT_FFO</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Logger</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>FB_Standard_PMPSDB</Name>
+      <BitSize>29824</BitSize>
+      <SubItem>
+        <Name>io_fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bRefreshBPs</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, FB will run. Reads when enable goes TRUE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPlcName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> E.g. lfe-motion</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bRefresh</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE to cause an extra read.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>848</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: REFRESH
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDirectory</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Directory where the DB is stored.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>856</BitOffs>
+        <Default>
+          <String>/Hard Disk/ftp/PMPS/</String>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nLastRefreshTime</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1504</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: LAST_REFRESH
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtEnable</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>1600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtRefresh</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>1728</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>1856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbTime</Name>
+        <Type Namespace="Tc2_Utilities">FB_LocalSystemTime</Type>
+        <Comment> Time tracking liften from Arbiter PLCs</Comment>
+        <BitSize>20480</BitSize>
+        <BitOffs>1984</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.bEnable</Name>
+            <Value>1</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.dwCycle</Name>
+            <Value>1</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbTime_to_UTC</Name>
+        <Type Namespace="Tc2_Utilities">FB_TzSpecificLocalTimeToSystemTime</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>22464</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetTimeZone</Name>
+        <Type Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Type>
+        <BitSize>3712</BitSize>
+        <BitOffs>26112</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name>VERSION</Name>
       <BitSize>64</BitSize>
       <SubItem>
@@ -24872,28 +33922,6 @@ External Setpoint Generation:
         <Type>UINT</Type>
         <BitSize>16</BitSize>
         <BitOffs>48</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name GUID="{5456DAC5-9FA5-4A6B-B497-840FCC690FDD}" Namespace="PLC" TcBaseType="true">PlcLicenseInfo</Name>
-      <BitSize>1024</BitSize>
-      <SubItem>
-        <Name>LicenseId</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Instances</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LicenseName</Name>
-        <Type GUID="{18071995-0000-0000-0000-00010000005F}">STRING(95)</Type>
-        <BitSize>768</BitSize>
-        <BitOffs>256</BitOffs>
       </SubItem>
     </DataType>
     <DataType>
@@ -25355,12 +34383,7 @@ External Setpoint Generation:
     <Module GUID="{DED1545C-5FCD-48E2-B686-7D2C250A3641}" TcSmClass="TComPlcObjDef">
       <Name>Library</Name>
       <CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
-      <Licenses>
-        <License>
-          <LicenseId>{bca6ee0a-9ce1-4d3f-98ca-413abc0d94fd}</LicenseId>
-          <Comment>TF6340 TC3 Serial-Communication</Comment>
-        </License>
-      </Licenses>
+      <Licenses/>
       <Contexts>
         <Context>
           <Id NeedCalleeCall="true">0</Id>
@@ -25376,7 +34399,7 @@ External Setpoint Generation:
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1900544</ByteSize>
+          <ByteSize>80216064</ByteSize>
           <Symbol>
             <Name>LCLS_General.DefaultGlobals.stSys.I_EcatMaster1</Name>
             <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
@@ -25404,7 +34427,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8677120</BitOffs>
+            <BitOffs>634736000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.bLimitForwardEnable</Name>
@@ -25427,7 +34450,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8685056</BitOffs>
+            <BitOffs>634744000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.bLimitBackwardEnable</Name>
@@ -25450,7 +34473,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8685064</BitOffs>
+            <BitOffs>634744008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.bHome</Name>
@@ -25473,7 +34496,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8685072</BitOffs>
+            <BitOffs>634744016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.bHardwareEnable</Name>
@@ -25496,7 +34519,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8685088</BitOffs>
+            <BitOffs>634744032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.nRawEncoderULINT</Name>
@@ -25509,7 +34532,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8685120</BitOffs>
+            <BitOffs>634744064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.nRawEncoderUINT</Name>
@@ -25522,7 +34545,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8685184</BitOffs>
+            <BitOffs>634744128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.nRawEncoderINT</Name>
@@ -25535,7 +34558,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8685200</BitOffs>
+            <BitOffs>634744144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.fbMotionStageSim.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -25547,7 +34570,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8699904</BitOffs>
+            <BitOffs>634763008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.Axis.NcToPlc</Name>
@@ -25559,7 +34582,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8885696</BitOffs>
+            <BitOffs>635108416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.bLimitForwardEnable</Name>
@@ -25582,7 +34605,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8893632</BitOffs>
+            <BitOffs>635116416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.bLimitBackwardEnable</Name>
@@ -25605,7 +34628,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8893640</BitOffs>
+            <BitOffs>635116424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.bHome</Name>
@@ -25628,7 +34651,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8893648</BitOffs>
+            <BitOffs>635116432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.bHardwareEnable</Name>
@@ -25651,7 +34674,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8893664</BitOffs>
+            <BitOffs>635116448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.nRawEncoderULINT</Name>
@@ -25664,7 +34687,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8893696</BitOffs>
+            <BitOffs>635116480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.nRawEncoderUINT</Name>
@@ -25677,7 +34700,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8893760</BitOffs>
+            <BitOffs>635116544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.nRawEncoderINT</Name>
@@ -25690,7 +34713,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8893776</BitOffs>
+            <BitOffs>635116560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.fbMotion.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -25702,14 +34725,14 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>8908480</BitOffs>
+            <BitOffs>635135424</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1900544</ByteSize>
+          <ByteSize>80216064</ByteSize>
           <Symbol>
             <Name>Interactive.M1.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -25720,7 +34743,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>8676096</BitOffs>
+            <BitOffs>634734976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.M1.bBrakeRelease</Name>
@@ -25743,7 +34766,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>8685080</BitOffs>
+            <BitOffs>634744024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.fbMotionStageSim.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -25755,7 +34778,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>8698880</BitOffs>
+            <BitOffs>634761984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.Axis.PlcToNc</Name>
@@ -25767,7 +34790,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>8884672</BitOffs>
+            <BitOffs>635107392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.Motor.bBrakeRelease</Name>
@@ -25790,7 +34813,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>8893656</BitOffs>
+            <BitOffs>635116440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>BasicTests.fbMotion.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -25802,14 +34825,14 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>8907456</BitOffs>
+            <BitOffs>635134400</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1900544</ByteSize>
+          <ByteSize>80216064</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -25831,16 +34854,32 @@ External Setpoint Generation:
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-		pv: @(PREFIX)LCLSGeneral:GlobalLogTrickleTrip
-		io: i
-		field: DESC Tripped by overall log count
-	</Value>
+        pv: @(PREFIX)LCLSGeneral:GlobalLogTrickleTrip
+        io: i
+        field: DESC Tripped by overall log count
+    </Value>
               </Property>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
             <BitOffs>4096088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GeneralConstants.MAX_STATES</Name>
+            <Comment> 16 including "Unknown" is the max for an EPICS MBBI
+ This is the max number of user-defined states (OUT, TARGET1, YAG...)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>15</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.iLogPort</Name>
@@ -25853,26 +34892,11 @@ External Setpoint Generation:
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-		pv: @(PREFIX)LCLSGeneral:LogPort
-		io: io
-		field: DESC The log host UDP port
-	</Value>
+        pv: @(PREFIX)LCLSGeneral:LogPort
+        io: io
+        field: DESC The log host UDP port
+    </Value>
               </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
-            <Comment> Trip if `nLocalTripThreshold` exceeded `nMinTimeViolationAcceptable` times</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>5</Value>
-            </Default>
-            <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
@@ -25893,14 +34917,14 @@ External Setpoint Generation:
           <Symbol>
             <Name>GVL_Logger.cLogHost</Name>
             <Comment>
-	Using the IP address directly avoids DNS configuration issues.
-	While we may want to address this in the future, for now the static IP
-	will suffice:
+    Using the IP address directly avoids DNS configuration issues.
+    While we may want to address this in the future, for now the static IP
+    will suffice:
 
-	$ nslookup ctl-logsrv01
-	Name:   ctl-logsrv01.pcdsn
-	Address: 172.21.32.36
-	</Comment>
+    $ nslookup ctl-logsrv01
+    Name:   ctl-logsrv01.pcdsn
+    Address: 172.21.32.36
+    </Comment>
             <BitSize>128</BitSize>
             <BaseType>STRING(15)</BaseType>
             <Default>
@@ -25910,10 +34934,10 @@ External Setpoint Generation:
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-		pv: @(PREFIX)LCLSGeneral:LogHost
-		io: io
-		field: DESC The log host IP address
-	</Value>
+        pv: @(PREFIX)LCLSGeneral:LogHost
+        io: io
+        field: DESC The log host IP address
+    </Value>
               </Property>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -25966,12 +34990,12 @@ External Setpoint Generation:
             <BitOffs>4096384</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
-            <Comment> Default trickle trip, activated by global threshold</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
+            <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
+            <Comment> Trip if `nLocalTripThreshold` exceeded `nMinTimeViolationAcceptable` times</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
             <Default>
-              <Value>100</Value>
+              <Value>5</Value>
             </Default>
             <Properties>
               <Property>
@@ -25979,65 +35003,6 @@ External Setpoint Generation:
               </Property>
             </Properties>
             <BitOffs>4096416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nTrickleTripTime</Name>
-            <Comment> Default time for log-handler to recognize a trickle overload condition, many log-message FB occasionally creating a message</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>10000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nTripResetPeriod</Name>
-            <Comment> Default time for CB auto-reset</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>600000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.sPlcHostname</Name>
-            <BitSize>648</BitSize>
-            <BaseType>STRING(80)</BaseType>
-            <Default>
-              <String>unknown</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_INVALID</Name>
-            <Comment> Retain data is invalid </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4097160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_LOGGER</Name>
@@ -26052,16 +35017,28 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097168</BitOffs>
+            <BitOffs>4096432</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
-            <Comment> Ref: https://infosys.beckhoff.com/english.php?content=../content/1033/tcpipserver/html/TcPlcLibTcpIp_FB_SocketUdpSendTo.htm
-		TODO: Activate the "Replace constants" option in the
-		TwinCAT PLC Control-&gt;"Project-&gt;Options...-&gt;Build" dialog window. 
-	</Comment>
+            <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
+            <Comment> Default trickle trip, activated by global threshold</Comment>
             <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTrickleTripTime</Name>
+            <Comment> Default time for log-handler to recognize a trickle overload condition, many log-message FB occasionally creating a message</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
             <Default>
               <Value>10000</Value>
             </Default>
@@ -26070,13 +35047,78 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097184</BitOffs>
+            <BitOffs>4096480</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Logger.fbRootLogger</Name>
-            <Comment>Instantiated here to be used everywhere</Comment>
-            <BitSize>130240</BitSize>
-            <BaseType Namespace="LCLS_General">FB_LogMessage</BaseType>
+            <Name>GVL_Logger.nTripResetPeriod</Name>
+            <Comment> Default time for CB auto-reset</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>600000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.sPlcHostname</Name>
+            <BitSize>648</BitSize>
+            <BaseType>STRING(80)</BaseType>
+            <Default>
+              <String>unknown</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_INVALID</Name>
+            <Comment> Retain data is invalid </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4097192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_EVENTLOG</Name>
+            <Comment> Event logger </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>110</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4097200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
+            <Comment> Ref: https://infosys.beckhoff.com/english.php?content=../content/1033/tcpipserver/html/TcPlcLibTcpIp_FB_SocketUdpSendTo.htm
+        TODO: Activate the "Replace constants" option in the
+        TwinCAT PLC Control-&gt;"Project-&gt;Options...-&gt;Build" dialog window.
+    </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>10000</Value>
+            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -26093,20 +35135,32 @@ External Setpoint Generation:
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-		pv: @(PREFIX)LCLSGeneral:LogMessageCount
-		io: i
-		field: DESC Total log messages on the last cycle
-	</Value>
+        pv: @(PREFIX)LCLSGeneral:LogMessageCount
+        io: i
+        field: DESC Total log messages on the last cycle
+    </Value>
               </Property>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227456</BitOffs>
+            <BitOffs>4097248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.fbRootLogger</Name>
+            <Comment>Instantiated here to be used everywhere</Comment>
+            <BitSize>86016</BitSize>
+            <BaseType Namespace="LCLS_General">FB_LogMessage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4097280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nTrickleThreshold</Name>
-            <Comment> If GlobAccEvents goes over this level for longer than the </Comment>
+            <Comment> If GlobAccEvents goes over this level for longer than the</Comment>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
             <Default>
@@ -26117,7 +35171,87 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227488</BitOffs>
+            <BitOffs>4183296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_EtherCAT</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>21</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.21.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4183328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_Standard</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.3.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4183616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_System</Name>
@@ -26134,15 +35268,19 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>21</Value>
+                <Value>26</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
                 <Value>0</Value>
               </SubItem>
               <SubItem>
+                <Name>.nFlags</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
                 <Name>.sVersion</Name>
-                <String>3.4.21.0</String>
+                <String>3.4.26.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -26153,22 +35291,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.AMSPORT_EVENTLOG</Name>
-            <Comment> Event logger </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>110</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4227808</BitOffs>
+            <BitOffs>4183904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_RTIME</Name>
@@ -26183,7 +35306,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227824</BitOffs>
+            <BitOffs>4184192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_IO</Name>
@@ -26198,7 +35321,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227840</BitOffs>
+            <BitOffs>4184208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NC</Name>
@@ -26212,7 +35335,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227856</BitOffs>
+            <BitOffs>4184224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSAF</Name>
@@ -26226,7 +35349,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227872</BitOffs>
+            <BitOffs>4184240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSVB</Name>
@@ -26240,7 +35363,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227888</BitOffs>
+            <BitOffs>4184256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_ISG</Name>
@@ -26254,7 +35377,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227904</BitOffs>
+            <BitOffs>4184272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CNC</Name>
@@ -26268,7 +35391,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227920</BitOffs>
+            <BitOffs>4184288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_LINE</Name>
@@ -26282,7 +35405,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227936</BitOffs>
+            <BitOffs>4184304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC</Name>
@@ -26296,7 +35419,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227952</BitOffs>
+            <BitOffs>4184320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS1</Name>
@@ -26311,7 +35434,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227968</BitOffs>
+            <BitOffs>4184336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS2</Name>
@@ -26326,7 +35449,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4227984</BitOffs>
+            <BitOffs>4184352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS3</Name>
@@ -26341,7 +35464,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228000</BitOffs>
+            <BitOffs>4184368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS4</Name>
@@ -26356,7 +35479,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228016</BitOffs>
+            <BitOffs>4184384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAM</Name>
@@ -26370,7 +35493,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228032</BitOffs>
+            <BitOffs>4184400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAMTOOL</Name>
@@ -26385,7 +35508,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228048</BitOffs>
+            <BitOffs>4184416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
@@ -26400,7 +35523,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228064</BitOffs>
+            <BitOffs>4184432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SCOPESERVER</Name>
@@ -26415,7 +35538,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228080</BitOffs>
+            <BitOffs>4184448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INVALID</Name>
@@ -26430,7 +35553,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228096</BitOffs>
+            <BitOffs>4184464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_IDLE</Name>
@@ -26444,7 +35567,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228112</BitOffs>
+            <BitOffs>4184480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESET</Name>
@@ -26458,7 +35581,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228128</BitOffs>
+            <BitOffs>4184496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INIT</Name>
@@ -26472,7 +35595,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228144</BitOffs>
+            <BitOffs>4184512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_START</Name>
@@ -26486,7 +35609,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228160</BitOffs>
+            <BitOffs>4184528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RUN</Name>
@@ -26500,7 +35623,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228176</BitOffs>
+            <BitOffs>4184544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOP</Name>
@@ -26514,7 +35637,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228192</BitOffs>
+            <BitOffs>4184560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SAVECFG</Name>
@@ -26528,7 +35651,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228208</BitOffs>
+            <BitOffs>4184576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_LOADCFG</Name>
@@ -26542,7 +35665,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228224</BitOffs>
+            <BitOffs>4184592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERFAILURE</Name>
@@ -26556,7 +35679,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228240</BitOffs>
+            <BitOffs>4184608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERGOOD</Name>
@@ -26570,7 +35693,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228256</BitOffs>
+            <BitOffs>4184624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_ERROR</Name>
@@ -26584,7 +35707,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228272</BitOffs>
+            <BitOffs>4184640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SHUTDOWN</Name>
@@ -26598,7 +35721,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228288</BitOffs>
+            <BitOffs>4184656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SUSPEND</Name>
@@ -26612,7 +35735,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228304</BitOffs>
+            <BitOffs>4184672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESUME</Name>
@@ -26626,7 +35749,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228320</BitOffs>
+            <BitOffs>4184688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_CONFIG</Name>
@@ -26641,7 +35764,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228336</BitOffs>
+            <BitOffs>4184704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RECONFIG</Name>
@@ -26656,7 +35779,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228352</BitOffs>
+            <BitOffs>4184720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOPPING</Name>
@@ -26670,7 +35793,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228368</BitOffs>
+            <BitOffs>4184736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INCOMPATIBLE</Name>
@@ -26684,7 +35807,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228384</BitOffs>
+            <BitOffs>4184752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_EXCEPTION</Name>
@@ -26698,7 +35821,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228400</BitOffs>
+            <BitOffs>4184768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_MAXSTATES</Name>
@@ -26713,36 +35836,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_REQUESTED</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228432</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_LOADED</Name>
-            <Comment> Persistent data loaded </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4228440</BitOffs>
+            <BitOffs>4184784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMTAB</Name>
@@ -26757,7 +35851,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228448</BitOffs>
+            <BitOffs>4184800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMNAME</Name>
@@ -26772,7 +35866,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228480</BitOffs>
+            <BitOffs>4184832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMVAL</Name>
@@ -26787,7 +35881,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228512</BitOffs>
+            <BitOffs>4184864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_HNDBYNAME</Name>
@@ -26801,7 +35895,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228544</BitOffs>
+            <BitOffs>4184896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VALBYNAME</Name>
@@ -26815,7 +35909,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228576</BitOffs>
+            <BitOffs>4184928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VALBYHND</Name>
@@ -26829,7 +35923,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228608</BitOffs>
+            <BitOffs>4184960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_RELEASEHND</Name>
@@ -26843,7 +35937,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228640</BitOffs>
+            <BitOffs>4184992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAME</Name>
@@ -26857,7 +35951,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228672</BitOffs>
+            <BitOffs>4185024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VERSION</Name>
@@ -26871,7 +35965,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228704</BitOffs>
+            <BitOffs>4185056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAMEEX</Name>
@@ -26885,7 +35979,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228736</BitOffs>
+            <BitOffs>4185088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_DOWNLOAD</Name>
@@ -26899,7 +35993,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228768</BitOffs>
+            <BitOffs>4185120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_UPLOAD</Name>
@@ -26913,7 +36007,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228800</BitOffs>
+            <BitOffs>4185152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_UPLOADINFO</Name>
@@ -26927,7 +36021,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228832</BitOffs>
+            <BitOffs>4185184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMNOTE</Name>
@@ -26942,7 +36036,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228864</BitOffs>
+            <BitOffs>4185216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIB</Name>
@@ -26957,7 +36051,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228896</BitOffs>
+            <BitOffs>4185248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIX</Name>
@@ -26972,7 +36066,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228928</BitOffs>
+            <BitOffs>4185280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RISIZE</Name>
@@ -26987,7 +36081,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228960</BitOffs>
+            <BitOffs>4185312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOB</Name>
@@ -27002,7 +36096,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4228992</BitOffs>
+            <BitOffs>4185344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOX</Name>
@@ -27017,7 +36111,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229024</BitOffs>
+            <BitOffs>4185376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_ROSIZE</Name>
@@ -27032,7 +36126,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229056</BitOffs>
+            <BitOffs>4185408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARI</Name>
@@ -27047,7 +36141,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229088</BitOffs>
+            <BitOffs>4185440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARO</Name>
@@ -27062,7 +36156,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229120</BitOffs>
+            <BitOffs>4185472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIOB</Name>
@@ -27077,7 +36171,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229152</BitOffs>
+            <BitOffs>4185504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_DEVICE_DATA</Name>
@@ -27092,7 +36186,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229184</BitOffs>
+            <BitOffs>4185536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIOFFS_DEVDATA_ADSSTATE</Name>
@@ -27107,7 +36201,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229216</BitOffs>
+            <BitOffs>4185568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIOFFS_DEVDATA_DEVSTATE</Name>
@@ -27122,7 +36216,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229248</BitOffs>
+            <BitOffs>4185600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENCREATE</Name>
@@ -27137,7 +36231,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229280</BitOffs>
+            <BitOffs>4185632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENREAD</Name>
@@ -27152,7 +36246,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229312</BitOffs>
+            <BitOffs>4185664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENWRITE</Name>
@@ -27167,7 +36261,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229344</BitOffs>
+            <BitOffs>4185696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CREATEFILE</Name>
@@ -27182,7 +36276,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229376</BitOffs>
+            <BitOffs>4185728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CLOSEHANDLE</Name>
@@ -27197,7 +36291,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229408</BitOffs>
+            <BitOffs>4185760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FOPEN</Name>
@@ -27211,7 +36305,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229440</BitOffs>
+            <BitOffs>4185792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FCLOSE</Name>
@@ -27225,7 +36319,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229472</BitOffs>
+            <BitOffs>4185824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FREAD</Name>
@@ -27239,7 +36333,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229504</BitOffs>
+            <BitOffs>4185856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FWRITE</Name>
@@ -27253,7 +36347,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229536</BitOffs>
+            <BitOffs>4185888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FSEEK</Name>
@@ -27267,7 +36361,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229568</BitOffs>
+            <BitOffs>4185920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FTELL</Name>
@@ -27281,7 +36375,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229600</BitOffs>
+            <BitOffs>4185952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FGETS</Name>
@@ -27295,7 +36389,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229632</BitOffs>
+            <BitOffs>4185984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FPUTS</Name>
@@ -27309,7 +36403,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229664</BitOffs>
+            <BitOffs>4186016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FSCANF</Name>
@@ -27323,7 +36417,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229696</BitOffs>
+            <BitOffs>4186048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FPRINTF</Name>
@@ -27337,7 +36431,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229728</BitOffs>
+            <BitOffs>4186080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FEOF</Name>
@@ -27351,7 +36445,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229760</BitOffs>
+            <BitOffs>4186112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FDELETE</Name>
@@ -27365,7 +36459,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229792</BitOffs>
+            <BitOffs>4186144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FRENAME</Name>
@@ -27379,7 +36473,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229824</BitOffs>
+            <BitOffs>4186176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_MKDIR</Name>
@@ -27393,7 +36487,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229856</BitOffs>
+            <BitOffs>4186208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_RMDIR</Name>
@@ -27407,7 +36501,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229888</BitOffs>
+            <BitOffs>4186240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
@@ -27421,7 +36515,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229920</BitOffs>
+            <BitOffs>4186272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_SENDEMAIL</Name>
@@ -27435,7 +36529,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229952</BitOffs>
+            <BitOffs>4186304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_TIMESERVICES</Name>
@@ -27449,7 +36543,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4229984</BitOffs>
+            <BitOffs>4186336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_STARTPROCESS</Name>
@@ -27463,7 +36557,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230016</BitOffs>
+            <BitOffs>4186368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CHANGENETID</Name>
@@ -27477,7 +36571,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230048</BitOffs>
+            <BitOffs>4186400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_DATEANDTIME</Name>
@@ -27492,7 +36586,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230080</BitOffs>
+            <BitOffs>4186432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_SYSTEMTIMES</Name>
@@ -27506,7 +36600,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230112</BitOffs>
+            <BitOffs>4186464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_RTCTIMEDIFF</Name>
@@ -27520,7 +36614,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230144</BitOffs>
+            <BitOffs>4186496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_ADJUSTTIMETORTC</Name>
@@ -27534,7 +36628,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230176</BitOffs>
+            <BitOffs>4186528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_TIMEZONINFORMATION</Name>
@@ -27548,7 +36642,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230208</BitOffs>
+            <BitOffs>4186560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
@@ -27563,7 +36657,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230240</BitOffs>
+            <BitOffs>4186592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_WARN</Name>
@@ -27578,7 +36672,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230272</BitOffs>
+            <BitOffs>4186624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
@@ -27593,7 +36687,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230304</BitOffs>
+            <BitOffs>4186656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
@@ -27608,7 +36702,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230336</BitOffs>
+            <BitOffs>4186688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_MSGBOX</Name>
@@ -27623,7 +36717,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230368</BitOffs>
+            <BitOffs>4186720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_RESOURCE</Name>
@@ -27637,7 +36731,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230400</BitOffs>
+            <BitOffs>4186752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_STRING</Name>
@@ -27651,7 +36745,36 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230432</BitOffs>
+            <BitOffs>4186784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_REQUESTED</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4186816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_LOADED</Name>
+            <Comment> Persistent data loaded </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4186824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_INVALID</Name>
@@ -27666,7 +36789,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230464</BitOffs>
+            <BitOffs>4186832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_BSOD</Name>
@@ -27681,7 +36804,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230472</BitOffs>
+            <BitOffs>4186840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_RTVIOLATION</Name>
@@ -27696,7 +36819,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230480</BitOffs>
+            <BitOffs>4186848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.nWatchdogTime</Name>
@@ -27708,97 +36831,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODEREAD</Name>
-            <Comment>"r": Opens for reading. If the file does not exist or cannot be found, the call fails.</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4230496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODEWRITE</Name>
-            <Comment>"w": Opens an empty file for writing. If the given file exists, its contents are destroyed.</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4230528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODEAPPEND</Name>
-            <Comment>"a": Opens for writing at the end of the file (appending) without removing the EOF marker before writing new data to the file; creates the file first if it doesnot exist.</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4230560</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODEPLUS</Name>
-            <Comment>"+": Opens for reading and writing</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>8</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4230592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODEBINARY</Name>
-            <Comment>"b": Open in binary (untranslated) mode.</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4230624</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.FOPEN_MODETEXT</Name>
-            <Comment>"t": Open in text (translated) mode.</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>32</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4230656</BitOffs>
+            <BitOffs>4186856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_PRIOCLASS</Name>
@@ -27813,7 +36846,97 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230912</BitOffs>
+            <BitOffs>4186864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODEREAD</Name>
+            <Comment>"r": Opens for reading. If the file does not exist or cannot be found, the call fails.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4186880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODEWRITE</Name>
+            <Comment>"w": Opens an empty file for writing. If the given file exists, its contents are destroyed.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4186912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODEAPPEND</Name>
+            <Comment>"a": Opens for writing at the end of the file (appending) without removing the EOF marker before writing new data to the file; creates the file first if it doesnot exist.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4186944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODEPLUS</Name>
+            <Comment>"+": Opens for reading and writing</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>8</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4186976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODEBINARY</Name>
+            <Comment>"b": Open in binary (untranslated) mode.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4187008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.FOPEN_MODETEXT</Name>
+            <Comment>"t": Open in text (translated) mode.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>32</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4187040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_FMTSELF</Name>
@@ -27828,7 +36951,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230928</BitOffs>
+            <BitOffs>4187296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_LOG</Name>
@@ -27843,7 +36966,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230944</BitOffs>
+            <BitOffs>4187312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_MSGBOX</Name>
@@ -27858,7 +36981,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230960</BitOffs>
+            <BitOffs>4187328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_SRCID</Name>
@@ -27873,7 +36996,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230976</BitOffs>
+            <BitOffs>4187344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_AUTOFMTALL</Name>
@@ -27887,7 +37010,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4230992</BitOffs>
+            <BitOffs>4187360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_INVALID</Name>
@@ -27902,7 +37025,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231008</BitOffs>
+            <BitOffs>4187376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_SIGNALED</Name>
@@ -27917,7 +37040,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231024</BitOffs>
+            <BitOffs>4187392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESET</Name>
@@ -27932,7 +37055,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231040</BitOffs>
+            <BitOffs>4187408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_CONFIRMED</Name>
@@ -27947,7 +37070,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231056</BitOffs>
+            <BitOffs>4187424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESETCON</Name>
@@ -27962,7 +37085,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231072</BitOffs>
+            <BitOffs>4187440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_SRCNAMESIZE</Name>
@@ -27976,7 +37099,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231088</BitOffs>
+            <BitOffs>4187456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_FMTPRGSIZE</Name>
@@ -27990,21 +37113,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.eWatchdogConfig</Name>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="Tc2_System">E_WATCHDOG_TIME_CONFIG</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4231120</BitOffs>
+            <BitOffs>4187472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_ADS_TIMEOUT</Name>
@@ -28019,7 +37128,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231136</BitOffs>
+            <BitOffs>4187488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.PI</Name>
@@ -28033,7 +37142,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231168</BitOffs>
+            <BitOffs>4187520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_STRING_LENGTH</Name>
@@ -28048,85 +37157,12 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4231232</BitOffs>
+            <BitOffs>4187584</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Version.stLibVersion_Tc3_Module</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>20</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>3.3.20.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4231776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_Tc2_Utilities</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>35</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>3.3.35.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4232448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.GLOBAL_DCF77_SEQUENCE_CHECK</Name>
-            <Comment> TRUE = Enable DCF77 telegram plausibility check (two telegrams are checked), FALSE = Disable check </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>Global_Variables.eWatchdogConfig</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="Tc2_System">E_WATCHDOG_TIME_CONFIG</BaseType>
             <Default>
               <Value>0</Value>
             </Default>
@@ -28135,7 +37171,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4232744</BitOffs>
+            <BitOffs>4188128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_AVERAGE_MEASURES</Name>
@@ -28158,7 +37194,83 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4232752</BitOffs>
+            <BitOffs>4188144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc3_Module</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>21</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.21.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4188160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_Utilities</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>54</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.54.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4188800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_FORMAT_HASH_PREFIX_TYPE</Name>
@@ -28173,7 +37285,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4232832</BitOffs>
+            <BitOffs>4189088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_SBCS_TABLE</Name>
@@ -28188,7 +37300,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4232848</BitOffs>
+            <BitOffs>4189104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_DCF77_PULSE_SPLIT</Name>
@@ -28203,7 +37315,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4232864</BitOffs>
+            <BitOffs>4189120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.GLOBAL_DCF77_SEQUENCE_CHECK</Name>
+            <Comment> TRUE = Enable DCF77 telegram plausibility check (two telegrams are checked), FALSE = Disable check </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4189152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_FIELD_SEP</Name>
@@ -28218,22 +37345,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4232896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_ROUTE_NAME_LEN</Name>
-            <Comment> Max. TwinCAT router route name length </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>31</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4232904</BitOffs>
+            <BitOffs>4189160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_REMOTE_PCS</Name>
@@ -28248,7 +37360,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4232912</BitOffs>
+            <BitOffs>4189168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ADAPTER_NAME_LENGTH</Name>
@@ -28263,7 +37375,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294400</BitOffs>
+            <BitOffs>4250656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ADAPTER_DESCRIPTION_LENGTH</Name>
@@ -28278,7 +37390,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294432</BitOffs>
+            <BitOffs>4250688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ADAPTER_ADDRESS_LENGTH</Name>
@@ -28293,7 +37405,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294464</BitOffs>
+            <BitOffs>4250720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_IPHELPERAPI</Name>
@@ -28308,7 +37420,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294496</BitOffs>
+            <BitOffs>4250752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_IPHOSTNAME</Name>
@@ -28323,7 +37435,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294528</BitOffs>
+            <BitOffs>4250784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.IPHELPERAPI_ADAPTERSINFO</Name>
@@ -28338,7 +37450,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294560</BitOffs>
+            <BitOffs>4250816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.IPHELPERAPI_IPADDRBYHOSTNAME</Name>
@@ -28353,7 +37465,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294592</BitOffs>
+            <BitOffs>4250848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_LOCAL_ADAPTERS</Name>
@@ -28368,7 +37480,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294624</BitOffs>
+            <BitOffs>4250880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_ADDREMOTE</Name>
@@ -28383,7 +37495,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294656</BitOffs>
+            <BitOffs>4250912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_DELREMOTE</Name>
@@ -28398,7 +37510,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294688</BitOffs>
+            <BitOffs>4250944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_ENUMREMOTE</Name>
@@ -28413,7 +37525,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294720</BitOffs>
+            <BitOffs>4250976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ROUTE_FLAG_TEMPORARY</Name>
@@ -28428,7 +37540,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294752</BitOffs>
+            <BitOffs>4251008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ROUTE_FLAG_DYNAMIC</Name>
@@ -28443,7 +37555,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294784</BitOffs>
+            <BitOffs>4251040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ROUTE_FLAG_NOOVERRIDE</Name>
@@ -28458,7 +37570,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294816</BitOffs>
+            <BitOffs>4251072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_ROUTE_NAME_LEN</Name>
+            <Comment> Max. TwinCAT router route name length </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>31</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4251104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_ADDR_LEN</Name>
@@ -28473,7 +37600,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294848</BitOffs>
+            <BitOffs>4251112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MIN_ROUTE_TRANSPORT</Name>
@@ -28488,7 +37615,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294856</BitOffs>
+            <BitOffs>4251120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_TRANSPORT</Name>
@@ -28503,22 +37630,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.DEFAULT_CSV_FIELD_DOUBLE_QUOTE</Name>
-            <Comment> CSV separator constant: double-quote (") =&gt; used to enclose special characters like line breaks, double-quotes, commas... </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>34</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4294872</BitOffs>
+            <BitOffs>4251128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ROUTE_ENTRY</Name>
@@ -28552,7 +37664,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4294880</BitOffs>
+            <BitOffs>4251136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FFILEFIND</Name>
@@ -28567,7 +37679,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296064</BitOffs>
+            <BitOffs>4252320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.HKEY_MAX_BINARY_DATA_SIZE</Name>
@@ -28582,7 +37694,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296096</BitOffs>
+            <BitOffs>4252352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IGR_GENERAL</Name>
@@ -28597,7 +37709,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296128</BitOffs>
+            <BitOffs>4252384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IOF_MODE</Name>
@@ -28612,7 +37724,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296160</BitOffs>
+            <BitOffs>4252416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_AMSLOGGER</Name>
@@ -28627,7 +37739,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296192</BitOffs>
+            <BitOffs>4252448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_MAX_ARGS</Name>
@@ -28642,7 +37754,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296208</BitOffs>
+            <BitOffs>4252464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_NAN</Name>
@@ -28657,7 +37769,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296224</BitOffs>
+            <BitOffs>4252480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_INF</Name>
@@ -28672,7 +37784,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296240</BitOffs>
+            <BitOffs>4252496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_DIGITS</Name>
@@ -28687,7 +37799,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296256</BitOffs>
+            <BitOffs>4252512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_PRECISION</Name>
@@ -28702,7 +37814,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296272</BitOffs>
+            <BitOffs>4252528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MIN_PRECISION</Name>
@@ -28717,7 +37829,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296288</BitOffs>
+            <BitOffs>4252544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_NOERROR</Name>
@@ -28732,7 +37844,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296320</BitOffs>
+            <BitOffs>4252576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PERCENTSIGNPOSITION</Name>
@@ -28747,7 +37859,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296352</BitOffs>
+            <BitOffs>4252608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ASTERISKPOSITION</Name>
@@ -28762,7 +37874,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296384</BitOffs>
+            <BitOffs>4252640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHVALUE</Name>
@@ -28777,7 +37889,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296416</BitOffs>
+            <BitOffs>4252672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONVALUE</Name>
@@ -28792,7 +37904,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296448</BitOffs>
+            <BitOffs>4252704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_FLAGPOSITION</Name>
@@ -28807,7 +37919,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296480</BitOffs>
+            <BitOffs>4252736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHPRECISIONVALPOS</Name>
@@ -28822,7 +37934,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296512</BitOffs>
+            <BitOffs>4252768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONDOTPOSITION</Name>
@@ -28837,7 +37949,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296544</BitOffs>
+            <BitOffs>4252800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_TYPEFIELDVALUE</Name>
@@ -28852,7 +37964,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296576</BitOffs>
+            <BitOffs>4252832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ARGTYPEINVALID</Name>
@@ -28867,7 +37979,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296608</BitOffs>
+            <BitOffs>4252864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_UNACCEPTEDPARAMETER</Name>
@@ -28882,7 +37994,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296640</BitOffs>
+            <BitOffs>4252896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INSUFFICIENTARGS</Name>
@@ -28897,7 +38009,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296672</BitOffs>
+            <BitOffs>4252928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_DESTBUFFOVERFLOW</Name>
@@ -28912,7 +38024,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296704</BitOffs>
+            <BitOffs>4252960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INVALIDPOINTERINPUT</Name>
@@ -28927,7 +38039,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296736</BitOffs>
+            <BitOffs>4252992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMTIME_DATEDELTA_OFFSET</Name>
+            <Comment> Number of past days since year zero until 1 January 1601 </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>584389</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4253024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ARG_VALUE</Name>
@@ -28953,7 +38080,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296768</BitOffs>
+            <BitOffs>4253056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_HEXASC_CODES</Name>
@@ -29102,7 +38229,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4296896</BitOffs>
+            <BitOffs>4253184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_DECASC_CODES</Name>
@@ -29160,7 +38287,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4297152</BitOffs>
+            <BitOffs>4253440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_MONTHDAYS</Name>
@@ -29277,7 +38404,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4302640</BitOffs>
+            <BitOffs>4258928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_YEARSDAY</Name>
@@ -29410,22 +38537,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMTIME_DATEDELTA_OFFSET</Name>
-            <Comment> Number of past days since year zero until 1 January 1601 </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>584389</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4303488</BitOffs>
+            <BitOffs>4259312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC</Name>
@@ -29447,7 +38559,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303520</BitOffs>
+            <BitOffs>4259776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC</Name>
@@ -29469,7 +38581,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303584</BitOffs>
+            <BitOffs>4259840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY</Name>
@@ -29491,7 +38603,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303648</BitOffs>
+            <BitOffs>4259904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN</Name>
@@ -29513,7 +38625,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303712</BitOffs>
+            <BitOffs>4259968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX</Name>
@@ -29535,22 +38647,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.DATE_AND_TIME_SECPERDAY</Name>
-            <Comment> Number of seconds per day </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>86400</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4303840</BitOffs>
+            <BitOffs>4260032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC64</Name>
@@ -29565,7 +38662,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303872</BitOffs>
+            <BitOffs>4260096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC64</Name>
@@ -29580,7 +38677,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4303936</BitOffs>
+            <BitOffs>4260160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY64</Name>
@@ -29595,7 +38692,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4304000</BitOffs>
+            <BitOffs>4260224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN64</Name>
@@ -29610,7 +38707,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4304064</BitOffs>
+            <BitOffs>4260288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX64</Name>
@@ -29625,7 +38722,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4304128</BitOffs>
+            <BitOffs>4260352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.WEST_EUROPE_TZI</Name>
@@ -29698,7 +38795,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4304192</BitOffs>
+            <BitOffs>4260416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.DATE_AND_TIME_SECPERDAY</Name>
+            <Comment> Number of seconds per day </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>86400</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4265376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DATE_AND_TIME_SECPERWEEK</Name>
@@ -29713,7 +38825,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4309152</BitOffs>
+            <BitOffs>4265408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_NONE</Name>
@@ -29728,7 +38840,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4315360</BitOffs>
+            <BitOffs>4271616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_LOG</Name>
@@ -29743,7 +38855,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4315392</BitOffs>
+            <BitOffs>4271648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_FILE</Name>
@@ -29758,7 +38870,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4315424</BitOffs>
+            <BitOffs>4271680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_VISU</Name>
@@ -29773,7 +38885,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4315456</BitOffs>
+            <BitOffs>4271712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.DEFAULT_CSV_FIELD_DOUBLE_QUOTE</Name>
+            <Comment> CSV separator constant: double-quote (") =&gt; used to enclose special characters like line breaks, double-quotes, commas... </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>34</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4390480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_CR</Name>
@@ -29788,7 +38915,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4315504</BitOffs>
+            <BitOffs>4390488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_LF</Name>
@@ -29803,47 +38930,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4315512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Constants.EMPTY_SEVERITY</Name>
-            <BitSize>16</BitSize>
-            <BaseType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4435184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
-            <Comment> Indication of whether the last instantiated test suite has an assert instance created </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4436904</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>500</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4436912</BitOffs>
+            <BitOffs>4391440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRUCT</Name>
@@ -29900,7 +38987,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4436928</BitOffs>
+            <BitOffs>4393184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRING</Name>
@@ -29914,7 +39001,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437056</BitOffs>
+            <BitOffs>4393312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_REGSTRING</Name>
@@ -29928,21 +39015,150 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437352</BitOffs>
+            <BitOffs>4393608</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>.TCPADS_MAXUDP_BUFFSIZE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
+            <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
+            <Comment> TcUnit logs complete test results. These include:
+         - Number of test suites
+         - Number of tests
+         - Number of successful tests
+         - Number of failed tests
+         - Any eventual failed assertion (with the expected &amp; actual value plus an user defined message)
+       These are all printed to the ADS logger (Visual Studio error list) marked with ERROR criticality
+
+       On top of this TcUnit also reports some statistics/extended information with HINT/INFO criticality.
+       These statistics are more detailed results of the tests. This information is used when results are
+       being collected by an external software (such as TcUnit-Runner) to do for example Jenkins integration.
+       This extra information however takes time to print, so by setting the following parameter to FALSE
+       it will speed up TcUnit finishing. </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Default>
-              <Value>8192</Value>
+              <Value>1</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437664</BitOffs>
+            <BitOffs>4393928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_IoFunctions</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>13</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.13.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4394016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_ModbusSrv</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>2</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.2.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4394304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_SerialCom</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>10</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.10.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4394592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_EVENT_CLASS</Name>
@@ -29999,7 +39215,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437696</BitOffs>
+            <BitOffs>4394880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_EVENT_ID</Name>
@@ -30013,7 +39229,35 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437824</BitOffs>
+            <BitOffs>4395008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Constants.EMPTY_SEVERITY</Name>
+            <BitSize>16</BitSize>
+            <BaseType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4395040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>1000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4395056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.SUCCESS_EVENT</Name>
@@ -30078,11 +39322,11 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4437856</BitOffs>
+            <BitOffs>4395072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.nLangId_OnlineMonitoring</Name>
-            <Comment> language id for online monitoring; English(US)=1033 ; German(Germay)=1031</Comment>
+            <Comment> language id for online monitoring; English(US)=1033 ; German(Germany)=1031</Comment>
             <BitSize>32</BitSize>
             <BaseType>DINT</BaseType>
             <Default>
@@ -30093,11 +39337,11 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4438048</BitOffs>
+            <BitOffs>4395264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>ParameterList.cSourceNameSize</Name>
-            <Comment> size [bytes] for source names</Comment>
+            <Comment> size [bytes] for source names (recommended is a size between 128 and 512)</Comment>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
             <Default>
@@ -30116,7 +39360,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4438080</BitOffs>
+            <BitOffs>4395296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_EventLogger</Name>
@@ -30133,7 +39377,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>19</Value>
+                <Value>33</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
@@ -30141,11 +39385,11 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.nFlags</Name>
-                <Value>0</Value>
+                <Value>1</Value>
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>3.1.19.0</String>
+                <String>3.1.33.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -30156,7 +39400,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4438112</BitOffs>
+            <BitOffs>4395328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_INTERNAL.UNINITIALIZED_CLASS_GUID</Name>
@@ -30214,7 +39458,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4438400</BitOffs>
+            <BitOffs>4395616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>.TCPADS_MAXUDP_BUFFSIZE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>8192</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4395744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_JsonXml</Name>
@@ -30231,15 +39489,19 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>4</Value>
+                <Value>18</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
                 <Value>0</Value>
               </SubItem>
               <SubItem>
+                <Name>.nFlags</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
                 <Name>.sVersion</Name>
-                <String>3.3.4.0</String>
+                <String>3.3.18.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -30250,7 +39512,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4438528</BitOffs>
+            <BitOffs>4395776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
@@ -30264,56 +39526,124 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4438816</BitOffs>
+            <BitOffs>4396064</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfAsserts</Name>
+            <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
             <Default>
-              <Value>500</Value>
+              <Value>1000</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4438832</BitOffs>
+            <BitOffs>4396080</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_TcUnit.TcUnitRunner</Name>
-            <BitSize>768</BitSize>
-            <BaseType Namespace="LCLS_General.TcUnit">FB_TcUnitRunner</BaseType>
+            <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
+            <Comment> Enable (TRUE) or disable (FALSE) publishing of the xUnit Xml report </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4438848</BitOffs>
+            <BitOffs>4396096</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
-            <Comment> Pointer to current test suite being called </Comment>
-            <BitSize>64</BitSize>
-            <BaseType PointerTo="1" Namespace="LCLS_General.TcUnit">FB_TestSuite</BaseType>
+            <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
+            <Comment> Indication of whether the last instantiated test suite has an assert instance created </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4439616</BitOffs>
+            <BitOffs>4396104</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
-            <Comment> Current name of test being called </Comment>
+            <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
+            <Comment> This is the maximum number of ADS-messages that can be stored for reporting at the same time.
+       Having a size of 2000 means that it's possible to report up to ~400 test cases in one single
+       PLC cycle. Each entry consumes around 500 bytes, so with an example of a ring buffer size of
+       2000 it means that TcUnit will consume around 1 MB of router memory. </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>2000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4396112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
+            <Comment> Default reserved PLC memory buffer used for composition of the xUnit xml file (64 kb default) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>65535</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4396128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
+            <Comment> Default path and filename for the xunit testresults e.g.: for use with jenkins </Comment>
             <BitSize>2048</BitSize>
             <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Default>
+              <String>C:\tcunit_xunit_testresults.xml</String>
+            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4439680</BitOffs>
+            <BitOffs>4396160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
+            <Comment> Time delay between a test suite is finished and the execution of the next test suite starts
+       if using RUN_IN_SEQUENCE() </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4398208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
+            <Comment> Whether or not the current test being called has finished running </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4398240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
@@ -30327,7 +39657,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4441728</BitOffs>
+            <BitOffs>4398248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -30343,48 +39673,95 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4441744</BitOffs>
+            <BitOffs>4398256</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PMPS_GVL.MAX_FAST_FAULTS</Name>
-            <BitSize>32</BitSize>
-            <BaseType>DINT</BaseType>
-            <Default>
-              <Value>50</Value>
-            </Default>
+            <Name>GVL_TcUnit.TcUnitRunner</Name>
+            <BitSize>621828352</BitSize>
+            <BaseType Namespace="LCLS_General.TcUnit">FB_TcUnitRunner</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4441760</BitOffs>
+            <BitOffs>4398272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
+            <Comment> Pointer to current test suite being called </Comment>
+            <BitSize>64</BitSize>
+            <BaseType PointerTo="1" Namespace="LCLS_General.TcUnit">FB_TestSuite</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>626226624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
+            <Comment> Current name of test being called </Comment>
+            <BitSize>2048</BitSize>
+            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>626226688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
-            <BitSize>32000</BitSize>
+            <BitSize>64000</BitSize>
             <BaseType PointerTo="1" Namespace="LCLS_General.TcUnit">FB_TestSuite</BaseType>
             <ArrayInfo>
               <LBound>1</LBound>
-              <Elements>500</Elements>
+              <Elements>1000</Elements>
             </ArrayInfo>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4441792</BitOffs>
+            <BitOffs>626228736</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_TcUnit.AdsLogger</Name>
-            <Comment> Buffered ADS logger for output to the error list </Comment>
-            <BitSize>4129152</BitSize>
-            <BaseType Namespace="LCLS_General.TcUnit">FB_ADSLogStringMessageFifoQueue</BaseType>
+            <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
+            <Comment> If the user is utilizing the TEST_ORDERED(), we need to keep track of which ordered test is currently running.
+       We do this by defining an array, in where we can see which current TEST_ORDERED() is the one to be handled right now.
+       The below array is only used for TEST_ORDERED()-tests.  </Comment>
+            <BitSize>16000</BitSize>
+            <BaseType>UINT</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>1000</Elements>
+            </ArrayInfo>
+            <Properties>
+              <Property>
+                <Name>LowerBorder</Name>
+                <Value>1</Value>
+              </Property>
+              <Property>
+                <Name>UpperBorder</Name>
+                <Value>100</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>626292736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.AdsMessageQueue</Name>
+            <Comment> Buffered ADS message queue for output to the error list </Comment>
+            <BitSize>8321152</BitSize>
+            <BaseType Namespace="LCLS_General.TcUnit">FB_AdsLogStringMessageFifoQueue</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4473792</BitOffs>
+            <BitOffs>626308736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -30397,7 +39774,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iMinor</Name>
-                <Value>0</Value>
+                <Value>2</Value>
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
@@ -30409,7 +39786,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>1.0.0.0</String>
+                <String>1.2.0.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -30420,12 +39797,12 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8602944</BitOffs>
+            <BitOffs>634629888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stRequestedBeamParameters</Name>
             <Comment>Summarized request for the line, as recognized by the line arbiter PLC</Comment>
-            <BitSize>1216</BitSize>
+            <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
             <Properties>
               <Property>
@@ -30440,12 +39817,12 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8603232</BitOffs>
+            <BitOffs>634630176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stCurrentBeamParameters</Name>
             <Comment>Currently active BP set, broadcast by the line arbiter PLC</Comment>
-            <BitSize>1216</BitSize>
+            <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
             <Properties>
               <Property>
@@ -30460,15 +39837,15 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8604448</BitOffs>
+            <BitOffs>634631936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundaries</Name>
-            <BitSize>512</BitSize>
+            <BitSize>1024</BitSize>
             <BaseType>REAL</BaseType>
             <ArrayInfo>
               <LBound>0</LBound>
-              <Elements>16</Elements>
+              <Elements>32</Elements>
             </ArrayInfo>
             <Properties>
               <Property>
@@ -30485,7 +39862,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8605664</BitOffs>
+            <BitOffs>634633696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
@@ -30500,7 +39877,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8606176</BitOffs>
+            <BitOffs>634634720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.PERange</Name>
@@ -30512,7 +39889,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8606208</BitOffs>
+            <BitOffs>634634752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
@@ -30526,7 +39903,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8606272</BitOffs>
+            <BitOffs>634634816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
@@ -30540,7 +39917,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8606336</BitOffs>
+            <BitOffs>634634880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
@@ -30554,111 +39931,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8606400</BitOffs>
+            <BitOffs>634634944</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PMPS_GVL.MAX_STOPPERS</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
+            <Name>PMPS_GVL.TRANS_SCALING_FACTOR</Name>
+            <Comment> Scaling factor for fixed-point transmission</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
             <Default>
-              <Value>16</Value>
+              <Value>1</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8606432</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>20</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8606448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cstFullBeam</Name>
-            <BitSize>1216</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nTran</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fPP_mJ</Name>
-                <Value>10000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.neVRange</Name>
-                <Value>65535</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nRate</Name>
-                <Value>1000000</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)FullBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC Full beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8606464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cstSafeBeam</Name>
-            <BitSize>1216</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nTran</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fPP_mJ</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.neVRange</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nRate</Name>
-                <Value>0</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)SafeBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC Safe beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8607680</BitOffs>
+            <BitOffs>634634976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
@@ -30673,7 +39961,107 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8608896</BitOffs>
+            <BitOffs>634635008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634635024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stAttenuators</Name>
+            <BitSize>64</BitSize>
+            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.xAttOK</Name>
+                <Value>1</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634635040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstFullBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)FullBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Full beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634635104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cst0RateBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)0RateBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC 0-rate beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634636864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
+            <Comment>  {attribute 'pytmc' := '
+        pv: @(PREFIX)SafeBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Safe beam constant
+    '} 
+   cstSafeBeam    :    ST_BeamParams := (
+        nTran := 0,
+        neVRange := 0,
+        nRate    := 0
+    );</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>20</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634638624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -30688,11 +40076,11 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8608912</BitOffs>
+            <BitOffs>634638640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
-            <BitSize>512</BitSize>
+            <BitSize>1024</BitSize>
             <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
             <ArrayInfo>
               <LBound>1</LBound>
@@ -30707,99 +40095,42 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8608928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.MAX_ASSERTIONS</Name>
-            <Comment>Maximum number of assertions permitted in the arbiter</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>20</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8609440</BitOffs>
+            <BitOffs>634638656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_cBoundaries</Name>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Default>
-              <Value>15</Value>
+              <Value>31</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8609472</BitOffs>
+            <BitOffs>634639680</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Interactive.bInit</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
+            <Comment> Max fast faults for an FFO</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
             <Default>
-              <Value>0</Value>
-            </Default>
-            <BitOffs>8609488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.bOut</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>8609496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.iLowBound_LUnd</Name>
-            <Comment>///////////////////////
-///////////////////////</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>24</Value>
+              <Value>50</Value>
             </Default>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-		pv: @(PREFIX)L:UND:FirstSegment
-		io: i
-	</Value>
-              </Property>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8609504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.iHighBound_LUnd</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>46</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-		pv: @(PREFIX)L:UND:LastSegment
-		io: i
-	</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8609536</BitOffs>
+            <BitOffs>634639696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
-            <Comment>////////////////////////////////////		</Comment>
+            <Comment>///////////////////////
+///////////////////////
+////////////////////////////////////		</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
             <Default>
@@ -30820,79 +40151,15 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8609568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.fPeriod_mm_LUnd</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>26</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: Period
-        io: i
-        field: EGU mm
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8609600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.fLowK_LUnd</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>0.54</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)L:UND:LowK
-        io: i
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8609664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.fHiK_LUnd</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>2.5</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)L:UND:HiK
-        io: i
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8609728</BitOffs>
+            <BitOffs>634639712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
-            <BitSize>512</BitSize>
+            <BitSize>1024</BitSize>
             <BaseType>REAL</BaseType>
             <ArrayInfo>
               <LBound>0</LBound>
-              <Elements>16</Elements>
+              <Elements>32</Elements>
             </ArrayInfo>
             <Default>
               <SubItem>
@@ -30901,63 +40168,127 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>[1]</Name>
-                <Value>2700</Value>
+                <Value>1700</Value>
               </SubItem>
               <SubItem>
                 <Name>[2]</Name>
-                <Value>4400</Value>
+                <Value>2100</Value>
               </SubItem>
               <SubItem>
                 <Name>[3]</Name>
-                <Value>6100</Value>
+                <Value>2500</Value>
               </SubItem>
               <SubItem>
                 <Name>[4]</Name>
-                <Value>7800</Value>
+                <Value>3800</Value>
               </SubItem>
               <SubItem>
                 <Name>[5]</Name>
-                <Value>9500</Value>
+                <Value>4000</Value>
               </SubItem>
               <SubItem>
                 <Name>[6]</Name>
-                <Value>11200</Value>
+                <Value>5000</Value>
               </SubItem>
               <SubItem>
                 <Name>[7]</Name>
-                <Value>12900</Value>
+                <Value>7000</Value>
               </SubItem>
               <SubItem>
                 <Name>[8]</Name>
-                <Value>14600</Value>
+                <Value>7500</Value>
               </SubItem>
               <SubItem>
                 <Name>[9]</Name>
-                <Value>16300</Value>
+                <Value>7700</Value>
               </SubItem>
               <SubItem>
                 <Name>[10]</Name>
-                <Value>18000</Value>
+                <Value>8900</Value>
               </SubItem>
               <SubItem>
                 <Name>[11]</Name>
-                <Value>19700</Value>
+                <Value>10000</Value>
               </SubItem>
               <SubItem>
                 <Name>[12]</Name>
-                <Value>21400</Value>
+                <Value>11100</Value>
               </SubItem>
               <SubItem>
                 <Name>[13]</Name>
-                <Value>23100</Value>
+                <Value>12000</Value>
               </SubItem>
               <SubItem>
                 <Name>[14]</Name>
-                <Value>24800</Value>
+                <Value>13000</Value>
               </SubItem>
               <SubItem>
                 <Name>[15]</Name>
+                <Value>13500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[16]</Name>
+                <Value>14000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[17]</Name>
+                <Value>16900</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[18]</Name>
+                <Value>18000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[19]</Name>
+                <Value>20000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[20]</Name>
+                <Value>22000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[21]</Name>
+                <Value>24000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[22]</Name>
                 <Value>25000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[23]</Name>
+                <Value>25500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[24]</Name>
+                <Value>26000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[25]</Name>
+                <Value>27000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[26]</Name>
+                <Value>28000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[27]</Name>
+                <Value>28500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[28]</Name>
+                <Value>29000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[29]</Name>
+                <Value>30000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[30]</Name>
+                <Value>60000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[31]</Name>
+                <Value>90000</Value>
               </SubItem>
             </Default>
             <Properties>
@@ -30975,80 +40306,144 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8609792</BitOffs>
+            <BitOffs>634639744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
-            <BitSize>512</BitSize>
+            <BitSize>1024</BitSize>
             <BaseType>REAL</BaseType>
             <ArrayInfo>
               <LBound>0</LBound>
-              <Elements>16</Elements>
+              <Elements>32</Elements>
             </ArrayInfo>
             <Default>
               <SubItem>
                 <Name>[0]</Name>
-                <Value>250</Value>
+                <Value>100</Value>
               </SubItem>
               <SubItem>
                 <Name>[1]</Name>
-                <Value>270</Value>
+                <Value>250</Value>
               </SubItem>
               <SubItem>
                 <Name>[2]</Name>
-                <Value>400</Value>
+                <Value>270</Value>
               </SubItem>
               <SubItem>
                 <Name>[3]</Name>
-                <Value>540</Value>
+                <Value>350</Value>
               </SubItem>
               <SubItem>
                 <Name>[4]</Name>
-                <Value>850</Value>
+                <Value>400</Value>
               </SubItem>
               <SubItem>
                 <Name>[5]</Name>
-                <Value>1150</Value>
+                <Value>450</Value>
               </SubItem>
               <SubItem>
                 <Name>[6]</Name>
-                <Value>1250</Value>
+                <Value>480</Value>
               </SubItem>
               <SubItem>
                 <Name>[7]</Name>
-                <Value>1450</Value>
+                <Value>530</Value>
               </SubItem>
               <SubItem>
                 <Name>[8]</Name>
-                <Value>1550</Value>
+                <Value>680</Value>
               </SubItem>
               <SubItem>
                 <Name>[9]</Name>
-                <Value>1650</Value>
+                <Value>730</Value>
               </SubItem>
               <SubItem>
                 <Name>[10]</Name>
-                <Value>1750</Value>
+                <Value>850</Value>
               </SubItem>
               <SubItem>
                 <Name>[11]</Name>
-                <Value>1820</Value>
+                <Value>1100</Value>
               </SubItem>
               <SubItem>
                 <Name>[12]</Name>
-                <Value>2000</Value>
+                <Value>1150</Value>
               </SubItem>
               <SubItem>
                 <Name>[13]</Name>
-                <Value>3200</Value>
+                <Value>1250</Value>
               </SubItem>
               <SubItem>
                 <Name>[14]</Name>
-                <Value>5000</Value>
+                <Value>1450</Value>
               </SubItem>
               <SubItem>
                 <Name>[15]</Name>
-                <Value>7100</Value>
+                <Value>1500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[16]</Name>
+                <Value>1550</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[17]</Name>
+                <Value>1650</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[18]</Name>
+                <Value>1700</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[19]</Name>
+                <Value>1750</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[20]</Name>
+                <Value>1820</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[21]</Name>
+                <Value>1850</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[22]</Name>
+                <Value>2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[23]</Name>
+                <Value>2200</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[24]</Name>
+                <Value>2500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[25]</Name>
+                <Value>2800</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[26]</Name>
+                <Value>3000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[27]</Name>
+                <Value>3150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[28]</Name>
+                <Value>3500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[29]</Name>
+                <Value>4000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[30]</Name>
+                <Value>5300</Value>
+              </SubItem>
+              <SubItem>
+                <Name>[31]</Name>
+                <Value>7000</Value>
               </SubItem>
             </Default>
             <Properties>
@@ -31066,18 +40461,48 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8610304</BitOffs>
+            <BitOffs>634640768</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PMPS_TOOLS.fbJson</Name>
-            <BitSize>384</BitSize>
-            <BaseType Namespace="LCLS_General.Tc3_JsonXml">FB_JsonSaxWriter</BaseType>
+            <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
+            <Comment>Maximum number of BP requests in the arbiter</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>20</Value>
+            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8610816</BitOffs>
+            <BitOffs>634641792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_PARAM.TRANS_MARGIN</Name>
+            <Comment> Allowed % margin above requested transmission level in SafeBPCompare (0.0500 = 5deci% default). Note: change this value if scaling factor changes.</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>0.05</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634641824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_TOOLS.fbJson</Name>
+            <BitSize>384</BitSize>
+            <BaseType Namespace="Tc3_JsonXml">FB_JsonSaxWriter</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634641856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -31094,7 +40519,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>29</Value>
+                <Value>48</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
@@ -31102,11 +40527,11 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.nFlags</Name>
-                <Value>0</Value>
+                <Value>1</Value>
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>3.3.29.0</String>
+                <String>3.3.48.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -31117,25 +40542,28 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8611200</BitOffs>
+            <BitOffs>634642240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.bInit</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <BitOffs>634642528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.bOut</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>634642536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.nCounter</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>8611488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.bGoOut</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>8611504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.bIn</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>8611512</BitOffs>
+            <BitOffs>634642544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -31146,7 +40574,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8611520</BitOffs>
+            <BitOffs>634642560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -31160,7 +40588,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8618624</BitOffs>
+            <BitOffs>634649664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -31174,146 +40602,194 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8618688</BitOffs>
+            <BitOffs>634649728</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Interactive.M1</Name>
-            <BitSize>21056</BitSize>
-            <BaseType>DUT_MotionStage</BaseType>
-            <BitOffs>8676032</BitOffs>
+            <Name>Global_Version.stLibVersion_Tc2_Math</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.1.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634649792</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Interactive.fbMotionStageSim</Name>
-            <BitSize>171328</BitSize>
-            <BaseType>FB_MotionStageSim</BaseType>
-            <BitOffs>8697088</BitOffs>
+            <Name>Interactive.bGoOut</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>634650080</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Interactive.stOut</Name>
-            <BitSize>2432</BitSize>
-            <BaseType>DUT_PositionState</BaseType>
-            <BitOffs>8868416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.fbGoOut</Name>
-            <BitSize>2944</BitSize>
-            <BaseType>FB_PositionStateMove</BaseType>
-            <BitOffs>8870848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.stIn</Name>
-            <BitSize>2432</BitSize>
-            <BaseType>DUT_PositionState</BaseType>
-            <BitOffs>8873792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Interactive.fbGoIn</Name>
-            <BitSize>2944</BitSize>
-            <BaseType>FB_PositionStateMove</BaseType>
-            <BitOffs>8876224</BitOffs>
+            <Name>Interactive.bIn</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>634650088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.bGoIn</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>8879168</BitOffs>
+            <BitOffs>634650096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.bHCF</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>8879176</BitOffs>
+            <BitOffs>634650104</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Interactive.bGoHCF</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>8879184</BitOffs>
+            <Name>Interactive.M1</Name>
+            <BitSize>25280</BitSize>
+            <BaseType>DUT_MotionStage</BaseType>
+            <BitOffs>634734912</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>BasicTests.bError</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>8879192</BitOffs>
+            <Name>Interactive.fbMotionStageSim</Name>
+            <BitSize>327296</BitSize>
+            <BaseType>FB_MotionStageSim</BaseType>
+            <BitOffs>634760192</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>BasicTests.errState</Name>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="Tc2_MC2">MC_AxisStates</BaseType>
-            <BitOffs>8879200</BitOffs>
+            <Name>Interactive.stOut</Name>
+            <BitSize>3648</BitSize>
+            <BaseType>DUT_PositionState</BaseType>
+            <BitOffs>635087488</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>MOTION_GVL.MAX_STATES</Name>
-            <Comment> Allocated space for 6 states besides Unknown (16 including Unknown is the max for an EPICS MBBI)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>6</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8879216</BitOffs>
+            <Name>Interactive.fbGoOut</Name>
+            <BitSize>2944</BitSize>
+            <BaseType>FB_PositionStateMove</BaseType>
+            <BitOffs>635091136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.stIn</Name>
+            <BitSize>3648</BitSize>
+            <BaseType>DUT_PositionState</BaseType>
+            <BitOffs>635094080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Interactive.fbGoIn</Name>
+            <BitSize>2944</BitSize>
+            <BaseType>FB_PositionStateMove</BaseType>
+            <BitOffs>635097728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.stUnsafe</Name>
-            <BitSize>2432</BitSize>
+            <BitSize>3648</BitSize>
             <BaseType>DUT_PositionState</BaseType>
-            <BitOffs>8879232</BitOffs>
+            <BitOffs>635100672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Interactive.fbGoBad</Name>
             <BitSize>2944</BitSize>
             <BaseType>FB_PositionStateMove</BaseType>
-            <BitOffs>8881664</BitOffs>
+            <BitOffs>635104320</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>BasicTests.Motor</Name>
-            <BitSize>21056</BitSize>
-            <BaseType>DUT_MotionStage</BaseType>
-            <BitOffs>8884608</BitOffs>
+            <Name>Interactive.bGoHCF</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>635107264</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>BasicTests.fbMotion</Name>
-            <BitSize>171328</BitSize>
-            <BaseType>FB_MotionStageSim</BaseType>
-            <BitOffs>8905664</BitOffs>
+            <Name>BasicTests.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>635107272</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>BasicTests.fbRequest</Name>
-            <BitSize>1920</BitSize>
-            <BaseType>FB_MotionRequest</BaseType>
-            <BitOffs>9076992</BitOffs>
+            <Name>BasicTests.errState</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="Tc2_MC2">MC_AxisStates</BaseType>
+            <BitOffs>635107280</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>MOTION_GVL.stUnknownState</Name>
-            <BitSize>2432</BitSize>
-            <BaseType>DUT_PositionState</BaseType>
+            <Name>GVL.nHomingError</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
             <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>Unknown</String>
-              </SubItem>
+              <Value>85248</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9079936</BitOffs>
+            <BitOffs>635107296</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>MOTION_GVL.stInvalidState</Name>
-            <BitSize>2432</BitSize>
-            <BaseType>DUT_PositionState</BaseType>
+            <Name>BasicTests.Motor</Name>
+            <BitSize>25280</BitSize>
+            <BaseType>DUT_MotionStage</BaseType>
+            <BitOffs>635107328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>BasicTests.fbMotion</Name>
+            <BitSize>327296</BitSize>
+            <BaseType>FB_MotionStageSim</BaseType>
+            <BitOffs>635132608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>BasicTests.fbRequest</Name>
+            <BitSize>1920</BitSize>
+            <BaseType>FB_MotionRequest</BaseType>
+            <BitOffs>635459904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.fbPmpsFileReader</Name>
+            <BitSize>935360</BitSize>
+            <BaseType Namespace="PMPS">FB_JsonFileToJsonDoc</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9082368</BitOffs>
+            <BitOffs>635462848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.fbStandardPMPSDB</Name>
+            <BitSize>29824</BitSize>
+            <BaseType>FB_Standard_PMPSDB</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)DB
+        io: io
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636398208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_lcls_twincat_motion</Name>
@@ -31346,27 +40822,10 @@ External Setpoint Generation:
                 <Name>const_non_replaced</Name>
               </Property>
               <Property>
-                <Name>linkalways</Name>
-              </Property>
-              <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9084800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL.nHomingError</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>85248</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9085088</BitOffs>
+            <BitOffs>636428032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_ErrorSystem.cSizeOfErrorData</Name>
@@ -31380,7 +40839,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9085120</BitOffs>
+            <BitOffs>636428320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -31395,7 +40854,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9085144</BitOffs>
+            <BitOffs>636428344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -31425,7 +40884,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9085152</BitOffs>
+            <BitOffs>636428352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -31455,7 +40914,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9085216</BitOffs>
+            <BitOffs>636428416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -31470,7 +40929,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9085280</BitOffs>
+            <BitOffs>636428480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -31484,7 +40943,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9085288</BitOffs>
+            <BitOffs>636428488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -31499,7 +40958,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9085296</BitOffs>
+            <BitOffs>636428496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -31514,7 +40973,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9085312</BitOffs>
+            <BitOffs>636428512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -31528,7 +40987,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9085344</BitOffs>
+            <BitOffs>636428544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -31542,90 +41001,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9085376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{5456DAC5-9FA5-4A6B-B497-840FCC690FDD}">PlcLicenseInfo</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>1</Elements>
-            </ArrayInfo>
-            <Default>
-              <SubItem>
-                <Name>[1].LicenseId.Data1</Name>
-                <Value>3165056522</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseId.Data2</Name>
-                <Value>40161</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseId.Data3</Name>
-                <Value>19775</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseId.Data4[0]</Name>
-                <Value>152</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseId.Data4[1]</Name>
-                <Value>202</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseId.Data4[2]</Name>
-                <Value>65</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseId.Data4[3]</Name>
-                <Value>58</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseId.Data4[4]</Name>
-                <Value>188</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseId.Data4[5]</Name>
-                <Value>13</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseId.Data4[6]</Name>
-                <Value>148</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseId.Data4[7]</Name>
-                <Value>253</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].Instances</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>[1].LicenseName</Name>
-                <String>TF6340 TC3 Serial-Communication</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9085408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9086432</BitOffs>
+            <BitOffs>636428576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -31639,7 +41015,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9086464</BitOffs>
+            <BitOffs>636428608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -31657,7 +41033,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9088512</BitOffs>
+            <BitOffs>636430656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636431680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -31671,7 +41061,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9089536</BitOffs>
+            <BitOffs>636431712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -31692,7 +41082,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9089600</BitOffs>
+            <BitOffs>636431744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -31715,14 +41105,14 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9459072</BitOffs>
+            <BitOffs>636479232</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>1900544</ByteSize>
+          <ByteSize>80216064</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -31761,6 +41151,17 @@ External Setpoint Generation:
             </Properties>
             <BitOffs>3072032</BitOffs>
           </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.BP_jsonDoc</Name>
+            <BitSize>64</BitSize>
+            <BaseType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3072064</BitOffs>
+          </Symbol>
         </DataArea>
       </DataAreas>
       <Deployment/>
@@ -31776,15 +41177,15 @@ External Setpoint Generation:
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2020-09-10T11:02:58</Value>
+          <Value>2023-03-28T17:14:21</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>606208</Value>
+          <Value>569344</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>688128</Value>
+          <Value>79073280</Value>
         </Property>
       </Properties>
     </Module>

--- a/lcls-twincat-motion/Library/Library.tmc
+++ b/lcls-twincat-motion/Library/Library.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{91F9B2CC-4D75-DEAF-7FA5-96CD225AE4BA}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FC6A19FD-B8E0-38E2-990B-C7916F508AD2}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
@@ -209,31 +209,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>79580408</GetCodeOffs>
+        <GetCodeOffs>79580400</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>79580480</GetCodeOffs>
+        <GetCodeOffs>79580472</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79580496</GetCodeOffs>
+        <GetCodeOffs>79580488</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79580456</GetCodeOffs>
+        <GetCodeOffs>79580448</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79580488</GetCodeOffs>
+        <GetCodeOffs>79580480</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1472,15 +1472,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79580288</GetCodeOffs>
-        <SetCodeOffs>79580336</SetCodeOffs>
+        <GetCodeOffs>79580280</GetCodeOffs>
+        <SetCodeOffs>79580328</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79580368</GetCodeOffs>
-        <SetCodeOffs>79580392</SetCodeOffs>
+        <GetCodeOffs>79580360</GetCodeOffs>
+        <SetCodeOffs>79580384</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>ExtendName</Name>
@@ -1726,37 +1726,37 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>79580592</GetCodeOffs>
+        <GetCodeOffs>79580584</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>79580552</GetCodeOffs>
+        <GetCodeOffs>79580544</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79580728</GetCodeOffs>
+        <GetCodeOffs>79580720</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79580736</GetCodeOffs>
+        <GetCodeOffs>79580728</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79580648</GetCodeOffs>
+        <GetCodeOffs>79580640</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79580744</GetCodeOffs>
+        <GetCodeOffs>79580736</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -2355,7 +2355,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>79580792</GetCodeOffs>
+        <GetCodeOffs>79580784</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -33730,7 +33730,7 @@ contributing fast faults, unless the FFO is currently vetoed.
     </DataType>
     <DataType>
       <Name>FB_Standard_PMPSDB</Name>
-      <BitSize>29824</BitSize>
+      <BitSize>29760</BitSize>
       <SubItem>
         <Name>io_fbFFHWO</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
@@ -33744,23 +33744,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bRefreshBPs</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
         <Name>bEnable</Name>
         <Type>BOOL</Type>
         <Comment> If TRUE, FB will run. Reads when enable goes TRUE.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
+        <BitOffs>128</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -33773,7 +33761,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>STRING(80)</Type>
         <Comment> E.g. lfe-motion</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>200</BitOffs>
+        <BitOffs>136</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -33786,7 +33774,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> Set to TRUE to cause an extra read.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
+        <BitOffs>784</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -33806,7 +33794,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>STRING(80)</Type>
         <Comment> Directory where the DB is stored.</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>856</BitOffs>
+        <BitOffs>792</BitOffs>
         <Default>
           <String>/Hard Disk/ftp/PMPS/</String>
         </Default>
@@ -33821,7 +33809,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nLastRefreshTime</Name>
         <Type>DINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>1504</BitOffs>
+        <BitOffs>1440</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -33837,35 +33825,47 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>bReadPmpsDb</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1472</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>bExecute</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1536</BitOffs>
+        <BitOffs>1480</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtEnable</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>1600</BitOffs>
+        <BitOffs>1536</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtRefresh</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>1728</BitOffs>
+        <BitOffs>1664</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftBusy</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
         <BitSize>96</BitSize>
-        <BitOffs>1856</BitOffs>
+        <BitOffs>1792</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbTime</Name>
         <Type Namespace="Tc2_Utilities">FB_LocalSystemTime</Type>
         <Comment> Time tracking liften from Arbiter PLCs</Comment>
         <BitSize>20480</BitSize>
-        <BitOffs>1984</BitOffs>
+        <BitOffs>1920</BitOffs>
         <Default>
           <SubItem>
             <Name>.bEnable</Name>
@@ -33881,13 +33881,13 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>fbTime_to_UTC</Name>
         <Type Namespace="Tc2_Utilities">FB_TzSpecificLocalTimeToSystemTime</Type>
         <BitSize>3648</BitSize>
-        <BitOffs>22464</BitOffs>
+        <BitOffs>22400</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbGetTimeZone</Name>
         <Type Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Type>
         <BitSize>3712</BitSize>
-        <BitOffs>26112</BitOffs>
+        <BitOffs>26048</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -40775,7 +40775,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.fbStandardPMPSDB</Name>
-            <BitSize>29824</BitSize>
+            <BitSize>29760</BitSize>
             <BaseType>FB_Standard_PMPSDB</BaseType>
             <Properties>
               <Property>
@@ -40825,7 +40825,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428032</BitOffs>
+            <BitOffs>636427968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_ErrorSystem.cSizeOfErrorData</Name>
@@ -40839,7 +40839,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428320</BitOffs>
+            <BitOffs>636428256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -40854,7 +40854,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428344</BitOffs>
+            <BitOffs>636428280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -40884,7 +40884,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428352</BitOffs>
+            <BitOffs>636428288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -40914,7 +40914,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428416</BitOffs>
+            <BitOffs>636428352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -40929,7 +40929,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428480</BitOffs>
+            <BitOffs>636428416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -40943,7 +40943,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428488</BitOffs>
+            <BitOffs>636428424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -40958,7 +40958,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428496</BitOffs>
+            <BitOffs>636428432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -40973,7 +40973,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428512</BitOffs>
+            <BitOffs>636428448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -40987,7 +40987,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428544</BitOffs>
+            <BitOffs>636428480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -41001,7 +41001,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428576</BitOffs>
+            <BitOffs>636428512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -41015,7 +41015,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636428608</BitOffs>
+            <BitOffs>636428544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -41033,7 +41033,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636430656</BitOffs>
+            <BitOffs>636430592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -41047,7 +41047,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636431680</BitOffs>
+            <BitOffs>636431616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -41061,7 +41061,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636431712</BitOffs>
+            <BitOffs>636431648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -41082,7 +41082,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636431744</BitOffs>
+            <BitOffs>636431680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -41105,7 +41105,7 @@ contributing fast faults, unless the FFO is currently vetoed.
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636479232</BitOffs>
+            <BitOffs>636479168</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -41177,7 +41177,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-03-28T17:14:21</Value>
+          <Value>2023-04-05T16:03:02</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
@@ -4,7 +4,6 @@
     <Declaration><![CDATA[FUNCTION_BLOCK FB_Standard_PMPSDB
 VAR_IN_OUT
     io_fbFFHWO: FB_HardwareFFOutput;
-    bRefreshBPs: BOOL;
 END_VAR
 VAR_INPUT
     // If TRUE, FB will run. Reads when enable goes TRUE.
@@ -26,6 +25,7 @@ VAR_OUTPUT
         io: i
     '}
     nLastRefreshTime: DINT;
+    bReadPmpsDb: BOOL;
 END_VAR
 VAR
     bExecute: BOOL;
@@ -44,9 +44,6 @@ END_VAR
     RETURN;
 END_IF
 
-IF bRefresh = TRUE THEN
-    bRefreshBPs := TRUE;
-END_IF
 rtEnable(CLK:=bEnable);
 rtRefresh(CLK:=bRefresh);
 bRefresh := FALSE;
@@ -69,6 +66,12 @@ MOTION_GVL.fbPmpsFileReader(
 );
 
 ftBusy(CLK:=MOTION_GVL.fbPmpsFileReader.bBusy);
+IF ftBusy.Q THEN
+    bReadPmpsDb := TRUE;
+ELSE
+    bReadPmpsDb := FALSE;
+END_IF
+
 
 // Lifted from Arbiter PLCs: keep track of the time
 fbTime(sNetID:='');

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
@@ -5,7 +5,6 @@
 VAR_IN_OUT
     io_fbFFHWO: FB_HardwareFFOutput;
     bRefreshBPs: BOOL;
-
 END_VAR
 VAR_INPUT
     // If TRUE, FB will run. Reads when enable goes TRUE.

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
@@ -4,6 +4,8 @@
     <Declaration><![CDATA[FUNCTION_BLOCK FB_Standard_PMPSDB
 VAR_IN_OUT
     io_fbFFHWO: FB_HardwareFFOutput;
+    bRefreshBPs: BOOL;
+
 END_VAR
 VAR_INPUT
     // If TRUE, FB will run. Reads when enable goes TRUE.
@@ -41,6 +43,10 @@ END_VAR
     <Implementation>
       <ST><![CDATA[IF NOT bEnable THEN
     RETURN;
+END_IF
+
+IF bRefresh = TRUE THEN
+    bRefreshBPs := TRUE;
 END_IF
 rtEnable(CLK:=bEnable);
 rtRefresh(CLK:=bRefresh);

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.29" ClassName="CNestedPlcProjDef">
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNestedPlcProjDef">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
@@ -1254,6 +1254,11 @@ External Setpoint Generation:
 						<![CDATA[ Any time a FF occurs]]>
 					</Comment>
 					<Type>UDINT</Type>
+					<InOut>7</InOut>
+				</Var>
+				<Var>
+					<Name>PMPS_GVL.BP_jsonDoc</Name>
+					<Type>SJsonValue</Type>
 					<InOut>7</InOut>
 				</Var>
 			</Vars>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add `VAR_OUT` `BOOL` `bReadPmpsDb` to `FB_Standard_PMPSDB`
- Set it high for once when `fbPmpsFileReader.bBusy` is finished.
- Creates a handle to trigger a reload of pmps database parameters not in state implementation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=368318178
Asks for hard coded beam parameters to be loaded from the JSON doc.

## How Has This Been Tested?
This was tested using lcls-plc-tmo-optics/pull/35
https://github.com/pcdshub/lcls-plc-tmo-optics/pull/35
https://github.com/pcdshub/lcls-twincat-optics/pull/18
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
