### PR TITLE
API: remove many unused PVs that scale with motor/state counts

### DIFF
--- a/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
@@ -9,40 +9,12 @@ STRUCT
     // PLC Axis Reference
     Axis: AXIS_REF;
     // NC Forward Limit Switch: TRUE if ok to move
-    {attribute 'pytmc' := '
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    '}
     bLimitForwardEnable AT %I*: BOOL;
     // NC Backward Limit Switch: TRUE if ok to move
-    {attribute 'pytmc' := '
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    '}
     bLimitBackwardEnable AT %I*: BOOL;
     // NO Home Switch: TRUE if at home
-    {attribute 'pytmc' := '
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    '}
     bHome AT %I*: BOOL;
     // NC Brake Output: TRUE to release brake
-    {attribute 'pytmc' := '
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    '}
     bBrakeRelease AT %Q*: BOOL;
     // NC STO Input: TRUE if ok to move
     {attribute 'pytmc' := '
@@ -64,49 +36,14 @@ STRUCT
     (* Psuedo-hardware *)
 
     // Forward enable EPS summary
-    {attribute 'pytmc' := '
-        pv: PLC:bAllForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to move forward
-    '}
     bAllForwardEnable: BOOL:=FALSE;
     // Backward enable EPS summary
-    {attribute 'pytmc' := '
-        pv: PLC:bAllBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to move backward
-    '}
     bAllBackwardEnable: BOOL:=FALSE;
     // Enable EPS summary encapsulating emergency stop button and any additional motion preventive hardware
-    {attribute 'pytmc' := '
-        pv: PLC:bAllEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to have power
-    '}
     bAllEnable: BOOL:=FALSE;
     // Forward virtual gantry limit switch
-    {attribute 'pytmc' := '
-        pv: PLC:bGantryForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry ok to move forward
-    '}
     bGantryForwardEnable: BOOL:=FALSE;
     // Backward virtual gantry limit switch
-    {attribute 'pytmc' := '
-        pv: PLC:bGantryBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry ok to move backward
-    '}
     bGantryBackwardEnable: BOOL:=FALSE;
     // Encoder count summary, if linked above
     {attribute 'pytmc' := '
@@ -139,50 +76,16 @@ STRUCT
 
     (* Settings *)
     // Name to use for log messages, fast faults, etc.
-    {attribute 'pytmc' := '
-        pv: PLC:sName
-        io: i
-        field: DESC PLC program name
-    '}
     sName: STRING;
     // If TRUE, we want to enable the motor independently of PMPS or other safety systems.
-    {attribute 'pytmc' := '
-        pv: PLC:bPowerSelf
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if axis is in PMPS
-    '}
     bPowerSelf: BOOL:=FALSE;
     // Determines when we automatically enable the motor
-    {attribute 'pytmc' := '
-        pv: PLC:nEnableMode
-        io: i
-        field: DESC Describes when the axis will automatically get power
-    '}
     nEnableMode: E_StageEnableMode:=E_StageEnableMode.DURING_MOTION;
     // Determines when we automatically disengage the brake
-    {attribute 'pytmc' := '
-        pv: PLC:nBrakeMode
-        io: i
-        field: DESC Describes when the brake will be released
-    '}
     nBrakeMode: E_StageBrakeMode:=E_StageBrakeMode.IF_ENABLED;
     // Determines our encoder homing strategy
-    {attribute 'pytmc' := '
-        pv: PLC:nHomingMode
-        io: i
-        field: DESC Describes our homing strategy
-    '}
     nHomingMode: E_EpicsHomeCmd:=E_EpicsHomeCmd.NONE;
     // Set true to activate gantry EPS
-    {attribute 'pytmc' := '
-        pv: PLC:bGantryAxis
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry EPS active
-    '}
     bGantryAxis: BOOL:=FALSE;
 
     // Set to gantry difference tolerance
@@ -193,13 +96,6 @@ STRUCT
 
     (* Commands *)
     // Used internally to request enables
-    {attribute 'pytmc' := '
-        pv: PLC:bEnable
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally to request enables
-    '}
     bEnable: BOOL;
     // Used internally to reset errors and other state
     {attribute 'pytmc' := '
@@ -211,13 +107,6 @@ STRUCT
     '}
     bReset: BOOL;
     // Used internally and by the IOC to start or stop a move
-    {attribute 'pytmc' := '
-        pv: PLC:bExecute
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally and by the IOC to start or stop
-    '}
     bExecute: BOOL;
     // Used by the IOC to disable an axis
     {attribute 'pytmc' := '
@@ -231,11 +120,6 @@ STRUCT
 
     (* Shortcut Commands *)
     // Start a move to fPosition with fVelocity
-    {attribute 'pytmc' := '
-        pv: PLC:bMoveCmd
-        io: io
-        field: DESC Start a move
-    '}
     bMoveCmd: BOOL;
     // Start the homing routine
     {attribute 'pytmc' := '
@@ -247,46 +131,16 @@ STRUCT
 
     (* Command Args *)
     // Used internally and by the IOC to pick what kind of move to do
-    {attribute 'pytmc' := '
-        pv: PLC:nCommand
-        io: io
-        field: DESC Used internally and by the IOC to pick move type
-    '}
     nCommand: INT;
     // Used internally and by the IOC to pass additional data to some commands
-    {attribute 'pytmc' := '
-        pv: PLC:nCmdData
-        io: io
-        field: DESC Used internally and by the IOC to pass extra args
-    '}
     nCmdData: INT;
     // Used internally and by the IOC to pick a destination for the move
-    {attribute 'pytmc' := '
-        pv: PLC:fPosition
-        io: io
-        field: DESC Used internally and by the IOC as the set position
-    '}
     fPosition: LREAL;
     // Used internally and by the IOC to pick a move velocity
-    {attribute 'pytmc' := '
-        pv: PLC:fVelocity
-        io: io
-        field: DESC Used internally and by the IOC to set velocity
-    '}
     fVelocity: LREAL;
     // Used internally and by the IOC to pick a move acceleration
-    {attribute 'pytmc' := '
-        pv: PLC:fAcceleration
-        io: io
-        field: DESC Used internally and by the IOC to set acceleration
-    '}
     fAcceleration: LREAL;
     // Used internally and by the IOC to pick a move deceleration
-    {attribute 'pytmc' := '
-        pv: PLC:fDeceleration
-        io: io
-        field: DESC Used internally and by the IOC to set deceleration
-    '}
     fDeceleration: LREAL;
     // Used internally and by the IOC to pick a home position
     {attribute 'pytmc' := '
@@ -298,56 +152,18 @@ STRUCT
 
     (* Info *)
     // Unique ID assigned to each axis in the NC
-    {attribute 'pytmc' := '
-        pv: PLC:nMotionAxisID
-        io: i
-        field: DESC Unique ID assigned to each axis in the NC
-    '}
     nMotionAxisID: UDINT:=0;
 
     (* Returns *)
     // TRUE if done enabling
-    {attribute 'pytmc' := '
-        pv: PLC:bEnableDone
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if done enabling
-    '}
     bEnableDone: BOOL;
     // TRUE if in the middle of a command
-    {attribute 'pytmc' := '
-        pv: PLC:bBusy
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if in the middle of a command
-    '}
     bBusy: BOOL;
     // TRUE if we've done a command and it has finished
-    {attribute 'pytmc' := '
-        pv: PLC:bDone
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if command finished successfully
-    '}
     bDone: BOOL;
     // TRUE if the motor has been homed, or does not need to be homed
-    {attribute 'pytmc' := '
-        pv: PLC:bHomed
-        io: i
-        field: DESC TRUE if the motor has been homed
-    '}
     bHomed: BOOL;
     // TRUE if we have safety permission to move
-    {attribute 'pytmc' := '
-        pv: PLC:bSafetyReady
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if safe to start a move
-    '}
     bSafetyReady: BOOL;
     // TRUE if we're in an error state
     {attribute 'pytmc' := '

--- a/lcls-twincat-motion/Library/DUTs/ST_PositionState.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/ST_PositionState.TcDUT
@@ -28,12 +28,6 @@ STRUCT
     nEncoderCount: UDINT;
 
     // Maximum allowable deviation from fPosition while at the state
-    {attribute 'pytmc' := '
-        pv: DELTA
-        io: io
-        field: DRVL 0.0
-        field: DESC Max deviation from position at this state
-    '}
     fDelta: LREAL;
 
     // Speed at which to move to this state
@@ -45,19 +39,9 @@ STRUCT
     fVelocity: LREAL;
 
     // (optional) Acceleration to use for moves to this state
-    {attribute 'pytmc' := '
-        pv: ACCL
-        io: io
-        field: DESC Acceleration to use for moves to this state
-    '}
     fAccel: LREAL;
 
     // (optional) Deceleration to use for moves to this state
-    {attribute 'pytmc' := '
-        pv: DCCL
-        io: io
-        field: DESC Deceleration to use for moves to this state
-    '}
     fDecel: LREAL;
 
     // Safety parameter. This must be set to TRUE by the PLC program to allow moves to this state. This is expected to change as conditions change.
@@ -71,23 +55,9 @@ STRUCT
     bMoveOk: BOOL;
 
     // Signifies to FB_PositionStateLock that this state should be immutable
-    {attribute 'pytmc' := '
-        pv: LOCKED
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if state is immutable
-    '}
     bLocked: BOOL;
 
     // Set this to TRUE when you make your state. This defaults to FALSE so that uninitialized states can never be moved to
-    {attribute 'pytmc' := '
-        pv: VALID
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if this is a real state
-    '}
     bValid: BOOL;
 
     // Set this to TRUE when you want to use the raw encoder counts to define the state
@@ -97,9 +67,6 @@ STRUCT
     bUpdated: BOOL;
 
     // We give this a state name and it is used to load parameters from the pmps database.
-    {attribute 'pytmc' := '
-        pv:
-    '}
     stPMPS: ST_DbStateParams;
 END_STRUCT
 END_TYPE]]></Declaration>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
https://docs.google.com/spreadsheets/d/1xfSB1mJwVu4tXvxBT85TEYVi29Z7VoQ4w5CXw13rV8A/edit#gid=0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
> Due to issues with PV count and long boot times in the TMO plc motion IOC, I'm planning to remove a bunch of PVs from the twincat motion library. This should improve the boot time for all the other beckhoff motion IOCs too

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/a, hopefully the pragma lint CI passes

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Google doc and release notes

## Pre-merge checklist
- [x] Code works interactively
- [ ] Test suite passes locally
- [ ] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
