### PR TITLE
ECS-6474 : Enable Backlash compensation in TwinCAT motion Library

### DIFF
--- a/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
@@ -219,15 +219,15 @@ STRUCT
 	(* Backlash compensation*)
 	// Enabled axis backlash compensation
     {attribute 'pytmc' := '
-        pv: PLC:bBacklash
+        pv: PLC:bBacklashEn
         io: io
         field: ZNAM FALSE
         field: ONAM TRUE
         field: DESC Enable Backlash compensation
     '}
-    bBacklash: BOOL;
+    bUserBacklashEn: BOOL;
 	
-	// Enabled axis backlash compensation
+	// backlash compensation status
     {attribute 'pytmc' := '
         pv: PLC:bBacklasStatus
         io: i

--- a/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
@@ -216,6 +216,43 @@ STRUCT
         field: DESC Position lag difference
     '}
     fPosDiff: LREAL;
+	(* Backlash compensation*)
+	// Enabled axis backlash compensation
+    {attribute 'pytmc' := '
+        pv: PLC:bBacklash
+        io: io
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC Enable Backlash compensation
+    '}
+    bBacklash: BOOL;
+	
+	// Enabled axis backlash compensation
+    {attribute 'pytmc' := '
+        pv: PLC:bBacklasStatus
+        io: i
+        field: ZNAM DISABLED
+        field: ONAM ENABLED
+        field: DESC Backlash compensation status
+    '}
+    bBacklashStatus: BOOL;
+	
+	// Backlash compensation value
+    {attribute 'pytmc' := '
+        pv: PLC:fBacklashCompensation
+        io: io
+        field: DESC Backlash compensation
+    '}
+    fBacklashCompensation: LREAL;
+	
+	// Current Backlash compensation value ?
+    {attribute 'pytmc' := '
+        pv: PLC:fCurrentBacklashCompensation
+        io: i
+        field: DESC Current Backlash compensation
+    '}
+    fCurrentBacklashCompensation: LREAL;
+	
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/ST_MotionStage.TcDUT
@@ -216,8 +216,8 @@ STRUCT
         field: DESC Position lag difference
     '}
     fPosDiff: LREAL;
-	(* Backlash compensation*)
-	// Enabled axis backlash compensation
+    (* Backlash compensation*)
+    // Enabled axis backlash compensation
     {attribute 'pytmc' := '
         pv: PLC:bBacklashEn
         io: io
@@ -226,8 +226,8 @@ STRUCT
         field: DESC Enable Backlash compensation
     '}
     bUserBacklashEn: BOOL;
-	
-	// backlash compensation status
+
+    // backlash compensation status
     {attribute 'pytmc' := '
         pv: PLC:bBacklasStatus
         io: i
@@ -236,23 +236,23 @@ STRUCT
         field: DESC Backlash compensation status
     '}
     bBacklashStatus: BOOL;
-	
-	// Backlash compensation value
+
+    // Backlash compensation value
     {attribute 'pytmc' := '
         pv: PLC:fBacklashCompensation
         io: io
         field: DESC Backlash compensation
     '}
     fBacklashCompensation: LREAL;
-	
-	// Current Backlash compensation value ?
+
+    // Current Backlash compensation value ?
     {attribute 'pytmc' := '
         pv: PLC:fCurrentBacklashCompensation
         io: i
         field: DESC Current Backlash compensation
     '}
     fCurrentBacklashCompensation: LREAL;
-	
+
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionBacklashCompensation.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionBacklashCompensation.TcPOU
@@ -24,10 +24,9 @@ END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[(*Note: Configure within the axis parameters set "position correction" to true *)
 (*Directional change for compensation
-  default: psotive backlash):
+  default: positive backlash):
   TRUE -> Negative backlash compensation *)
-(* Disabled Compensation to register a new value change*)
-
+(* Reset Compensation to register a new value change*)
 bBacklashCompEnable R= bHoming OR (stMotionStage.fBacklashCompensation<>bPrevCompensation);
 bBacklashCompEnable S= bMove;
 

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionBacklashCompensation.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionBacklashCompensation.TcPOU
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
-  <POU Name="FB_MotionBacklashCompensation" Id="{ca6d14d0-2e55-42e4-8fc6-d17fd5f74053}" SpecialFunc="None">
+  <POU Name="FB_MotionBacklashCompensation" Id="{8a5f8930-cc79-4651-8951-8645e0708394}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_MotionBacklashCompensation
 VAR_IN_OUT
     stMotionStage: ST_MotionStage;
@@ -17,107 +17,32 @@ VAR_OUTPUT
 END_VAR
 VAR
     fbBacklashCompensation: MC_BacklashCompensation;
-    rtHomeExec: R_TRIG;
-    rtMoveExec: F_TRIG;
+	// Default: Positive backlash compensation
+	bPrevCompensation : LREAL := 0.0;
+	bBacklashCompEnable: BOOL;
 END_VAR]]></Declaration>
     <Implementation>
-      <ST><![CDATA[(*Configure within the axis parameters set "position correction" to true *)
-rtHomeExec(CLK:=bHoming);
-rtMoveExec(CLK:=bMove);
+      <ST><![CDATA[(*Note: Configure within the axis parameters set "position correction" to true *)
+(*Directional change for compensation 
+  default: psotive backlash): 
+  TRUE -> Negative backlash compensation *)
+(* Disabled Compensation to register a new value change*)
 
-IF rtHomeExec.Q THEN
-	BacklashCompDisable();
-END_IF
+bBacklashCompEnable R= bHoming OR (stMotionStage.fBacklashCompensation<>bPrevCompensation);
+bBacklashCompEnable S= bMove;
 
-IF rtMoveExec.Q THEN
-	BacklashCompEnable();
-END_IF
+fbBacklashCompensation(Axis:=stMotionStage.Axis, 
+	Enable:= ( stMotionStage.bUserBacklashEn AND bBacklashCompEnable), 
+	Backlash:=stMotionStage.fBacklashCompensation, 
+	CompensationInPositiveDirection:=(stMotionStage.fBacklashCompensation<0.0),
+	Ramp:=stMotionStage.fVelocity, 
+	DisableMode:=DisableModeHold, 
+	Enabled=> stMotionStage.bBacklashStatus, 
+	Error=>bError, 
+	ErrorID=>nErrorID, 
+	CurrentBacklash=>stMotionStage.fCurrentBacklashCompensation);
 
-
-
-]]></ST>
+bPrevCompensation:=stMotionStage.fBacklashCompensation;]]></ST>
     </Implementation>
-    <Method Name="BacklashCompDisable" Id="{dfa38fb4-8af5-4573-b73f-c7816c901f59}">
-      <Declaration><![CDATA[METHOD BacklashCompDisable
-
-]]></Declaration>
-      <Implementation>
-        <ST><![CDATA[(*Disable the compensation*)
-(*Reset the compenstion value*)
-fbBacklashCompensation.DisableMode := DisableModeReset;
-fbBacklashCompensation.Enable := FALSE;
-	
-IF fbBacklashCompensation.Error THEN
-    bError:=fbBacklashCompensation.Error;
-    nErrorID:=fbBacklashCompensation.ErrorID;
-END_IF
-
-bEnabled := fbBacklashCompensation.Enabled;]]></ST>
-      </Implementation>
-    </Method>
-    <Method Name="BacklashCompEnable" Id="{11e7a569-1bd6-4259-a522-e58298a869f9}">
-      <Declaration><![CDATA[METHOD BacklashCompEnable
-
-VAR
-	// Default: Positive backlash compensation
-	bCompensationInDirection : BOOL := FALSE;
-END_VAR
-]]></Declaration>
-      <Implementation>
-        <ST><![CDATA[(*Enable backlash compensation*)
-(*Positive backlash: CompensationInPositiveDirection -> false
-  Negative backlash: CompensationInPositiveDirection -> true
-*)
-IF stMotionStage.fBacklashCompensation < 0.0 THEN
-	bCompensationInDirection := TRUE;
-END_IF
-(*A movement in the desired direction will need to be compensated*)
-fbBacklashCompensation.CompensationInPositiveDirection := bCompensationInDirection;
-// peraphs a sanity check is needed for the backlash value?
-fbBacklashCompensation.Backlash := stMotionStage.fBacklashCompensation; (*mm*)
-fbBacklashCompensation.Ramp := stMotionStage.fVelocity;(*mm/s*)
-fbBacklashCompensation.Enable := stMotionStage.bBacklash;
-
-IF fbBacklashCompensation.Error THEN
-    bError:= fbBacklashCompensation.Error;
-    nErrorID:= fbBacklashCompensation.ErrorID;
-END_IF
-
-bEnabled := fbBacklashCompensation.Enabled;
-stMotionStage.bBacklashStatus:=bEnabled;
-stMotionStage.fCurrentBacklashCompensation:=fbBacklashCompensation.CurrentBacklash;]]></ST>
-      </Implementation>
-    </Method>
-    <LineIds Name="FB_MotionBacklashCompensation">
-      <LineId Id="336" Count="0" />
-      <LineId Id="338" Count="5" />
-      <LineId Id="345" Count="0" />
-      <LineId Id="344" Count="0" />
-      <LineId Id="346" Count="2" />
-      <LineId Id="357" Count="0" />
-      <LineId Id="356" Count="0" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MotionBacklashCompensation.BacklashCompDisable">
-      <LineId Id="6" Count="3" />
-      <LineId Id="11" Count="1" />
-      <LineId Id="14" Count="0" />
-      <LineId Id="13" Count="0" />
-      <LineId Id="5" Count="0" />
-      <LineId Id="17" Count="0" />
-      <LineId Id="16" Count="0" />
-    </LineIds>
-    <LineIds Name="FB_MotionBacklashCompensation.BacklashCompEnable">
-      <LineId Id="9" Count="0" />
-      <LineId Id="23" Count="0" />
-      <LineId Id="25" Count="2" />
-      <LineId Id="38" Count="1" />
-      <LineId Id="41" Count="0" />
-      <LineId Id="13" Count="0" />
-      <LineId Id="42" Count="0" />
-      <LineId Id="14" Count="2" />
-      <LineId Id="45" Count="7" />
-      <LineId Id="44" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionBacklashCompensation.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionBacklashCompensation.TcPOU
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_MotionBacklashCompensation" Id="{ca6d14d0-2e55-42e4-8fc6-d17fd5f74053}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_MotionBacklashCompensation
+VAR_IN_OUT
+    stMotionStage: ST_MotionStage;
+END_VAR
+VAR_INPUT
+    bHoming: BOOL;
+	bMove: BOOL;
+END_VAR
+VAR_OUTPUT
+    bEnabled: BOOL;
+    bBusy: BOOL;
+    bError: BOOL;
+    nErrorID: UDINT;
+END_VAR
+VAR
+    fbBacklashCompensation: MC_BacklashCompensation;
+    rtHomeExec: R_TRIG;
+    rtMoveExec: F_TRIG;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[(*Configure within the axis parameters set "position correction" to true *)
+rtHomeExec(CLK:=bHoming);
+rtMoveExec(CLK:=bMove);
+
+IF rtHomeExec.Q THEN
+	BacklashCompDisable();
+END_IF
+
+IF rtMoveExec.Q THEN
+	BacklashCompEnable();
+END_IF
+
+
+
+]]></ST>
+    </Implementation>
+    <Method Name="BacklashCompDisable" Id="{dfa38fb4-8af5-4573-b73f-c7816c901f59}">
+      <Declaration><![CDATA[METHOD BacklashCompDisable
+
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[(*Disable the compensation*)
+(*Reset the compenstion value*)
+fbBacklashCompensation.DisableMode := DisableModeReset;
+fbBacklashCompensation.Enable := FALSE;
+	
+IF fbBacklashCompensation.Error THEN
+    bError:=fbBacklashCompensation.Error;
+    nErrorID:=fbBacklashCompensation.ErrorID;
+END_IF
+
+bEnabled := fbBacklashCompensation.Enabled;]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="BacklashCompEnable" Id="{11e7a569-1bd6-4259-a522-e58298a869f9}">
+      <Declaration><![CDATA[METHOD BacklashCompEnable
+
+VAR
+	// Default: Positive backlash compensation
+	bCompensationInDirection : BOOL := FALSE;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[(*Enable backlash compensation*)
+(*Positive backlash: CompensationInPositiveDirection -> false
+  Negative backlash: CompensationInPositiveDirection -> true
+*)
+IF stMotionStage.fBacklashCompensation < 0.0 THEN
+	bCompensationInDirection := TRUE;
+END_IF
+(*A movement in the desired direction will need to be compensated*)
+fbBacklashCompensation.CompensationInPositiveDirection := bCompensationInDirection;
+// peraphs a sanity check is needed for the backlash value?
+fbBacklashCompensation.Backlash := stMotionStage.fBacklashCompensation; (*mm*)
+fbBacklashCompensation.Ramp := stMotionStage.fVelocity;(*mm/s*)
+fbBacklashCompensation.Enable := stMotionStage.bBacklash;
+
+IF fbBacklashCompensation.Error THEN
+    bError:= fbBacklashCompensation.Error;
+    nErrorID:= fbBacklashCompensation.ErrorID;
+END_IF
+
+bEnabled := fbBacklashCompensation.Enabled;
+stMotionStage.bBacklashStatus:=bEnabled;
+stMotionStage.fCurrentBacklashCompensation:=fbBacklashCompensation.CurrentBacklash;]]></ST>
+      </Implementation>
+    </Method>
+    <LineIds Name="FB_MotionBacklashCompensation">
+      <LineId Id="336" Count="0" />
+      <LineId Id="338" Count="5" />
+      <LineId Id="345" Count="0" />
+      <LineId Id="344" Count="0" />
+      <LineId Id="346" Count="2" />
+      <LineId Id="357" Count="0" />
+      <LineId Id="356" Count="0" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MotionBacklashCompensation.BacklashCompDisable">
+      <LineId Id="6" Count="3" />
+      <LineId Id="11" Count="1" />
+      <LineId Id="14" Count="0" />
+      <LineId Id="13" Count="0" />
+      <LineId Id="5" Count="0" />
+      <LineId Id="17" Count="0" />
+      <LineId Id="16" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MotionBacklashCompensation.BacklashCompEnable">
+      <LineId Id="9" Count="0" />
+      <LineId Id="23" Count="0" />
+      <LineId Id="25" Count="2" />
+      <LineId Id="38" Count="1" />
+      <LineId Id="41" Count="0" />
+      <LineId Id="13" Count="0" />
+      <LineId Id="42" Count="0" />
+      <LineId Id="14" Count="2" />
+      <LineId Id="45" Count="7" />
+      <LineId Id="44" Count="0" />
+    </LineIds>
+  </POU>
+</TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionBacklashCompensation.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionBacklashCompensation.TcPOU
@@ -7,7 +7,7 @@ VAR_IN_OUT
 END_VAR
 VAR_INPUT
     bHoming: BOOL;
-	bMove: BOOL;
+    bMove: BOOL;
 END_VAR
 VAR_OUTPUT
     bEnabled: BOOL;
@@ -17,30 +17,30 @@ VAR_OUTPUT
 END_VAR
 VAR
     fbBacklashCompensation: MC_BacklashCompensation;
-	// Default: Positive backlash compensation
-	bPrevCompensation : LREAL := 0.0;
-	bBacklashCompEnable: BOOL;
+    // Default: Positive backlash compensation
+    bPrevCompensation : LREAL := 0.0;
+    bBacklashCompEnable: BOOL;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[(*Note: Configure within the axis parameters set "position correction" to true *)
-(*Directional change for compensation 
-  default: psotive backlash): 
+(*Directional change for compensation
+  default: psotive backlash):
   TRUE -> Negative backlash compensation *)
 (* Disabled Compensation to register a new value change*)
 
 bBacklashCompEnable R= bHoming OR (stMotionStage.fBacklashCompensation<>bPrevCompensation);
 bBacklashCompEnable S= bMove;
 
-fbBacklashCompensation(Axis:=stMotionStage.Axis, 
-	Enable:= ( stMotionStage.bUserBacklashEn AND bBacklashCompEnable), 
-	Backlash:=stMotionStage.fBacklashCompensation, 
-	CompensationInPositiveDirection:=(stMotionStage.fBacklashCompensation<0.0),
-	Ramp:=stMotionStage.fVelocity, 
-	DisableMode:=DisableModeHold, 
-	Enabled=> stMotionStage.bBacklashStatus, 
-	Error=>bError, 
-	ErrorID=>nErrorID, 
-	CurrentBacklash=>stMotionStage.fCurrentBacklashCompensation);
+fbBacklashCompensation(Axis:=stMotionStage.Axis,
+    Enable:= ( stMotionStage.bUserBacklashEn AND bBacklashCompEnable),
+    Backlash:=stMotionStage.fBacklashCompensation,
+    CompensationInPositiveDirection:=(stMotionStage.fBacklashCompensation<0.0),
+    Ramp:=stMotionStage.fVelocity,
+    DisableMode:=DisableModeHold,
+    Enabled=> stMotionStage.bBacklashStatus,
+    Error=>bError,
+    ErrorID=>nErrorID,
+    CurrentBacklash=>stMotionStage.fCurrentBacklashCompensation);
 
 bPrevCompensation:=stMotionStage.fBacklashCompensation;]]></ST>
     </Implementation>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionHoming.TcPOU
@@ -237,7 +237,7 @@ IF bMove THEN
                 Position:=stMotionStage.fHomePosition);
             nHomeStateMachine := IDLE;
             bBusy := FALSE;
-            bDone := TRUE;
+            bDone := TRUE; // need this
         ERROR:
             bError := TRUE;
             nErrorID := fbJog.ErrorID;
@@ -257,5 +257,9 @@ IF bMove THEN
     END_CASE
 END_IF]]></ST>
     </Implementation>
+    <LineIds Name="FB_MotionHoming">
+      <LineId Id="3" Count="204" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -15,6 +15,7 @@ VAR
     fbMotionHome: FB_MotionHoming;
     fbSaveRestore: FB_EncSaveRestore;
     fbLogError: FB_LogMotionError;
+	fbBacklashCompensation: FB_MotionBacklashCompensation;
     bExecute: BOOL;
     bExecMove: BOOL;
     bExecHome: BOOL;
@@ -35,6 +36,11 @@ VAR
     bMoveCmd: BOOL;
     rtMoveCmdShortcut: R_TRIG;
     rtHomeCmdShortcut: R_TRIG;
+	// backlash compensation
+	bBacklashEnabled: BOOL;
+    bBacklashBusy: BOOL;
+    bBacklashError: BOOL;
+    nBacklashErrorID: UDINT;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -52,6 +58,7 @@ IF rtMoveCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
 ELSIF rtHomeCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
     stMotionStage.bExecute := TRUE;
     stMotionStage.nCommand := E_EpicsMotorCmd.HOME;
+	// maybe disable backlash here
 END_IF
 // Always reset, even if not rising edge, so command can be issued again
 IF stMotionStage.bMoveCmd OR stMotionStage.bHomeCmd THEN
@@ -62,6 +69,7 @@ END_IF
 // Automatically fill the correct nCmdData for homing
 IF stMotionStage.nCommand = E_EpicsMotorCmd.HOME THEN
     stMotionStage.nCmdData := stMotionStage.nHomingMode;
+	// or maybe here
 END_IF
 
 // Check if the command wants to cause a move
@@ -138,15 +146,21 @@ IF stMotionStage.bError THEN
     bExecute := FALSE;
 END_IF
 
+bExecHome := bExecute AND (stMotionStage.nCommand = 10);
+// absolute move is valid only after after backlash compensation is enabled
+bExecMove := bExecute AND NOT bExecHome AND bBacklashEnabled; 
 
-bExecHome := bExecute AND stMotionStage.nCommand = 10;
-bExecMove := bExecute AND NOT bExecHome;
-
+// backlash compensention handling
+fbBacklashCompensation(stMotionStage:=stMotionStage, 
+	bHoming:=bExecHome, 
+	bMove:=bExecMove, 
+	bEnabled=>bBacklashEnabled);
+	
 // Handle standard commands using ESS's FB
 fbDriveVirtual(En:=TRUE,
     bEnable:=stMotionStage.bAllEnable,
     bReset:=stMotionStage.bReset,
-    bExecute:=bExecMove,
+    bExecute:=bExecMove, // add a condition on this boolean, backlsash needs to be enabled
     nCommand:=INT_TO_UINT(stMotionStage.nCommand),
     nCmdData:=INT_TO_UINT(stMotionStage.nCmdData),
     fVelocity:=stMotionStage.fVelocity,
@@ -174,6 +188,12 @@ IF NOT stMotionStage.bError THEN
     stMotionStage.bError := fbDriveVirtual.bError;
     stMotionStage.nErrorId := fbDriveVirtual.nErrorId;
 END_IF
+
+IF NOT stMotionStage.bError THEN
+    stMotionStage.bError := fbBacklashCompensation.bError;
+    stMotionStage.nErrorId := fbBacklashCompensation.nErrorId;
+END_IF
+
 IF NOT stMotionStage.bError THEN
     stMotionStage.bError := fbMotionHome.bError;
     stMotionStage.nErrorId := fbMotionHome.nErrorId;
@@ -305,5 +325,27 @@ fbSaveRestore(
     stMotionStage:=stMotionStage,
     bEnable:=stMotionStage.nHomingMode <> E_EpicsHomeCmd.NONE);]]></ST>
     </Implementation>
+    <LineIds Name="FB_MotionStage">
+      <LineId Id="3" Count="13" />
+      <LineId Id="303" Count="0" />
+      <LineId Id="17" Count="9" />
+      <LineId Id="304" Count="0" />
+      <LineId Id="27" Count="74" />
+      <LineId Id="103" Count="1" />
+      <LineId Id="381" Count="0" />
+      <LineId Id="105" Count="0" />
+      <LineId Id="389" Count="0" />
+      <LineId Id="384" Count="3" />
+      <LineId Id="364" Count="0" />
+      <LineId Id="388" Count="0" />
+      <LineId Id="107" Count="17" />
+      <LineId Id="374" Count="0" />
+      <LineId Id="126" Count="12" />
+      <LineId Id="376" Count="3" />
+      <LineId Id="375" Count="0" />
+      <LineId Id="380" Count="0" />
+      <LineId Id="139" Count="128" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -15,7 +15,7 @@ VAR
     fbMotionHome: FB_MotionHoming;
     fbSaveRestore: FB_EncSaveRestore;
     fbLogError: FB_LogMotionError;
-	fbBacklashCompensation: FB_MotionBacklashCompensation;
+    fbBacklashCompensation: FB_MotionBacklashCompensation;
     bExecute: BOOL;
     bExecMove: BOOL;
     bExecHome: BOOL;
@@ -36,8 +36,8 @@ VAR
     bMoveCmd: BOOL;
     rtMoveCmdShortcut: R_TRIG;
     rtHomeCmdShortcut: R_TRIG;
-	// backlash compensation
-	bBacklashEnabled: BOOL;
+    // backlash compensation
+    bBacklashEnabled: BOOL;
     bBacklashBusy: BOOL;
     bBacklashError: BOOL;
     nBacklashErrorID: UDINT;
@@ -58,7 +58,7 @@ IF rtMoveCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
 ELSIF rtHomeCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
     stMotionStage.bExecute := TRUE;
     stMotionStage.nCommand := E_EpicsMotorCmd.HOME;
-	// maybe disable backlash here
+    // maybe disable backlash here
 END_IF
 // Always reset, even if not rising edge, so command can be issued again
 IF stMotionStage.bMoveCmd OR stMotionStage.bHomeCmd THEN
@@ -69,7 +69,7 @@ END_IF
 // Automatically fill the correct nCmdData for homing
 IF stMotionStage.nCommand = E_EpicsMotorCmd.HOME THEN
     stMotionStage.nCmdData := stMotionStage.nHomingMode;
-	// or maybe here
+    // or maybe here
 END_IF
 
 // Check if the command wants to cause a move
@@ -148,14 +148,14 @@ END_IF
 
 bExecHome := bExecute AND (stMotionStage.nCommand = 10);
 // absolute move is valid only after after backlash compensation is enabled
-bExecMove := bExecute AND NOT bExecHome; 
+bExecMove := bExecute AND NOT bExecHome;
 
 // backlash compensention handling
-fbBacklashCompensation(stMotionStage:=stMotionStage, 
-	bHoming:=bExecHome, 
-	bMove:=bExecMove, 
-	bEnabled=>bBacklashEnabled);
-	
+fbBacklashCompensation(stMotionStage:=stMotionStage,
+    bHoming:=bExecHome,
+    bMove:=bExecMove,
+    bEnabled=>bBacklashEnabled);
+
 // Handle standard commands using ESS's FB
 fbDriveVirtual(En:=TRUE,
     bEnable:=stMotionStage.bAllEnable,

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -36,11 +36,6 @@ VAR
     bMoveCmd: BOOL;
     rtMoveCmdShortcut: R_TRIG;
     rtHomeCmdShortcut: R_TRIG;
-    // backlash compensation
-    bBacklashEnabled: BOOL;
-    bBacklashBusy: BOOL;
-    bBacklashError: BOOL;
-    nBacklashErrorID: UDINT;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -153,8 +148,7 @@ bExecMove := bExecute AND NOT bExecHome;
 // backlash compensention handling
 fbBacklashCompensation(stMotionStage:=stMotionStage,
     bHoming:=bExecHome,
-    bMove:=bExecMove,
-    bEnabled=>bBacklashEnabled);
+    bMove:=bExecMove );
 
 // Handle standard commands using ESS's FB
 fbDriveVirtual(En:=TRUE,

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -148,7 +148,7 @@ END_IF
 
 bExecHome := bExecute AND (stMotionStage.nCommand = 10);
 // absolute move is valid only after after backlash compensation is enabled
-bExecMove := bExecute AND NOT bExecHome AND bBacklashEnabled; 
+bExecMove := bExecute AND NOT bExecHome; 
 
 // backlash compensention handling
 fbBacklashCompensation(stMotionStage:=stMotionStage, 
@@ -325,27 +325,5 @@ fbSaveRestore(
     stMotionStage:=stMotionStage,
     bEnable:=stMotionStage.nHomingMode <> E_EpicsHomeCmd.NONE);]]></ST>
     </Implementation>
-    <LineIds Name="FB_MotionStage">
-      <LineId Id="3" Count="13" />
-      <LineId Id="303" Count="0" />
-      <LineId Id="17" Count="9" />
-      <LineId Id="304" Count="0" />
-      <LineId Id="27" Count="74" />
-      <LineId Id="103" Count="1" />
-      <LineId Id="381" Count="0" />
-      <LineId Id="105" Count="0" />
-      <LineId Id="389" Count="0" />
-      <LineId Id="384" Count="3" />
-      <LineId Id="364" Count="0" />
-      <LineId Id="388" Count="0" />
-      <LineId Id="107" Count="17" />
-      <LineId Id="374" Count="0" />
-      <LineId Id="126" Count="12" />
-      <LineId Id="376" Count="3" />
-      <LineId Id="375" Count="0" />
-      <LineId Id="380" Count="0" />
-      <LineId Id="139" Count="128" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
The new feature adds support for backlash correction in the LCLS TwinCAT motion library for assisting in more precise positioning for both closed and open loop systems. 
<!--- Describe your changes in detail -->

- Add EPICS support in ST_MotionStage for Backlash compensation user interface
- Created an FB_MotionBacklashCompensation wrapping MC_BacklashCompensation to implement compensation functionalities
- Add call for FB_MotionBacklashCompensation and expanded error handling in FB_MotionStage

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The feature is required to fix a vital need for more precise positioning of open and closed loop systems facing motion backlashes.
https://jira.slac.stanford.edu/browse/ECS-6374
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The Backlash compensation algorithm has been tested for:
-  Disabling backlash compensation when homing an axis.
-  Updating the compensation value and setting the direction based on the sign of the user interface variable ( EPICS interface)
- Enabling compensation when a move command is registered and updating user interface variables.
- Applying compensation in the direction of the backlash

<!--- Include details of your testing environment, and the tests you ran to -->
The feature has been tested on a LAB setup organized as running from a local machine running the latest TWinCAT ( 4026.13) with dependant LCLS libraries compiled under the same version of TwinCAT.
The testing setup consisted of:
- Beckhoff EL7047 drive and EL5101 incremental encoder attached to a stepper motor served as the stage.
- An NC axis was added to the library under test and linked to the staged hardware
- A sample PLC program leveraging the LCLS TwinCAT motion control library resources was used to test the feature

**NB:** _The NC axis configuration parameter "Position Correction" must be set  "TRUE" before activating the configurations._

The Validation of the compensation feature consisted of:
- Homing the axis and verifying that the move was done without compensation
- Setting a compensation value and observing the direction of backlash compensation correction
- Registering a move in one direction and reversing to observe compensation being applied. 

This observation was made by capturing the encoder count at a given position A, then at position B, and reversing to position C without any compensation being applied. Then going through the same process from the same position A with backlash compensation enabled, a user-defined compensation value set,  thus observing the final count of the encoder at position C. 

The results showed that the compensated encoder count at C  is that of the uncompensated one minus the compensation value in encoder counts. this held for both backlash directions.

<!--- see how your change affects other areas of the code, etc. -->
The feature required that some code be added to the MotionStage ST and B. The backlash compensation feature implementation mainly reads in two inputs from variables in  FB_MotionStage and expands its error handling. 

**NB:** _Unit tests for this feature have not been developed yet. So testing only deals with what's existing including the added support for backlash compensation._

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
the  FB_MotionBacklashCompensation FB carries light documentation of the feature implemented and the required initial conditions.



## Pre-merge checklist
- [x] Code works interactively
- [ ] Test suite passes locally
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
