### PR TITLE
FIX: some fast faults could only be reset once due to rt detection

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MotionBPTM.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MotionBPTM.TcPOU
@@ -96,6 +96,7 @@ bTransitionAuthorized := bInternalAuth OR (bArbiterTimeout AND bMoveOnArbiterTim
 // Only reset at safe beam OR at no bptm errors (some other FF should catch additional issues)
 ffBPTMTimeoutAndMove.i_xOK := NOT (bArbiterTimeout AND bMoveOnArbiterTimeout);
 ffBPTMTimeoutAndMove.i_xReset S= bResetBPTMTimeout OR (bptm.bDone AND NOT bptm.bError);
+ffBPTMTimeoutAndMove.i_xReset R= NOT ffBPTMTimeoutAndMove.i_xOK;
 ffBPTMTimeoutAndMove(
     i_DevName := sDeviceName,
     i_Desc := 'BPTM Timeout',
@@ -123,7 +124,8 @@ bptm(
 
 // Trip the beam for BPTM Errors
 ffBPTMError.i_xOK := NOT bptm.bError;
-ffBPTMError.i_xReset S= bptm.bDone AND NOT bptm.bError;
+ffBPTMError.i_xReset S= bptm.bDone AND ffBPTMError.i_xOK;
+ffBPTMError.i_xReset R= NOT ffBPTMError.i_xOK;
 ffBPTMError(
     i_DevName := sDeviceName,
     i_Desc := 'BPTM error, state transition failed',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
A fast fault can be reset on a rising trigger to the reset input
Previously, the code would never bring this input back to low, it would stay high
Therefore, the fault could only be reset once

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Permanent fast faults are bad
closes #202 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively in kfe motion, and:
![image](https://github.com/pcdshub/lcls-twincat-motion/assets/10647860/c2d037f2-2df0-411f-ba32-131a1ee5c346)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a

## Pre-merge checklist
- [x] Code works interactively
- [x] Test suite passes locally
- [ ] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
