### PR TITLE
BUG: reverse the in/out order in the in/out example fbs to match their enum

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState1D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState1D_InOut.TcPOU
@@ -61,8 +61,8 @@ fbPositionState1D(
 );
 
 // Send updates made on the array back to the inputs (VAR_IN_OUT) for maximum clarity
-stIn := astPositionState[1];
-stOut := astPositionState[2];]]></ST>
+stOut := astPositionState[1];
+stIn := astPositionState[2];]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState1D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState1D_InOut.TcPOU
@@ -47,9 +47,9 @@ IF stOut.sName = '' THEN
     stOut.sName := 'OUT';
 END_IF
 
-// Assemble the states array, matching the enum values (OUT is 1, IN is 2)
-astPositionState[1] := stOut;
-astPositionState[2] := stIn;
+// Assemble the states array, matching the enum values
+astPositionState[E_EpicsInOut.OUT] := stOut;
+astPositionState[E_EpicsInOut.IN] := stIn;
 
 // Call the main function block, passing our motors, states, enums and an enable
 fbPositionState1D(
@@ -61,8 +61,8 @@ fbPositionState1D(
 );
 
 // Send updates made on the array back to the inputs (VAR_IN_OUT) for maximum clarity
-stOut := astPositionState[1];
-stIn := astPositionState[2];]]></ST>
+stOut := astPositionState[E_EpicsInOut.OUT];
+stIn := astPositionState[E_EpicsInOut.IN];]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState1D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState1D_InOut.TcPOU
@@ -47,9 +47,9 @@ IF stOut.sName = '' THEN
     stOut.sName := 'OUT';
 END_IF
 
-// Assemble the states array, matching the enum values (IN is 1, OUT is 2)
-astPositionState[1] := stIn;
-astPositionState[2] := stOut;
+// Assemble the states array, matching the enum values (OUT is 1, IN is 2)
+astPositionState[1] := stOut;
+astPositionState[2] := stIn;
 
 // Call the main function block, passing our motors, states, enums and an enable
 fbPositionState1D(

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState2D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState2D_InOut.TcPOU
@@ -57,11 +57,11 @@ IF stOut2.sName = '' THEN
     stOut2.sName := 'OUT';
 END_IF
 
-// Assemble the states arrays, matching the enum values (OUT is 1, IN is 2)
-astPositionState1[1] := stOut1;
-astPositionState1[2] := stIn1;
-astPositionState2[1] := stOut2;
-astPositionState2[2] := stIn2;
+// Assemble the states arrays, matching the enum values
+astPositionState1[E_EpicsInOut.OUT] := stOut1;
+astPositionState1[E_EpicsInOut.IN] := stIn1;
+astPositionState2[E_EpicsInOut.OUT] := stOut2;
+astPositionState2[E_EpicsInOut.IN] := stIn2;
 
 // Call the main function block, passing our motors, states, and an enable
 fbPositionState2D(
@@ -75,10 +75,10 @@ fbPositionState2D(
 );
 
 // Send updates made on the array back to the inputs (VAR_IN_OUT) for maximum clarity
-stOut1 := astPositionState1[1];
-stIn1 := astPositionState1[2];
-stOut2 := astPositionState2[1];
-stIn2 := astPositionState2[2];]]></ST>
+stOut1 := astPositionState1[E_EpicsInOut.OUT];
+stIn1 := astPositionState1[E_EpicsInOut.IN];
+stOut2 := astPositionState2[E_EpicsInOut.OUT];
+stIn2 := astPositionState2[E_EpicsInOut.IN];]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState2D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState2D_InOut.TcPOU
@@ -57,11 +57,11 @@ IF stOut2.sName = '' THEN
     stOut2.sName := 'OUT';
 END_IF
 
-// Assemble the states arrays, matching the enum values (IN is 1, OUT is 2)
-astPositionState1[1] := stIn1;
-astPositionState1[2] := stOut1;
-astPositionState2[1] := stIn2;
-astPositionState2[2] := stOut2;
+// Assemble the states arrays, matching the enum values (OUT is 1, IN is 2)
+astPositionState1[1] := stOut1;
+astPositionState1[2] := stIn1;
+astPositionState2[1] := stOut2;
+astPositionState2[2] := stIn2;
 
 // Call the main function block, passing our motors, states, and an enable
 fbPositionState2D(

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState2D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionState2D_InOut.TcPOU
@@ -75,10 +75,10 @@ fbPositionState2D(
 );
 
 // Send updates made on the array back to the inputs (VAR_IN_OUT) for maximum clarity
-stIn1 := astPositionState1[1];
-stOut1 := astPositionState1[2];
-stIn2 := astPositionState2[1];
-stOut2 := astPositionState2[2];]]></ST>
+stOut1 := astPositionState1[1];
+stIn1 := astPositionState1[2];
+stOut2 := astPositionState2[1];
+stIn2 := astPositionState2[2];]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS1D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS1D_InOut.TcPOU
@@ -51,9 +51,9 @@ IF stOut.sName = '' THEN
     stOut.sName := 'OUT';
 END_IF
 
-// Assemble the states array, matching the enum values (IN is 1, OUT is 2)
-astPositionState[1] := stIn;
-astPositionState[2] := stOut;
+// Assemble the states array, matching the enum values (OUT is 1, IN is 2)
+astPositionState[1] := stOut;
+astPositionState[2] := stIn;
 
 // Call the main function block, passing our motors, states, and an enable
 fbPositionStatePMPS1D(

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS1D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS1D_InOut.TcPOU
@@ -69,8 +69,8 @@ fbPositionStatePMPS1D(
 );
 
 // Send updates made on the array back to the inputs (VAR_IN_OUT) for maximum clarity
-stIn := astPositionState[1];
-stOut := astPositionState[2];]]></ST>
+stOut := astPositionState[1];
+stIn := astPositionState[2];]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS1D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS1D_InOut.TcPOU
@@ -51,9 +51,9 @@ IF stOut.sName = '' THEN
     stOut.sName := 'OUT';
 END_IF
 
-// Assemble the states array, matching the enum values (OUT is 1, IN is 2)
-astPositionState[1] := stOut;
-astPositionState[2] := stIn;
+// Assemble the states array, matching the enum values
+astPositionState[E_EpicsInOut.OUT] := stOut;
+astPositionState[E_EpicsInOut.IN] := stIn;
 
 // Call the main function block, passing our motors, states, and an enable
 fbPositionStatePMPS1D(
@@ -69,8 +69,8 @@ fbPositionStatePMPS1D(
 );
 
 // Send updates made on the array back to the inputs (VAR_IN_OUT) for maximum clarity
-stOut := astPositionState[1];
-stIn := astPositionState[2];]]></ST>
+stOut := astPositionState[E_EpicsInOut.OUT];
+stIn := astPositionState[E_EpicsInOut.IN];]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS2D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS2D_InOut.TcPOU
@@ -83,10 +83,10 @@ fbPositionStatePMPS2D(
 );
 
 // Send updates made on the array back to the inputs (VAR_IN_OUT) for maximum clarity
-stIn1 := astPositionState1[1];
-stOut1 := astPositionState1[2];
-stIn2 := astPositionState2[1];
-stOut2 := astPositionState2[2];]]></ST>
+stOut1 := astPositionState1[1];
+stIn1 := astPositionState1[2];
+stOut2 := astPositionState2[1];
+stIn2 := astPositionState2[2];]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS2D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS2D_InOut.TcPOU
@@ -61,11 +61,11 @@ IF stOut2.sName = '' THEN
     stOut2.sName := 'OUT';
 END_IF
 
-// Assemble the states arrays, matching the enum values (IN is 1, OUT is 2)
-astPositionState1[1] := stIn1;
-astPositionState1[2] := stOut1;
-astPositionState2[1] := stIn2;
-astPositionState2[2] := stOut2;
+// Assemble the states arrays, matching the enum values (OUT is 1, IN is 2)
+astPositionState1[1] := stOut1;
+astPositionState1[2] := stIn1;
+astPositionState2[1] := stOut2;
+astPositionState2[2] := stIn2;
 
 // Call the main function block, passing our motors, states, and an enable
 fbPositionStatePMPS2D(

--- a/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS2D_InOut.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/States/Examples/FB_PositionStatePMPS2D_InOut.TcPOU
@@ -61,11 +61,11 @@ IF stOut2.sName = '' THEN
     stOut2.sName := 'OUT';
 END_IF
 
-// Assemble the states arrays, matching the enum values (OUT is 1, IN is 2)
-astPositionState1[1] := stOut1;
-astPositionState1[2] := stIn1;
-astPositionState2[1] := stOut2;
-astPositionState2[2] := stIn2;
+// Assemble the states arrays, matching the enum values
+astPositionState1[E_EpicsInOut.OUT] := stOut1;
+astPositionState1[E_EpicsInOut.IN] := stIn1;
+astPositionState2[E_EpicsInOut.OUT] := stOut2;
+astPositionState2[E_EpicsInOut.IN] := stIn2;
 
 // Call the main function block, passing our motors, states, and an enable
 fbPositionStatePMPS2D(
@@ -83,10 +83,10 @@ fbPositionStatePMPS2D(
 );
 
 // Send updates made on the array back to the inputs (VAR_IN_OUT) for maximum clarity
-stOut1 := astPositionState1[1];
-stIn1 := astPositionState1[2];
-stOut2 := astPositionState2[1];
-stIn2 := astPositionState2[2];]]></ST>
+stOut1 := astPositionState1[E_EpicsInOut.OUT];
+stIn1 := astPositionState1[E_EpicsInOut.IN];
+stOut2 := astPositionState2[E_EpicsInOut.OUT];
+stIn2 := astPositionState2[E_EpicsInOut.IN];]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -983,7 +983,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{E61EF94A-CFE8-4DDF-B7C9-5F7AD2CF9D83}" Name="Library" PrjFilePath="..\..\Library\Library.plcproj" TmcFilePath="..\..\Library\Library.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{0C997D26-FEC1-46B4-2438-632FFA910317}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Library\Library.tmc" TmcHash="{69E061D5-9F44-CF40-4E04-EDBF9AD71F5C}">
 			<Name>Library Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Reverse IN and OUT indices for the example state FBs to match the enum, because if the order is wrong then IN sends us to OUT and vice versa.
See https://github.com/pcdshub/lcls-twincat-motion/blob/master/lcls-twincat-motion/Library/DUTs/E_EpicsInOut.TcDUT

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #208 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fixes the remaining issue in https://github.com/pcdshub/lcls-plc-kfe-rix-motion/pull/61

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
only here

## Pre-merge checklist
- [x] Code works interactively
- [ ] Test suite passes locally
- [ ] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
