### PR TITLE
FIX: issues relating to "queued" moves in state mover with bMoveOk

### DIFF
--- a/lcls-twincat-motion/Library/DUTs/E_LCLSMotionError.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/E_LCLSMotionError.TcDUT
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="E_LCLSMotionError" Id="{ddea4357-8fae-44da-b5b7-bd2ca001f059}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE E_LCLSMotionError :
+(
+    ABORTED := 16#7900,
+    UNSAFE := 16#7901,
+    INVALID := 16#7902,
+    TEST := 16#FFFF
+) UDINT;
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -105,6 +105,9 @@
     <Compile Include="DUTs\Deprecated\ENUM_StatePMPSStatus.TcDUT">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="DUTs\E_LCLSMotionError.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="DUTs\E_MotionFFType.TcDUT">
       <SubType>Code</SubType>
     </Compile>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionRequest.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionRequest.TcPOU
@@ -104,7 +104,7 @@ CASE nState OF
                 E_MotionRequest.ABORT:
                     nState := ERROR;
                     bError := TRUE;
-                    nErrorId := 16#7900;
+                    nErrorId := E_LCLSMotionError.ABORTED;
             END_CASE
         ELSE
             nState := START_MOVE;

--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateMove.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateMove.TcPOU
@@ -139,7 +139,7 @@ IF nLatchAllowErrorID <> 0 OR (bExecute AND NOT bAllowMove) THEN
     END_IF
     // Keep error latched until it is cleared, otherwise it can be lost early
     nLatchAllowErrorID := nErrorID;
-    sErrorMessage := CONCAT(CONCAT(F_MotionErrorCodeLookup(nErrorId := nErrorID), " for "), stPositionState.sName);
+    sErrorMessage := CONCAT(CONCAT(F_MotionErrorCodeLookup(nErrorId := nErrorID), ' for '), stPositionState.sName);
 END_IF
 
 // This can be useful if we're running this FB standalone for some reason

--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateMove.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateMove.TcPOU
@@ -91,17 +91,25 @@ VAR_OUTPUT
 END_VAR
 VAR
     fbMotionRequest: FB_MotionRequest;
+    rtExec: R_TRIG;
+    rtReset: R_TRIG;
+    bInnerExec: BOOL;
     bAllowMove: BOOL;
+    nLatchAllowErrorID: UDINT;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Veto the move for uninitialized and unsafe states
 bAllowMove := stPositionState.bMoveOk AND stPositionState.bValid AND stPositionState.bUpdated;
 
+rtExec(CLK:=bExecute);
+bInnerExec S= rtExec.Q AND bAllowMove;
+bInnerExec R= NOT bExecute;
+
 // Do the move
 fbMotionRequest(
     stMotionStage := stMotionStage,
-    bExecute := bExecute AND bAllowMove,
+    bExecute := bInnerExec,
     bReset := bReset,
     enumMotionRequest := enumMotionRequest,
     fPos := stPositionState.fPosition,
@@ -114,15 +122,24 @@ fbMotionRequest(
     bBusy => bBusy,
     bDone => bDone);
 
+rtReset(CLK:=bReset);
+IF rtReset.Q THEN
+    nLatchAllowErrorID := 0;
+END_IF
+
 // Inject custom error if we can't move because of bMoveOk or bValid
-IF bExecute AND NOT bAllowMove THEN
+IF nLatchAllowErrorID <> 0 OR (bExecute AND NOT bAllowMove) THEN
     bError := TRUE;
-    IF stPositionState.bValid THEN
-        nErrorId := 16#7901;
+    IF nLatchAllowErrorID <> 0 THEN
+        nErrorID := nLatchAllowErrorID;
+    ELSIF stPositionState.bValid THEN
+        nErrorID := 16#7901;
     ELSE
-        nErrorId := 16#7902;
+        nErrorID := 16#7902;
     END_IF
-    sErrorMessage := F_MotionErrorCodeLookup(nErrorId := nErrorID);
+    // Keep error latched until it is cleared, otherwise it can be lost early
+    nLatchAllowErrorID := nErrorID;
+    sErrorMessage := CONCAT(CONCAT(F_MotionErrorCodeLookup(nErrorId := nErrorID), " for "), stPositionState.sName);
 END_IF
 
 // This can be useful if we're running this FB standalone for some reason

--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateMove.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateMove.TcPOU
@@ -133,9 +133,9 @@ IF nLatchAllowErrorID <> 0 OR (bExecute AND NOT bAllowMove) THEN
     IF nLatchAllowErrorID <> 0 THEN
         nErrorID := nLatchAllowErrorID;
     ELSIF stPositionState.bValid THEN
-        nErrorID := 16#7901;
+        nErrorID := E_LCLSMotionError.UNSAFE;
     ELSE
-        nErrorID := 16#7902;
+        nErrorID := E_LCLSMotionError.INVALID;
     END_IF
     // Keep error latched until it is cleared, otherwise it can be lost early
     nLatchAllowErrorID := nErrorID;

--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateMove.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateMove.TcPOU
@@ -103,7 +103,7 @@ END_VAR
 bAllowMove := stPositionState.bMoveOk AND stPositionState.bValid AND stPositionState.bUpdated;
 
 rtExec(CLK:=bExecute);
-bInnerExec S= rtExec.Q AND bAllowMove;
+bInnerExec S= rtExec.Q AND bAllowMove AND NOT bError;
 bInnerExec R= NOT bExecute;
 
 // Do the move

--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateND_Core.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_PositionStateND_Core.TcPOU
@@ -69,6 +69,7 @@ fbInput(
     stUserInput:=stEpicsToPlc,
     bMoveBusy:=fbMove.bBusy,
     nStartingState:=fbRead.nPositionIndex,
+    bMoveError:=fbMove.bError,
     nCurrGoal=>nCurrGoal,
     bExecMove=>,
     bResetMove=>,

--- a/lcls-twincat-motion/Library/POUs/Motion/States/FB_StatesInputHandler.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/FB_StatesInputHandler.TcPOU
@@ -19,6 +19,8 @@ VAR_INPUT
     bMoveBusy: BOOL;
     // The starting state number to seed nCurrGoal with
     nStartingState: UINT;
+    // TRUE if we have a move error, to prevent moves
+    bMoveError: BOOL;
 END_VAR
 VAR_OUTPUT
     // The goal index to input to the motion FB. This will be clamped to the range 0..GeneralConstants.MAX_STATES
@@ -83,6 +85,10 @@ CASE nState OF
             nState := IDLE;
         END_IF
 END_CASE
+
+IF bMoveError THEN
+    bExecMove := FALSE;
+END_IF
 
 // Help us detect if there is an EPICS put before the next cycle
 stUserInput.nSetValue := 0;

--- a/lcls-twincat-motion/Library/POUs/Motion/Utils/F_MotionErrorCodeLookup.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/Utils/F_MotionErrorCodeLookup.TcPOU
@@ -29,10 +29,10 @@ END_VAR
     16#4FFF: msg:='Unknown NC error (not in manual)';
 
     // Custom error definitions
-    16#7900: msg:='Aborted move request with active move in progress';
-    16#7901: msg:='Position state unsafe';
-    16#7902: msg:='Position state invalid';
-    16#FFFF: msg:='Fake testing error';
+    E_LCLSMotionError.ABORTED: msg:='Aborted move request with active move in progress';
+    E_LCLSMotionError.UNSAFE: msg:='Position state unsafe';
+    E_LCLSMotionError.INVALID: msg:='Position state invalid';
+    E_LCLSMotionError.TEST: msg:='Fake testing error';
 
     // Fallbacks
     0: msg:='';

--- a/lcls-twincat-motion/Library/Tests/FB_PositionStateMove_Test.TcPOU
+++ b/lcls-twincat-motion/Library/Tests/FB_PositionStateMove_Test.TcPOU
@@ -280,7 +280,7 @@ VAR_INST
     fStartPos: LREAL;
     stState: ST_PositionState := (
         sName:='GOAL',
-        fPosition:=235,
+        fPosition:=135,
         fDelta:=0.5,
         fVelocity:=1,
         bValid:=TRUE,
@@ -384,14 +384,15 @@ CASE nStep OF
         nStep := 6;
     // We should be able to start a move via bExecute now
     6:
+        stState.fVelocity := 2000;
+        stState.fAccel := 15000;
+        stState.fDecel := 15000;
         fbMove(
             stMotionStage:=stMotionStage,
             stPositionState:=stState,
             bExecute:=TRUE,
         );
-        tonInternal(IN:=TRUE, PT:=T#200ms);
-        IF tonInternal.Q THEN
-            tonInternal(IN:=FALSE);
+        IF fbMove.bAtState AND stMotionStage.bDone THEN
             nStep := 7;
         END_IF
 END_CASE
@@ -401,9 +402,12 @@ IF nStep = 7 OR tonTimer.Q THEN
         tonTimer.Q,
         'Test timed out',
     );
-    AssertTrue(
-        fbMove.bBusy,
-        'Motor was not moving at end of test',
+    // Check that we've reached the goal
+    AssertEquals_LREAL(
+        Expected:=stState.fPosition,
+        Actual:=stMotionStage.stAxisStatus.fActPosition,
+        Delta:=0.1,
+        Message:='Motor did not reach the goal.',
     );
     bOneTestDone := TRUE;
     TEST_FINISHED();

--- a/lcls-twincat-motion/Library/Tests/FB_PositionStateMove_Test.TcPOU
+++ b/lcls-twincat-motion/Library/Tests/FB_PositionStateMove_Test.TcPOU
@@ -284,12 +284,13 @@ VAR_INST
         fDelta:=0.5,
         fVelocity:=1,
         bValid:=TRUE,
-        bMoveOk:=FALSE
+        bMoveOk:=FALSE,
+        bUpdated:=TRUE
     );
     tonInternal: TON;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[TEST(CONCAT('TestInvalid', UINT_TO_STRING(nTestIndex)));
+        <ST><![CDATA[TEST('TestMoveOk');
 IF nTestCounter <> nTestIndex THEN
     RETURN;
 END_IF
@@ -388,7 +389,7 @@ CASE nStep OF
             stPositionState:=stState,
             bExecute:=TRUE,
         );
-        tonInternal(IN:=TRUE, PT:=T#100ms);
+        tonInternal(IN:=TRUE, PT:=T#200ms);
         IF tonInternal.Q THEN
             tonInternal(IN:=FALSE);
             nStep := 7;

--- a/lcls-twincat-motion/Library/Tests/FB_PositionStateMove_Test.TcPOU
+++ b/lcls-twincat-motion/Library/Tests/FB_PositionStateMove_Test.TcPOU
@@ -21,6 +21,7 @@ VAR
     bOneTestDone: BOOL;
     fTestStartPos: LREAL;
     tonTimer: TON;
+    tonCleanup: TON;
     nIter: DINT;
     bStatesReady: BOOL;
 END_VAR
@@ -88,22 +89,40 @@ TestBadStates(4);
 // Test that we need a new bExecute to start a new move if a move goes from unsafe to safe
 TestMoveOk(5);
 
-IF bOneTestDone THEN
-    bOneTestDone := FALSE;
-    nTestCounter := nTestCounter + 1;
-    fbMove(
-        stMotionStage:=stMotionStage,
-        stPositionState:=stDummyPos,
-        bExecute:=FALSE,
-        bReset:=TRUE,
-    );
-    fbMove(
-        stMotionStage:=stMotionStage,
-        stPositionState:=stDummyPos,
-        bExecute:=FALSE,
-        bReset:=FALSE,
-    );
-    tonTimer(IN:=FALSE);
+// Wait a few cycles for remaining errors to propagate
+tonCleanup(IN:=bOneTestDone, PT:=T#1s);
+IF tonCleanup.Q THEN
+    IF fbMove.bBusy THEN
+        fbMove(
+            stMotionStage:=stMotionStage,
+            stPositionState:=stDummyPos,
+            bExecute:=FALSE,
+            bReset:=FALSE,
+        );
+    ELSIF stMotionStage.bBusy THEN
+        stMotionStage.bExecute := FALSE;
+    ELSIF fbMove.bError THEN
+        fbMove(
+            stMotionStage:=stMotionStage,
+            stPositionState:=stDummyPos,
+            bExecute:=FALSE,
+            bReset:=TRUE,
+        );
+    ELSIF stMotionStage.bError THEN
+       stMotionStage.bReset := TRUE;
+    ELSE
+        fbMove(
+            stMotionStage:=stMotionStage,
+            stPositionState:=stDummyPos,
+            bExecute:=FALSE,
+            bReset:=FALSE,
+        );
+        stMotionStage.bReset := FALSE;
+
+        bOneTestDone := FALSE;
+        nTestCounter := nTestCounter + 1;
+        tonTimer(IN:=FALSE);
+    END_IF
 END_IF
 // Use this timer to time out any tests that stall
 tonTimer(
@@ -120,7 +139,7 @@ END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST(CONCAT('TestInvalid', UINT_TO_STRING(nTestIndex)));
-IF nTestCounter <> nTestIndex THEN
+IF nTestCounter <> nTestIndex OR bOneTestDone THEN
     RETURN;
 END_IF
 
@@ -203,11 +222,12 @@ END_VAR
 VAR_INST
     bLocalInit: BOOL;
     bInterruptStarted: BOOL;
+    tonBusy: TON;
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST(CONCAT('TestMove', UINT_TO_STRING(nTestIndex)));
-IF nTestCounter <> nTestIndex THEN
+IF nTestCounter <> nTestIndex OR bOneTestDone THEN
     RETURN;
 END_IF
 
@@ -224,7 +244,10 @@ IF NOT bLocalInit THEN
     bLocalInit := TRUE;
 END_IF
 
-bInterruptStarted S= bInterrupt AND stMotionStage.bBusy;
+// Simulate waiting a moment before stopping
+tonBusy(IN:=stMotionStage.bBusy, PT:=T#100ms);
+bInterruptStarted S= bInterrupt AND tonBusy.Q;
+
 fbMove(
     stMotionStage:=stMotionstage,
     stPositionState:=astPositionState[nStateIndex],
@@ -270,7 +293,7 @@ END_IF
 ]]></ST>
       </Implementation>
     </Method>
-    <Method Name="TestMoveOk" Id="{7a9d32d9-3644-4ac8-8f5e-231743ac6603}">
+    <Method Name="TestMoveOk" Id="{0a0e07ec-6039-465c-88e5-a08bb2253266}">
       <Declaration><![CDATA[METHOD TestMoveOk
 VAR_INPUT
     nTestIndex: UINT;
@@ -288,83 +311,79 @@ VAR_INST
         bUpdated:=TRUE
     );
     tonInternal: TON;
+    bLocalExec: BOOL;
+    bLocalReset: BOOL;
+END_VAR
+VAR CONSTANT
+    END: UINT := 999;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('TestMoveOk');
-IF nTestCounter <> nTestIndex THEN
+IF nTestCounter <> nTestIndex OR bOneTestDone THEN
     RETURN;
 END_IF
 
 CASE nStep OF
-    // Move to a state that is bad
+    // Initial setup and checks
     0:
         fStartPos := stMotionStage.stAxisStatus.fActPosition;
         AssertFalse(
             fbMove.bError,
-            'Started with an error',
+            'Started with a fbMove error',
         );
-        fbMove(
-            stMotionStage:=stMotionStage,
-            stPositionState:=stState,
-            bExecute:=TRUE,
+        AssertFalse(
+            stMotionStage.bError,
+            'Started with a motor error',
         );
-        nStep := 1;
-    // The move should have failed with an error
+        bLocalExec := FALSE;
+        bLocalReset := FALSE;
+        nStep := nStep + 1;
+    // Move to a state that is bad
     1:
-        fbMove(
-            stMotionStage:=stMotionStage,
-            stPositionState:=stState,
-            bExecute:=TRUE,
-        );
+        stState.bMoveOk := FALSE;
+        bLocalExec := TRUE;
+        nStep := nStep + 1;
+    // The move should have failed with an error on the FB that never propagated to the motor itself- we shouldn't have attempted the move at all
+    2:
         AssertTrue(
             fbMove.bError,
             'Did not have the expected move not ok error',
         );
-        nStep := 2;
-    // Make the state no longer bad, and wait a bit
-    2:
-        stState.bMoveOk := TRUE;
-        fbMove(
-            stMotionStage:=stMotionStage,
-            stPositionState:=stState,
-            bExecute:=TRUE,
+        AssertFalse(
+            stMotionStage.bError,
+            'Had a motion error, but we never should have asked for a move?',
         );
-        tonInternal(IN:=TRUE, PT:=T#100ms);
+        nStep := nStep + 1;
+    // Make the state no longer bad, and wait a bit
+    3:
+        stState.bMoveOk := TRUE;
+        tonInternal(IN:=TRUE, PT:=T#500ms);
         IF tonInternal.Q THEN
             tonInternal(IN:=FALSE);
-            nStep := 3;
+            nStep := nStep + 1;
         END_IF
     // There should be no movement still
-    3:
+    4:
         AssertEquals_LREAL(
             Expected:=fStartPos,
             Actual:=stMotionStage.stAxisStatus.fActPosition,
             Delta:=0.1,
             Message:='Motor moved without bReset or a new bExecute!',
         );
-        // Reset the error
-        fbMove(
-            stMotionStage:=stMotionStage,
-            stPositionState:=stState,
-            bExecute:=TRUE,
-            bReset:=TRUE,
-        );
-        nStep := 4;
+        // Reset the error (rising edge)
+        bLocalReset := TRUE;
+        nStep := nStep + 1;
     // After we reset the error, wait a bit
-    4:
-        fbMove(
-            stMotionStage:=stMotionStage,
-            stPositionState:=stState,
-            bExecute:=TRUE,
-            bReset:=FALSE,
-        );
-        tonInternal(IN:=TRUE, PT:=T#100ms);
+    5:
+        // Drop for rising edges later
+        bLocalReset := FALSE;
+        tonInternal(IN:=TRUE, PT:=T#500ms);
         IF tonInternal.Q THEN
             tonInternal(IN:=FALSE);
-            nStep := 5;
+            nStep := nStep + 1;
         END_IF
-    // There should STILL be no movement
-    5:
+    // There should be no error, and STILL be no movement
+    6:
         AssertFalse(
             fbMove.bError,
             'The error should be reset',
@@ -375,29 +394,29 @@ CASE nStep OF
             Delta:=0.1,
             Message:='Motor moved without a new bExecute!',
         );
-        // Set bExecute to FALSE for an upcoming rising edge
-        fbMove(
-            stMotionStage:=stMotionStage,
-            stPositionState:=stState,
-            bExecute:=FALSE,
-        );
-        nStep := 6;
+        // Set bExecute to FALSE for an upcoming rising edge. It should be TRUE at this point.
+        bLocalExec := FALSE;
+        nStep := nStep + 1;
     // We should be able to start a move via bExecute now
-    6:
+    7:
         stState.fVelocity := 2000;
         stState.fAccel := 15000;
         stState.fDecel := 15000;
-        fbMove(
-            stMotionStage:=stMotionStage,
-            stPositionState:=stState,
-            bExecute:=TRUE,
-        );
+        bLocalExec := TRUE;
         IF fbMove.bAtState AND stMotionStage.bDone THEN
-            nStep := 7;
+            nStep := END;
         END_IF
 END_CASE
 
-IF nStep = 7 OR tonTimer.Q THEN
+// Run fbMove exactly once every cycle no matter what
+fbMove(
+    stMotionStage:=stMotionStage,
+    stPositionState:=stState,
+    bExecute:=bLocalExec,
+    bReset:=bLocalReset,
+);
+
+IF nStep = END OR tonTimer.Q THEN
     AssertFalse(
         tonTimer.Q,
         'Test timed out',
@@ -411,8 +430,7 @@ IF nStep = 7 OR tonTimer.Q THEN
     );
     bOneTestDone := TRUE;
     TEST_FINISHED();
-END_IF
-]]></ST>
+END_IF]]></ST>
       </Implementation>
     </Method>
   </POU>

--- a/lcls-twincat-motion/Library/Tests/FB_PositionStateMove_Test.TcPOU
+++ b/lcls-twincat-motion/Library/Tests/FB_PositionStateMove_Test.TcPOU
@@ -85,6 +85,8 @@ TestMove(2, 2, FALSE);
 TestMove(3, 3, TRUE);
 // Test that we cannot move to an invalid state
 TestBadStates(4);
+// Test that we need a new bExecute to start a new move if a move goes from unsafe to safe
+TestMoveOk(5);
 
 IF bOneTestDone THEN
     bOneTestDone := FALSE;
@@ -263,6 +265,146 @@ IF fbMove.bDone OR tonTimer.Q OR (bInterruptStarted AND NOT fbMove.bBusy) THEN
     bOneTestDone := TRUE;
     bLocalInit := FALSE;
     bInterruptStarted := FALSE;
+    TEST_FINISHED();
+END_IF
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="TestMoveOk" Id="{7a9d32d9-3644-4ac8-8f5e-231743ac6603}">
+      <Declaration><![CDATA[METHOD TestMoveOk
+VAR_INPUT
+    nTestIndex: UINT;
+END_VAR
+VAR_INST
+    nStep: UINT;
+    fStartPos: LREAL;
+    stState: ST_PositionState := (
+        sName:='GOAL',
+        fPosition:=235,
+        fDelta:=0.5,
+        fVelocity:=1,
+        bValid:=TRUE,
+        bMoveOk:=FALSE
+    );
+    tonInternal: TON;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST(CONCAT('TestInvalid', UINT_TO_STRING(nTestIndex)));
+IF nTestCounter <> nTestIndex THEN
+    RETURN;
+END_IF
+
+CASE nStep OF
+    // Move to a state that is bad
+    0:
+        fStartPos := stMotionStage.stAxisStatus.fActPosition;
+        AssertFalse(
+            fbMove.bError,
+            'Started with an error',
+        );
+        fbMove(
+            stMotionStage:=stMotionStage,
+            stPositionState:=stState,
+            bExecute:=TRUE,
+        );
+        nStep := 1;
+    // The move should have failed with an error
+    1:
+        fbMove(
+            stMotionStage:=stMotionStage,
+            stPositionState:=stState,
+            bExecute:=TRUE,
+        );
+        AssertTrue(
+            fbMove.bError,
+            'Did not have the expected move not ok error',
+        );
+        nStep := 2;
+    // Make the state no longer bad, and wait a bit
+    2:
+        stState.bMoveOk := TRUE;
+        fbMove(
+            stMotionStage:=stMotionStage,
+            stPositionState:=stState,
+            bExecute:=TRUE,
+        );
+        tonInternal(IN:=TRUE, PT:=T#100ms);
+        IF tonInternal.Q THEN
+            tonInternal(IN:=FALSE);
+            nStep := 3;
+        END_IF
+    // There should be no movement still
+    3:
+        AssertEquals_LREAL(
+            Expected:=fStartPos,
+            Actual:=stMotionStage.stAxisStatus.fActPosition,
+            Delta:=0.1,
+            Message:='Motor moved without bReset or a new bExecute!',
+        );
+        // Reset the error
+        fbMove(
+            stMotionStage:=stMotionStage,
+            stPositionState:=stState,
+            bExecute:=TRUE,
+            bReset:=TRUE,
+        );
+        nStep := 4;
+    // After we reset the error, wait a bit
+    4:
+        fbMove(
+            stMotionStage:=stMotionStage,
+            stPositionState:=stState,
+            bExecute:=TRUE,
+            bReset:=FALSE,
+        );
+        tonInternal(IN:=TRUE, PT:=T#100ms);
+        IF tonInternal.Q THEN
+            tonInternal(IN:=FALSE);
+            nStep := 5;
+        END_IF
+    // There should STILL be no movement
+    5:
+        AssertFalse(
+            fbMove.bError,
+            'The error should be reset',
+        );
+        AssertEquals_LREAL(
+            Expected:=fStartPos,
+            Actual:=stMotionStage.stAxisStatus.fActPosition,
+            Delta:=0.1,
+            Message:='Motor moved without a new bExecute!',
+        );
+        // Set bExecute to FALSE for an upcoming rising edge
+        fbMove(
+            stMotionStage:=stMotionStage,
+            stPositionState:=stState,
+            bExecute:=FALSE,
+        );
+        nStep := 6;
+    // We should be able to start a move via bExecute now
+    6:
+        fbMove(
+            stMotionStage:=stMotionStage,
+            stPositionState:=stState,
+            bExecute:=TRUE,
+        );
+        tonInternal(IN:=TRUE, PT:=T#100ms);
+        IF tonInternal.Q THEN
+            tonInternal(IN:=FALSE);
+            nStep := 7;
+        END_IF
+END_CASE
+
+IF nStep = 7 OR tonTimer.Q THEN
+    AssertFalse(
+        tonTimer.Q,
+        'Test timed out',
+    );
+    AssertTrue(
+        fbMove.bBusy,
+        'Motor was not moving at end of test',
+    );
+    bOneTestDone := TRUE;
     TEST_FINISHED();
 END_IF
 ]]></ST>

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -983,7 +983,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{E61EF94A-CFE8-4DDF-B7C9-5F7AD2CF9D83}" Name="Library" PrjFilePath="..\..\Library\Library.plcproj" TmcFilePath="..\..\Library\Library.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{A521E4D2-867B-C8A0-F177-AC38EB4C1551}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{0C997D26-FEC1-46B4-2438-632FFA910317}">
 			<Name>Library Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1486,6 +1486,49 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>PRG_TEST.fb_PositionStateReadND_Test.afbSqMotionStage[2].fbDriveVirtual.MasterAxis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
@@ -3131,49 +3174,6 @@ External Setpoint Generation:
 					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bLimitForwardEnable</Name>
-					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bLimitBackwardEnable</Name>
-					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bHome</Name>
-					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bHardwareEnable</Name>
-					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderULINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderUINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
-					<Type>UINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
 			</Vars>
 			<Vars VarGrpType="2" AreaNo="1">
 				<Name>PlcTask Outputs</Name>
@@ -3315,6 +3315,19 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>PRG_TEST.fb_PositionStateReadND_Test.afbSqMotionStage[2].fbDriveVirtual.MasterAxis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
@@ -3873,19 +3886,6 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_TEST.fb_PositionStatePMPSND_Test.__FB_POSITIONSTATEPMPSND_TEST__TESTSTARTUP3D__FBFFHWO.q_xFastFaultOut</Name>
 					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.Axis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bBrakeRelease</Name>
-					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 			</Vars>
 			<Vars VarGrpType="8" AreaNo="4">

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -983,7 +983,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{E61EF94A-CFE8-4DDF-B7C9-5F7AD2CF9D83}" Name="Library" PrjFilePath="..\..\Library\Library.plcproj" TmcFilePath="..\..\Library\Library.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{1FCA17A7-AF74-AD80-7B07-555636D3E07F}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{49153F40-1CF2-6F25-B534-503BABA03898}">
 			<Name>Library Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -983,7 +983,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{E61EF94A-CFE8-4DDF-B7C9-5F7AD2CF9D83}" Name="Library" PrjFilePath="..\..\Library\Library.plcproj" TmcFilePath="..\..\Library\Library.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{49153F40-1CF2-6F25-B534-503BABA03898}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{F29DC6ED-12E6-B95C-BA1A-9ADD857EE9A2}">
 			<Name>Library Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -983,7 +983,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{E61EF94A-CFE8-4DDF-B7C9-5F7AD2CF9D83}" Name="Library" PrjFilePath="..\..\Library\Library.plcproj" TmcFilePath="..\..\Library\Library.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{F29DC6ED-12E6-B95C-BA1A-9ADD857EE9A2}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{A521E4D2-867B-C8A0-F177-AC38EB4C1551}">
 			<Name>Library Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1486,49 +1486,6 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>PRG_TEST.fb_PositionStateReadND_Test.afbSqMotionStage[2].fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bLimitForwardEnable</Name>
-					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bLimitBackwardEnable</Name>
-					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bHome</Name>
-					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bHardwareEnable</Name>
-					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderULINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderUINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
-					<Type>UINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
@@ -3174,6 +3131,49 @@ External Setpoint Generation:
 					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
 			</Vars>
 			<Vars VarGrpType="2" AreaNo="1">
 				<Name>PlcTask Outputs</Name>
@@ -3315,19 +3315,6 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>PRG_TEST.fb_PositionStateReadND_Test.afbSqMotionStage[2].fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.Axis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bBrakeRelease</Name>
-					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_TEST.fb_PositionStateMove_Test.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
@@ -3886,6 +3873,19 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_TEST.fb_PositionStatePMPSND_Test.__FB_POSITIONSTATEPMPSND_TEST__TESTSTARTUP3D__FBFFHWO.q_xFastFaultOut</Name>
 					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.stMotionStage.bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TEST.fb_PositionStateMove_Test.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 			</Vars>
 			<Vars VarGrpType="8" AreaNo="4">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- If there is a move error, cut the execute output
- Require a bExecute rising edge and bAllowMoves at the same time, or else no state moves

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://jira.slac.stanford.edu/browse/ECS-3932
There are cases where "unsafe" moves can become marked as "safe" during execution, and then immediately start as if they were waiting to become "safe" rather than cancelling the move request altogether.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created a unit test that follows the following sequence:
- Ask for a move to a `bMoveOk = FALSE` state
- Confirm no move
- Set `bMoveOk := TRUE`
- Confirm no move
- Reset the error
- Confirm no move
- Ask for a new move
- Confirm yes move

I also tested this interactively, and it works as one would expect: you need to reset the error, wait for the move to become safe, and then explicitly ask for the move again. Here's a screenshot of the new updated error message:
![image](https://github.com/pcdshub/lcls-twincat-motion/assets/10647860/a536f078-5e6b-4d28-894c-c2e9a852b56b)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes only

## Pre-merge checklist
- [x] Code works interactively
- [x] Test suite passes locally
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
