### PR TITLE
FIX: addressing the state input deadlock bug

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_StatesInputHandler.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_StatesInputHandler.TcPOU
@@ -42,13 +42,15 @@ END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[
-IF NOT bInit THEN
+bResetMove := stUserInput.bReset;
+IF bResetMove OR NOT bInit THEN
     bInit := TRUE;
     stUserInput.nSetValue := 0;
     nCurrGoal := nStartingState;
+    bExecMove := FALSE;
+    nState := IDLE;
+    bNewMove := FALSE;
 END_IF
-
-bResetMove := stUserInput.bReset;
 
 IF stUserInput.nSetValue <> 0 THEN
     nQueuedGoal := stUserInput.nSetValue;

--- a/lcls-twincat-motion/Library/Tests/FB_PositionStateND_Test.TcPOU
+++ b/lcls-twincat-motion/Library/Tests/FB_PositionStateND_Test.TcPOU
@@ -10,6 +10,9 @@
     The internals have already been tested, but we need to make sure that
     they've been put together at least somewhat sensibly.
     This FB will simply use each FB to move and check the results.
+
+    Additional tests:
+    - Regression test for issue #197 (input deadlock)
 *)
 VAR
     stMotionStage1: ST_MotionStage;
@@ -117,6 +120,7 @@ Test2D(6, E_TestStates.TARGET2);
 Test3D(7, E_TestStates.OUT);
 Test3D(8, E_TestStates.TARGET1);
 Test3D(9, E_TestStates.TARGET2);
+TestInputDeadlock(10);
 
 IF bOneTestDone THEN
     bOneTestDone := FALSE;
@@ -130,6 +134,11 @@ tonTimer(
 );
 ]]></ST>
     </Implementation>
+    <Action Name="MoveSomewhere" Id="{b90f716d-c484-4948-9e78-2546a48d2bbf}">
+      <Implementation>
+        <ST><![CDATA[]]></ST>
+      </Implementation>
+    </Action>
     <Method Name="Test1D" Id="{1ad9fa88-2d5f-4a1e-8b3b-83975d1536fe}">
       <Declaration><![CDATA[METHOD Test1D
 VAR_INPUT
@@ -363,6 +372,114 @@ IF tonTimer.Q OR fb_Move3D.stPlcToEpics.bDone THEN
     TEST_FINISHED();
 END_IF
 ]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="TestInputDeadlock" Id="{e699bbce-7f94-40ff-b107-4c33f7aef928}">
+      <Declaration><![CDATA[METHOD TestInputDeadlock
+(*
+    Regression test for issue #197
+
+    How to reproduce the issue:
+    1. Get the function block into any motion error
+    2. Ask for a move while in the error state
+
+    Then, the state mover never moves again.
+
+    To test we will follow steps 1 and 2, then reset the error, then move.
+
+    With our fix, our second attempt at the move (after an error reset) will succeed.
+    Our first attempt will fail regardless, since you cannot move a motor that is in an error state.
+
+    Without our fix, the motor could never be moved ever again and this move will time out.
+*)
+VAR_INPUT
+    nTestID: UINT;
+END_VAR
+VAR_INST
+    nTestStep: UINT := 1;
+    eNewGoal: E_TestStates;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+TEST('TestInputDeadlock');
+IF nTestCounter <> nTestID THEN
+    RETURN;
+END_IF
+
+CASE nTestStep OF
+    // Step 1: Normal move
+    1:
+        // Normal move: pick any other state
+        IF eGetPos = E_TestStates.OUT THEN
+            eNewGoal := E_TestStates.TARGET1;
+        ELSE
+            eNewGoal := E_TestStates.OUT;
+        END_IF
+        eSetPos := eNewGoal;
+        nTestStep := 2;
+    // Step 2: Cause a motion error. Easiest is to just set bError to TRUE during a move.
+    2:
+        // Cause the error if it's time
+        IF stMotionStage1.bBusy THEN
+            stMotionStage1.bError := TRUE;
+            stMotionStage1.nErrorId := 16#4FFF;
+        ELSIF stMotionStage1.bError THEN
+            nTestStep := 3;
+        END_IF
+     // Step 3: another normal move. This should get us into the potential bugged state.
+     3:
+        eSetPos := eNewGoal;
+        nTestStep := 4;
+    // Step 4: reset the error, which will allow fixed versions of the code to resume normal operations.
+    4:
+        fb_Move1D.stEpicsToPlc.bReset := TRUE;
+        IF NOT stMotionStage1.bError THEN
+            nTestStep := 5;
+        END_IF
+    // Step 5: last normal move, which will succeed if we fixed the bug.
+    5:
+        eSetPos := eNewGoal;
+        IF eGetPos = E_TestStates.Unknown THEN
+            nTestStep := 6;
+        END_IF
+    // Step 6: wait for the move to finish
+    6:
+        IF eGetPos = eNewGoal THEN
+            nTestStep := 7;
+        END_IF
+END_CASE
+
+fb_Move1D(
+    stMotionStage:=stMotionStage1,
+    astPositionState:=astPositionState1,
+    eEnumSet:=eSetPos,
+    eEnumGet:=eGetPos,
+    bEnable:=TRUE,
+);
+
+// Timeout and checks
+IF tonTimer.Q OR nTestStep = 7 THEN
+    AssertFalse(
+        tonTimer.Q,
+        'Timeout in deadlock test',
+    );
+    AssertEquals_UINT(
+        Expected:=eNewGoal,
+        Actual:=eGetPos,
+        'Did not reach a goal state in deadlock test',
+    );
+    fb_Move1D.stEpicsToPlc.bReset := TRUE;
+    fb_Move1D(
+        stMotionStage:=stMotionStage1,
+        astPositionState:=astPositionState1,
+        eEnumSet:=eSetPos,
+        eEnumGet:=eGetPos,
+        bEnable:=TRUE,
+    );
+    bOneTestDone := TRUE;
+    TEST_FINISHED();
+END_IF]]></ST>
       </Implementation>
     </Method>
   </POU>

--- a/lcls-twincat-motion/Library/Tests/FB_PositionStateND_Test.TcPOU
+++ b/lcls-twincat-motion/Library/Tests/FB_PositionStateND_Test.TcPOU
@@ -134,11 +134,6 @@ tonTimer(
 );
 ]]></ST>
     </Implementation>
-    <Action Name="MoveSomewhere" Id="{b90f716d-c484-4948-9e78-2546a48d2bbf}">
-      <Implementation>
-        <ST><![CDATA[]]></ST>
-      </Implementation>
-    </Action>
     <Method Name="Test1D" Id="{1ad9fa88-2d5f-4a1e-8b3b-83975d1536fe}">
       <Declaration><![CDATA[METHOD Test1D
 VAR_INPUT

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -983,7 +983,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{E61EF94A-CFE8-4DDF-B7C9-5F7AD2CF9D83}" Name="Library" PrjFilePath="..\..\Library\Library.plcproj" TmcFilePath="..\..\Library\Library.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{2681E5CF-E845-851B-C0AE-5F5D225C8351}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{1FCA17A7-AF74-AD80-7B07-555636D3E07F}">
 			<Name>Library Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When the user resets an error, bring the states input handler FB back to a known state.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Will close #197 

In short: previously, we could get into a deadlocked state where the input FB would always keep bExecute high, which means the move FB would never be able to get a rising edge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit test that fails before and passes afterwards
- Interactive testing with the example motion plc code

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Detailed documentation in the unit test

## Pre-merge checklist
- [x] Code works interactively
- [x] Test suite passes locally
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
