### PR TITLE
ENH: check PLC OS to set new default dir for BSD PLCs

### DIFF
--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -631,6 +631,10 @@
       <DefaultResolution>Tc2_Utilities, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc2_Utilities</Namespace>
     </PlaceholderReference>
+    <PlaceholderReference Include="Tc3_IPCDiag">
+      <DefaultResolution>Tc3_IPCDiag, * (Beckhoff Automation GmbH)</DefaultResolution>
+      <Namespace>Tc3_IPCDiag</Namespace>
+    </PlaceholderReference>
     <PlaceholderReference Include="Tc3_JsonXml">
       <DefaultResolution>Tc3_JsonXml, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc3_JsonXml</Namespace>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
@@ -45,7 +45,8 @@ VAR
 
     fbIPCReg: FB_IPCDiag_Register;
     fbCheckOS: FB_IPCDiag_ReadParameter;
-    sOSName: STRING;
+    sOSName: STRING := '';
+    nCheckOSTries: UINT := 3;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -68,13 +69,27 @@ END_IF
 
 IF sDirectory = '' THEN
     // Check OS for default directory
-    fbIPCReg(bExecute:=TRUE);
+    fbIPCReg(
+        bExecute:=TRUE,
+        tTimeout:=T#1s,
+    );
     fbCheckOS(
-        bExecute:=NOT fbIPCReg.bBusy,
+        bExecute:=fbIPCReg.bValid,
         eParameterKey:=E_IPCDiag_ParameterKey.OS_Name,
         fbRegister:=fbIPCReg,
     );
-    IF fbCheckOS.bValid THEN
+    IF fbIPCReg.bError OR fbCheckOS.bError THEN
+        IF nCheckOSTries <= 0 THEN
+            // Retry counter down to zero: set to error name to try old default
+            sOSName := 'Error';
+        ELSE
+            // Decrement retry counter
+            nCheckOSTries := nCheckOSTries - 1;
+            // Reset FBs
+            fbCheckOS(bExecute:=FALSE, fbRegister:=fbIPCReg);
+            fbIPCReg(bExecute:=FALSE);
+        END_IF
+    ELSIF fbCheckOS.bValid THEN
         fbCheckOS.GetParameter(
             pBuffer:=ADR(sOSName),
             nBufferSize:=SIZEOF(sOSName),

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_Standard_PMPSDB.TcPOU
@@ -22,7 +22,7 @@ VAR_INPUT
     // Set to TRUE to cause an extra read.
     bRefresh: BOOL;
     // Directory where the DB is stored.
-    sDirectory: STRING := '/Hard Disk/ftp/PMPS/';
+    sDirectory: STRING := '';
 END_VAR
 VAR_OUTPUT
     {attribute 'pytmc' := '
@@ -42,6 +42,10 @@ VAR
     fbTime : FB_LocalSystemTime := ( bEnable := TRUE, dwCycle := 1 );
     fbTime_to_UTC: FB_TzSpecificLocalTimeToSystemTime;
     fbGetTimeZone: FB_GetTimeZoneInformation;
+
+    fbIPCReg: FB_IPCDiag_Register;
+    fbCheckOS: FB_IPCDiag_ReadParameter;
+    sOSName: STRING;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -62,9 +66,30 @@ IF rtEnable.Q OR rtRefresh.Q THEN
     bExecute := TRUE;
 END_IF
 
+IF sDirectory = '' THEN
+    // Check OS for default directory
+    fbIPCReg(bExecute:=TRUE);
+    fbCheckOS(
+        bExecute:=NOT fbIPCReg.bBusy,
+        eParameterKey:=E_IPCDiag_ParameterKey.OS_Name,
+        fbRegister:=fbIPCReg,
+    );
+    IF fbCheckOS.bValid THEN
+        fbCheckOS.GetParameter(
+            pBuffer:=ADR(sOSName),
+            nBufferSize:=SIZEOF(sOSName),
+        );
+    END_IF
+    IF sOSName = 'TwinCAT/BSD' THEN
+        sDirectory := '/home/ecs-user/pmpsdb/';
+    ELSIF sOSName <> '' THEN
+        sDirectory := '/Hard Disk/ftp/PMPS/';
+    END_IF
+END_IF
+
 MOTION_GVL.fbPmpsFileReader(
     io_fbFFHWO:=io_fbFFHWO,
-    bExecute:=bExecute,
+    bExecute:=bExecute AND sDirectory <> '',
     sSrcPathName:=CONCAT(CONCAT(sDirectory, sPlcName), '.json'),
     sPLCName:=sPLCName,
     PMPS_jsonDoc=>PMPS_GVL.BP_jsonDoc,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use the IPCDiag FBs to check the PLC's OS, then use that OS to decide the default directory for pmpsdb reading.
These function blocks are somewhat strange, but I followed the docs closely and arrived at this implementation.

Here, I've set the new default directory for TwinCAT BSD PLCs to match the associated PRs:
https://github.com/pcdshub/twincat-bsd-ansible/pull/19
https://github.com/pcdshub/pmpsdb_client/pull/25

And I've left the default directory for other PLC types unchanged.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We can explicitly set a directory for the PMPS database loading in each project, but this leaves open the possibility for typos and copy/paste errors. The directory should be the same every time (dependent on OS), so we can directly check the OS to set a reasonable default. The code is skipped entirely if the user provides a directory.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively on a BSD PLC: the correct directory was checked and the file was opened. (plc-tst-bsd2)
Also checked on a Windows CE PLC, test suite passed and default directory was ftp (plc-tst-proto8, plc-tst-pmps-subsytem-b)

Tested again after adding some error handling, seemed to do the right thing

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://confluence.slac.stanford.edu/display/PCDS/TcBSD+Configuration+Reference#TcBSDConfigurationReference-PMPSDatabase

## Pre-merge checklist
- [x] Code works interactively
- [x] Test suite passes locally
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
