### PR TITLE
FIX: fix bug related to half-full state allocations

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MotionReadPMPSDBND.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MotionReadPMPSDBND.TcPOU
@@ -164,13 +164,11 @@ END_FOR
 // Check for duplicated sPmpsState strings
 FOR nIterState := 0 TO GeneralConstants.MAX_STATES DO
     FOR nIterState2 := 0 TO nIterState DO
-        IF nIterState <> nIterState2 THEN
-            IF asLookupKeys[nIterState] = asLookupKeys[nIterState2] THEN
-                // Duplicated key, we need an error and a flag in both spots
-                bError := TRUE;
-                abStateError[nIterState] := TRUE;
-                abStateError[nIterState2] := TRUE;
-            END_IF
+        IF nIterState <> nIterState2 AND asLookupKeys[nIterState] = asLookupKeys[nIterState2] AND asLookupKeys[nIterState] <> '' THEN
+            // Duplicated key, we need an error and a flag in both spots
+            bError := TRUE;
+            abStateError[nIterState] := TRUE;
+            abStateError[nIterState2] := TRUE;
         END_IF
     END_FOR
 END_FOR

--- a/lcls-twincat-motion/Library/Tests/FB_MotionReadPMPSDBND_Test.TcPOU
+++ b/lcls-twincat-motion/Library/Tests/FB_MotionReadPMPSDBND_Test.TcPOU
@@ -18,6 +18,7 @@ VAR
     astCorrectStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
     astNonsenseStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
     astDuplicatedStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    astHalfFullStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
     nIter: UINT;
 END_VAR
 ]]></Declaration>
@@ -32,7 +33,9 @@ FOR nIter := 1 TO GeneralConstants.MAX_STATES DO
     ELSE
         astDuplicatedStates[nIter].stPMPS.sPmpsState := 'State1';
     END_IF
-
+    IF nIter <= GeneralConstants.MAX_STATES / 2 THEN
+        astHalfFullStates[nIter].stPMPS.sPmpsState := CONCAT('State', UINT_TO_STRING(nIter));
+    END_IF
 END_FOR
 
 TestSolo();
@@ -40,6 +43,7 @@ TestTrio();
 TestNonsense();
 TestDupe();
 TestBackfill();
+TestHalfFull();
 ]]></ST>
     </Implementation>
     <Method Name="TestBackfill" Id="{6760dcd8-2b9b-46e0-8c98-6abb91b3d805}">
@@ -115,7 +119,48 @@ FOR nIter := 0 TO GeneralConstants.MAX_STATES DO
     AssertEquals_STRING(
         Expected:='',
         Actual:=fbRead.astDbStateParams[nIter].sPmpsState,
-        Message:='Errored output should have had no state names',
+        Message:=CONCAT('Errored output should have had no state names: ', UINT_TO_STRING(nIter)),
+    );
+END_FOR
+
+TEST_FINISHED();]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="TestHalfFull" Id="{ba25c1f7-f954-45b5-a656-97aca6a31871}">
+      <Declaration><![CDATA[METHOD TestHalfFull
+VAR_INST
+    fbRead: FB_MotionReadPMPSDBND;
+    astPositionState: ARRAY[1..MotionConstants.MAX_STATE_MOTORS] OF ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    fbFFHWO: FB_HardwareFFOutput := (bAutoReset := TRUE);
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+TEST('TestHalfFull');
+
+astPositionState[1] := astHalfFullStates;
+fbRead(
+    astPositionState:=astPositionState,
+    fbFFHWO:=fbFFHWO,
+    sTransitionKey:='State0',
+    sDeviceName:='TestHalfFull',
+);
+fbFFHWO.EvaluateOutput();
+
+AssertFalse(
+    fbRead.bError,
+    'Had an error',
+);
+AssertEquals_STRING(
+    Expected:=fbRead.sTransitionKey,
+    Actual:=fbRead.astDbStateParams[0].sPmpsState,
+    Message:='Output did not have the correct transition state',
+);
+FOR nIter := 1 TO GeneralConstants.MAX_STATES / 2 DO
+    AssertEquals_STRING(
+        Expected:=astCorrectStates[nIter].stPMPS.sPmpsState,
+        Actual:=fbRead.astDbStateParams[nIter].sPmpsState,
+        Message:=CONCAT('Output did not have the correct position state: ', UINT_TO_STRING(nIter)),
     );
 END_FOR
 
@@ -158,7 +203,7 @@ FOR nIter := 1 TO GeneralConstants.MAX_STATES DO
     AssertEquals_STRING(
         Expected:='',
         Actual:=fbRead.astDbStateParams[nIter].sPmpsState,
-        Message:='Errored output should have had no state names',
+        Message:=CONCAT('Errored output should have had no state names: ', UINT_TO_STRING(nIter)),
     );
 END_FOR
 
@@ -199,7 +244,7 @@ FOR nIter := 1 TO GeneralConstants.MAX_STATES DO
     AssertEquals_STRING(
         Expected:=astCorrectStates[nIter].stPMPS.sPmpsState,
         Actual:=fbRead.astDbStateParams[nIter].sPmpsState,
-        Message:='Output did not have the correct position state',
+        Message:=CONCAT('Output did not have the correct position state: ', UINT_TO_STRING(nIter)),
     );
 END_FOR
 
@@ -242,7 +287,7 @@ FOR nIter := 1 TO GeneralConstants.MAX_STATES DO
     AssertEquals_STRING(
         Expected:=astCorrectStates[nIter].stPMPS.sPmpsState,
         Actual:=fbRead.astDbStateParams[nIter].sPmpsState,
-        Message:='Output did not have the correct position state',
+        Message:=CONCAT('Output did not have the correct position state: ', UINT_TO_STRING(nIter)),
     );
 END_FOR
 

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -983,7 +983,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{E61EF94A-CFE8-4DDF-B7C9-5F7AD2CF9D83}" Name="Library" PrjFilePath="..\..\Library\Library.plcproj" TmcFilePath="..\..\Library\Library.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{04BC85D6-83FD-282E-475D-D30D58A807EC}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{2681E5CF-E845-851B-C0AE-5F5D225C8351}">
 			<Name>Library Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -3624,6 +3624,10 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>PRG_TEST.fb_MotionReadPMPSDBND_Test.__FB_MOTIONREADPMPSDBND_TEST__TESTDUPE__FBFFHWO.q_xFastFaultOut</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_MotionReadPMPSDBND_Test.__FB_MOTIONREADPMPSDBND_TEST__TESTHALFFULL__FBFFHWO.q_xFastFaultOut</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Fix the bug described in  issue 194  (closes #194)
- Add a test for this case
- Augment the existing test cases with a specific error message for each loop iteration. If you don't do this, they count as duplicate checks and are skipped.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Most TMO motion devices are currently stuck

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit test only
- Works in TMO running the dev build

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR text + later release notes

## Pre-merge checklist
- [x] Code works interactively
- [x] Test suite passes locally
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
