### PR TITLE
shorten  stEPSForwardEnable structs PVs 

### DIFF
--- a/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
@@ -117,21 +117,21 @@ STRUCT
     nEncoderCount: UDINT;
     // Forward Enable EPS struct
     {attribute 'pytmc' := '
-        pv: PLC:stEPSForwardEnable
+        pv: PLC:stEPSF
         io: i
         field: DESC Forward Enable Interlocks
     '}
     stEPSForwardEnable: DUT_EPS;
     // Backward Enable EPS struct
     {attribute 'pytmc' := '
-        pv: PLC:stEPSBackwardEnable
+        pv: PLC:stEPSB
         io: i
         field: DESC Backward Enable Interlocks
     '}
     stEPSBackwardEnable: DUT_EPS;
     // Power Enable EPS struct
     {attribute 'pytmc' := '
-        pv: PLC:stEPSPowerEnable
+        pv: PLC:stEPSP
         io: i
         field: DESC Power Interlocks
     '}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Shorten EPS pvs.
stEPSForwardEnable -> stEPSF
stEPSBackwardEnable -> stEPSB
stEPSPowerEnable  -> stEPSP

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Long PV names was stopping IOC from being build. 
'ERROR:pytmc.bin.db:Records exceeding the maximum length of 60 were found:'

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Test suite passes locally
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
