### PR TITLE
add nRawEncoderDINT field variable  for EL5072 LVDT terminal position…

### DIFF
--- a/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
@@ -32,7 +32,7 @@ STRUCT
     nRawEncoderUINT AT %I*: UINT;
     // Raw encoder IO for INT (LVDT)
     nRawEncoderINT AT %I*: INT;
-	// Raw encoder IO for INT (EL5072 LVDT)
+    // Raw encoder IO for INT (EL5072 LVDT)
     nRawEncoderDINT AT %I*: DINT;
 
     (* Psuedo-hardware *)

--- a/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
@@ -32,6 +32,8 @@ STRUCT
     nRawEncoderUINT AT %I*: UINT;
     // Raw encoder IO for INT (LVDT)
     nRawEncoderINT AT %I*: INT;
+	// Raw encoder IO for INT (EL5072 LVDT)
+    nRawEncoderDINT AT %I*: DINT;
 
     (* Psuedo-hardware *)
 

--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -680,8 +680,8 @@
   <ProjectExtensions>
     <PlcProjectOptions>
       <XmlArchive>
-  <Data>
-    <o xml:space="preserve" t="OptionKey">
+        <Data>
+          <o xml:space="preserve" t="OptionKey">
       <v n="Name">"&lt;ProjectRoot&gt;"</v>
       <d n="SubKeys" t="Hashtable" ckt="String" cvt="OptionKey">
         <v>{192FAD59-8248-4824-A8DE-9177C94C195A}</v>
@@ -748,14 +748,14 @@
       </d>
       <d n="Values" t="Hashtable" />
     </o>
-  </Data>
-  <TypeList>
-    <Type n="Boolean">System.Boolean</Type>
-    <Type n="Hashtable">System.Collections.Hashtable</Type>
-    <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
-    <Type n="String">System.String</Type>
-  </TypeList>
-</XmlArchive>
+        </Data>
+        <TypeList>
+          <Type n="Boolean">System.Boolean</Type>
+          <Type n="Hashtable">System.Collections.Hashtable</Type>
+          <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
+          <Type n="String">System.String</Type>
+        </TypeList>
+      </XmlArchive>
     </PlcProjectOptions>
   </ProjectExtensions>
   <!-- 

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_EncoderValue.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_EncoderValue.TcPOU
@@ -36,12 +36,5 @@ ELSE
     stMotionStage.nEncoderCount := 0;
 END_IF]]></ST>
     </Implementation>
-    <LineIds Name="FB_EncoderValue">
-      <LineId Id="3" Count="9" />
-      <LineId Id="33" Count="0" />
-      <LineId Id="32" Count="0" />
-      <LineId Id="13" Count="1" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_EncoderValue.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_EncoderValue.TcPOU
@@ -30,9 +30,18 @@ ELSIF stMotionStage.nRawEncoderUINT <> 0 THEN
     stMotionStage.nEncoderCount := UINT_TO_UDINT(stMotionStage.nRawEncoderUINT);
 ELSIF stMotionStage.nRawEncoderINT <> 0 THEN
     stMotionStage.nEncoderCount := INT_TO_UDINT(stMotionStage.nRawEncoderINT);
+ELSIF stMotionStage.nRawEncoderDINT <> 0 THEN
+    stMotionStage.nEncoderCount := DINT_TO_UDINT(stMotionStage.nRawEncoderDINT);
 ELSE
     stMotionStage.nEncoderCount := 0;
 END_IF]]></ST>
     </Implementation>
+    <LineIds Name="FB_EncoderValue">
+      <LineId Id="3" Count="9" />
+      <LineId Id="33" Count="0" />
+      <LineId Id="32" Count="0" />
+      <LineId Id="13" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
… reading

<!--- Provide a general summary of your changes in the Title above -->
## Description
lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT: add nRawEncoderDINT field variable  for EL5072 LVDT terminal position reading
## Motivation and Context
TMO DREAM KB slits has 2xEL5072 terminals to interface 4xLVDT position sensors.
EL5072 position INPUT variable has DINT type (raw position reading in nm).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Test suite passes locally
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
