### PR TITLE
FIX: run fbInternal first to mark states as ready to use

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateND_Core.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateND_Core.TcPOU
@@ -51,6 +51,11 @@ END_VAR]]></Declaration>
       <ST><![CDATA[
 stEpicsToPlc.nSetValue := eEnumSet;
 
+fbInternal(
+    astMotionStage:=astMotionStageMax,
+    astPositionState:=astPositionStateMax,
+);
+
 fbRead(
     astMotionStage:=astMotionStageMax,
     astPositionState:=astPositionStateMax,
@@ -67,11 +72,6 @@ fbInput(
     nCurrGoal=>nCurrGoal,
     bExecMove=>,
     bResetMove=>,
-);
-
-fbInternal(
-    astMotionStage:=astMotionStageMax,
-    astPositionState:=astPositionStateMax,
 );
 
 FOR nIterMotor := 1 TO MotionConstants.MAX_STATE_MOTORS DO


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Calling read/move requires fb internal to be called first, but somehow the ordering was wrong

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ends up making the pmps states devices come up in a "transition" state always because the PLC can't check that they are at the correct state during the first cycle

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Currently testing using my kfe motion PR

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Test suite passes locally
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
