### PR TITLE
Add a local PMPS look up flag.

### DIFF
--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -17,7 +17,7 @@
     <CombineIds>false</CombineIds>
     <Company>SLAC</Company>
     <Released>false</Released>
-    <Title>lcls-twincat-motion</Title>
+    <Title>lcls-twincat-motion-nrw</Title>
     <ProjectVersion>0.0.0</ProjectVersion>
     <WriteProductVersion>false</WriteProductVersion>
     <!--    <OutputType>Exe</OutputType>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MotionReadPMPSDBND.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MotionReadPMPSDBND.TcPOU
@@ -60,7 +60,6 @@ VAR
     asPrevLookupKeys: ARRAY[0..GeneralConstants.MAX_STATES] OF STRING;
     bNewKeys: BOOL;
     sTempBackfill: STRING;
-    nCopyIndex :INT;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[IF bUsePmpsDB THEN
@@ -69,14 +68,7 @@ END_VAR]]></Declaration>
     RunFastFaults();
     BackfillInfo();
 ELSE
-    FOR nCopyIndex := 0 TO GeneralConstants.MAX_STATES
-    DO
-        astDbStateParams[nCopyIndex].sPmpsState := astManualDbStateParams[nCopyIndex].sPmpsState;
-        astDbStateParams[nCopyIndex].stBeamParams := astManualDbStateParams[nCopyIndex].stBeamParams;
-        astDbStateParams[nCopyIndex].bBeamParamsLoaded := astManualDbStateParams[nCopyIndex].bBeamParamsLoaded;
-        astDbStateParams[nCopyIndex].stReactiveParams := astManualDbStateParams[nCopyIndex].stReactiveParams;
-        astDbStateParams[nCopyIndex].nRequestAssertionID := astManualDbStateParams[nCopyIndex].nRequestAssertionID;
-    END_FOR;
+    astDbStateParams:=astManualDbStateParams;
 END_IF
 
 ]]></ST>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MotionReadPMPSDBND.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MotionReadPMPSDBND.TcPOU
@@ -31,6 +31,10 @@ VAR_INPUT
     sDeviceName: STRING;
     // For debug: set this to TRUE in online mode to read the database immediately.
     bReadNow: BOOL;
+    // Set this to FALSE to load PMPS parameters locally
+    bUsePmpsDB: BOOL := TRUE;
+    // Local PMPSDB parameteres
+    astManualDbStateParams:  ARRAY[0..GeneralConstants.MAX_STATES] OF ST_DbStateParams;
 END_VAR
 VAR_OUTPUT
     // The raw lookup results from this FB. Index 0 is the transition beam, the rest of the indices match the state positions.
@@ -56,13 +60,25 @@ VAR
     asPrevLookupKeys: ARRAY[0..GeneralConstants.MAX_STATES] OF STRING;
     bNewKeys: BOOL;
     sTempBackfill: STRING;
+    nCopyIndex :INT;
 END_VAR]]></Declaration>
     <Implementation>
-      <ST><![CDATA[
-SelectLookupKeys();
-ReadDatabase();
-RunFastFaults();
-BackfillInfo();
+      <ST><![CDATA[IF bUsePmpsDB THEN
+    SelectLookupKeys();
+    ReadDatabase();
+    RunFastFaults();
+    BackfillInfo();
+ELSE
+    FOR nCopyIndex := 0 TO GeneralConstants.MAX_STATES
+    DO
+        astDbStateParams[nCopyIndex].sPmpsState := astManualDbStateParams[nCopyIndex].sPmpsState;
+        astDbStateParams[nCopyIndex].stBeamParams := astManualDbStateParams[nCopyIndex].stBeamParams;
+        astDbStateParams[nCopyIndex].bBeamParamsLoaded := astManualDbStateParams[nCopyIndex].bBeamParamsLoaded;
+        astDbStateParams[nCopyIndex].stReactiveParams := astManualDbStateParams[nCopyIndex].stReactiveParams;
+        astDbStateParams[nCopyIndex].nRequestAssertionID := astManualDbStateParams[nCopyIndex].nRequestAssertionID;
+    END_FOR;
+END_IF
+
 ]]></ST>
     </Implementation>
     <Action Name="BackfillInfo" Id="{da77ffc7-a50e-48a0-9b32-806e7f647a44}">

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS1D.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS1D.TcPOU
@@ -111,7 +111,7 @@ fbPMPSCore(
     nCurrGoal:=fbCore.nCurrGoal,
     bReadDBNow:=bReadDBNow,
     stDbStateParams=>stDbStateParams,
-    bUsePmpsDB:=TRUE,
+    bUsePmpsDB:=bUsePmpsDB,
 );
 
 stMotionStage := astMotionStageMax[1];

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS1D.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS1D.TcPOU
@@ -60,6 +60,8 @@ VAR_INPUT
     bReadDBNow: BOOL;
     // Set this to FALSE to load PMPS parameters locally
     bUsePmpsDB: BOOL := TRUE;
+    // Local PMPSDB parameteres
+    astManualDbStateParams:  ARRAY[0..GeneralConstants.MAX_STATES] OF ST_DbStateParams;
 END_VAR
 VAR_OUTPUT
     // Normal EPICS outputs, gathered into a single struct
@@ -112,6 +114,7 @@ fbPMPSCore(
     bReadDBNow:=bReadDBNow,
     stDbStateParams=>stDbStateParams,
     bUsePmpsDB:=bUsePmpsDB,
+    astManualDbStateParams:=astManualDbStateParams,
 );
 
 stMotionStage := astMotionStageMax[1];

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS1D.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS1D.TcPOU
@@ -58,6 +58,8 @@ VAR_INPUT
     stPMPSEpicsToPlc: ST_StatePMPSEpicsToPlc;
     // Set this to TRUE to re-read the loaded database immediately (useful for debug)
     bReadDBNow: BOOL;
+    // Set this to FALSE to load PMPS parameters locally
+    bUsePmpsDB: BOOL := TRUE;
 END_VAR
 VAR_OUTPUT
     // Normal EPICS outputs, gathered into a single struct
@@ -109,6 +111,7 @@ fbPMPSCore(
     nCurrGoal:=fbCore.nCurrGoal,
     bReadDBNow:=bReadDBNow,
     stDbStateParams=>stDbStateParams,
+    bUsePmpsDB:=TRUE,
 );
 
 stMotionStage := astMotionStageMax[1];

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS2D.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS2D.TcPOU
@@ -69,6 +69,8 @@ VAR_INPUT
     bReadDBNow: BOOL;
     // Set this to FALSE to load PMPS parameters locally
     bUsePmpsDB: BOOL := TRUE;
+    // Local PMPSDB parameteres
+    astManualDbStateParams:  ARRAY[0..GeneralConstants.MAX_STATES] OF ST_DbStateParams;
 END_VAR
 VAR_OUTPUT
     // Normal EPICS outputs, gathered into a single struct
@@ -123,6 +125,7 @@ fbPMPSCore(
     bReadDBNow:=bReadDBNow,
     stDbStateParams=>stDbStateParams,
     bUsePmpsDB:=bUsePmpsDB,
+    astManualDbStateParams:=astManualDbStateParams,
 );
 
 stMotionStage1 := astMotionStageMax[1];

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS2D.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS2D.TcPOU
@@ -67,6 +67,8 @@ VAR_INPUT
     stPMPSEpicsToPlc: ST_StatePMPSEpicsToPlc;
     // Set this to TRUE to re-read the loaded database immediately (useful for debug)
     bReadDBNow: BOOL;
+    // Set this to FALSE to load PMPS parameters locally
+    bUsePmpsDB: BOOL := TRUE;
 END_VAR
 VAR_OUTPUT
     // Normal EPICS outputs, gathered into a single struct
@@ -120,6 +122,7 @@ fbPMPSCore(
     nCurrGoal:=fbCore.nCurrGoal,
     bReadDBNow:=bReadDBNow,
     stDbStateParams=>stDbStateParams,
+    bUsePmpsDB:=TRUE,
 );
 
 stMotionStage1 := astMotionStageMax[1];

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS2D.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS2D.TcPOU
@@ -122,7 +122,7 @@ fbPMPSCore(
     nCurrGoal:=fbCore.nCurrGoal,
     bReadDBNow:=bReadDBNow,
     stDbStateParams=>stDbStateParams,
-    bUsePmpsDB:=TRUE,
+    bUsePmpsDB:=bUsePmpsDB,
 );
 
 stMotionStage1 := astMotionStageMax[1];

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS3D.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS3D.TcPOU
@@ -133,7 +133,7 @@ fbPMPSCore(
     nCurrGoal:=fbCore.nCurrGoal,
     bReadDBNow:=bReadDBNow,
     stDbStateParams=>stDbStateParams,
-    bUsePmpsDB:=TRUE,
+    bUsePmpsDB:=bUsePmpsDB,
 );
 
 stMotionStage1 := astMotionStageMax[1];

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS3D.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS3D.TcPOU
@@ -78,6 +78,8 @@ VAR_INPUT
     bReadDBNow: BOOL;
     // Set this to FALSE to load PMPS parameters locally
     bUsePmpsDB: BOOL := TRUE;
+    // Local PMPSDB parameteres
+    astManualDbStateParams:  ARRAY[0..GeneralConstants.MAX_STATES] OF ST_DbStateParams;
 END_VAR
 VAR_OUTPUT
     // Normal EPICS outputs, gathered into a single struct
@@ -134,6 +136,7 @@ fbPMPSCore(
     bReadDBNow:=bReadDBNow,
     stDbStateParams=>stDbStateParams,
     bUsePmpsDB:=bUsePmpsDB,
+    astManualDbStateParams:=astManualDbStateParams,
 );
 
 stMotionStage1 := astMotionStageMax[1];

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS3D.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPS3D.TcPOU
@@ -76,6 +76,8 @@ VAR_INPUT
     stPMPSEpicsToPlc: ST_StatePMPSEpicsToPlc;
     // Set this to TRUE to re-read the loaded database immediately (useful for debug)
     bReadDBNow: BOOL;
+    // Set this to FALSE to load PMPS parameters locally
+    bUsePmpsDB: BOOL := TRUE;
 END_VAR
 VAR_OUTPUT
     // Normal EPICS outputs, gathered into a single struct
@@ -131,6 +133,7 @@ fbPMPSCore(
     nCurrGoal:=fbCore.nCurrGoal,
     bReadDBNow:=bReadDBNow,
     stDbStateParams=>stDbStateParams,
+    bUsePmpsDB:=TRUE,
 );
 
 stMotionStage1 := astMotionStageMax[1];

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPSND_Core.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPSND_Core.TcPOU
@@ -46,6 +46,8 @@ VAR_INPUT
     bReadDBNow: BOOL;
     // Set this to FALSE to load PMPS parameters locally
     bUsePmpsDB: BOOL := TRUE;
+    // Local PMPSDB parameteres
+    astManualDbStateParams:  ARRAY[0..GeneralConstants.MAX_STATES] OF ST_DbStateParams;
 END_VAR
 VAR_OUTPUT
     // The PMPS database lookup associated with the current position state.
@@ -83,6 +85,18 @@ IF bUsePmpsDB THEN
         bReadNow:=bReadDBNow,
         astDbStateParams=>,
         bError=>,
+    );
+ELSE
+        fbMotionReadPMPSDB(
+        astPositionState:=astPositionStateMax,
+        fbFFHWO:=fbFFHWO,
+        sTransitionKey:=sTransitionKey,
+        sDeviceName:=sDeviceName,
+        bReadNow:=bReadDBNow,
+        astDbStateParams=>,
+        bError=>,
+        astManualDbStateParams:=astManualDbStateParams,
+        bUsePmpsDB:=bUsePmpsDB,
     );
 END_IF
 

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPSND_Core.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPSND_Core.TcPOU
@@ -44,6 +44,8 @@ VAR_INPUT
     nCurrGoal: UINT;
     // Set this to TRUE to re-read the loaded database immediately (useful for debug)
     bReadDBNow: BOOL;
+    // Set this to FALSE to load PMPS parameters locally
+    bUsePmpsDB: BOOL := TRUE;
 END_VAR
 VAR_OUTPUT
     // The PMPS database lookup associated with the current position state.
@@ -72,15 +74,17 @@ ELSE
     eStatePMPSStatus := E_StatePMPSStatus.TRANSITION;
 END_IF
 
-fbMotionReadPMPSDB(
-    astPositionState:=astPositionStateMax,
-    fbFFHWO:=fbFFHWO,
-    sTransitionKey:=sTransitionKey,
-    sDeviceName:=sDeviceName,
-    bReadNow:=bReadDBNow,
-    astDbStateParams=>,
-    bError=>,
-);
+IF bUsePmpsDB THEN
+    fbMotionReadPMPSDB(
+        astPositionState:=astPositionStateMax,
+        fbFFHWO:=fbFFHWO,
+        sTransitionKey:=sTransitionKey,
+        sDeviceName:=sDeviceName,
+        bReadNow:=bReadDBNow,
+        astDbStateParams=>,
+        bError=>,
+    );
+END_IF
 
 fbMotionBPTM(
     astMotionStage:=astMotionStageMax,

--- a/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
+++ b/lcls-twincat-motion/Library/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
     {attribute 'const_non_replaced'}
-    stLibVersion_lcls_twincat_motion : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
+    stLibVersion_lcls_twincat_motion_nrw : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -983,7 +983,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{E61EF94A-CFE8-4DDF-B7C9-5F7AD2CF9D83}" Name="Library" PrjFilePath="..\..\Library\Library.plcproj" TmcFilePath="..\..\Library\Library.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{0C997D26-FEC1-46B4-2438-632FFA910317}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{9E14035E-8A52-F1A5-AC38-B76DFBAADB32}">
 			<Name>Library Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- added a flag in order to skip looking up beam parameters in the database for lfe-optics.

We can delete this later and enforce DB use once LFE DB is online.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- there's currently no LFE PMPS database and we want to use multi dimensional state movers to send beam to TXI.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- will test with this code: https://github.com/pcdshub/lcls-plc-lfe-optics/pull/38
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Test suite passes locally
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
