### PR TITLE
ENH: invesitgate flutter fix

### DIFF
--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -597,9 +597,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PlaceholderReference Include="LCLS General">
-      <DefaultResolution>LCLS General, * (SLAC)</DefaultResolution>
-      <Namespace>LCLS_General</Namespace>
+    <PlaceholderReference Include="LCLS General-nrw">
+      <DefaultResolution>LCLS General-nrw, * (SLAC)</DefaultResolution>
+      <Namespace>LCLS_General_nrw</Namespace>
     </PlaceholderReference>
     <PlaceholderReference Include="PMPS">
       <DefaultResolution>PMPS, * (SLAC - LCLS)</DefaultResolution>

--- a/lcls-twincat-motion/Library/POUs/Deprecated/FB_PositionStatePMPS.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Deprecated/FB_PositionStatePMPS.TcPOU
@@ -40,6 +40,7 @@ VAR
     bFFOxOk: BOOL;
     bAtSafeState: BOOL;
     nIter: UINT;
+    fbFlutterDet : FB_FlutterDetection;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -111,11 +112,18 @@ bFFOxOk := F_SafeBPCompare(PMPS_GVL.stCurrentBeamParameters, stBeamNeeded);
 // You can pass in a different stHighBeamThreshold as an input parameter to customize this behavior
 bAtSafeState := F_SafeBPCompare(stHighBeamThreshold, stBeamNeeded);
 
+fbFlutterDet(bVarToMonitor:=bFFOxOk, fPastTime:=T#1000ms, nMaxFlipsAllowed:=3);
+
 // If the beam parameters are wrong, it is a fault! This encompasses all unknown arbiter-related errors.
 ffBeamParamsOk.i_xOK := bFFOxOk;
 ffBeamParamsOk.i_xReset S= bFFOxOk AND bAtSafeState;
 ffBeamParamsOk.i_xReset R= NOT ffBeamParamsOk.i_xOK;
-ffBeamParamsOk.i_xAutoReset := bBPOKAutoReset;
+
+IF fbFlutterDet.bExceededFlipMax = TRUE THEN
+    ffBeamParamsOk.i_xAutoReset := FALSE;
+ELSE
+    ffBeamParamsOk.i_xAutoReset := bBPOKAutoReset;
+END_IF
 
 ffBeamParamsOk(
     i_DevName:=stMotionStage.sName,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Implemented a function block  that can detect variables that flip too much, causing a flutter. Use that function block to show how it could be used to take away auto-reset capabilities for a particular fast fault. I am not sure this is a good solution, but worth discussing; seems like a lot of overhead. Probably a better solution is updating the GUI to show fluttering fast faults as discussed with @ZLLentz. 

- Also, unsure where we would want to trigger a reset of `fbFlutterDet`. I guess we want to give back the auto-reset capability when the flutter condition is gone. 
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
-Its hard to bypass a fluttering fast fault.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Test suite passes locally
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
