### PR TITLE
Warning Message for unset bHomed Flag for a Home mode defined stage

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -49,6 +49,13 @@ rtHomeCmdShortcut(CLK:=stMotionStage.bHomeCmd);
 IF rtMoveCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
     stMotionStage.bExecute := TRUE;
     stMotionStage.nCommand := E_EpicsMotorCmd.MOVE_ABSOLUTE;
+
+    // attempting to move an axis without homing first?
+    IF stMotionStage.nHomingMode <> E_EpicsHomeCmd.NONE THEN
+        // one can just set bHome here even though no homing was done?
+        stMotionStage.sErrorMessage := 'Axis homing mode set, but homing routine pending';
+    END_IF
+
 ELSIF rtHomeCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
     stMotionStage.bExecute := TRUE;
     stMotionStage.nCommand := E_EpicsMotorCmd.HOME;

--- a/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/FB_MotionStage.TcPOU
@@ -51,7 +51,7 @@ IF rtMoveCmdShortcut.Q AND NOT stMotionStage.bExecute THEN
     stMotionStage.nCommand := E_EpicsMotorCmd.MOVE_ABSOLUTE;
 
     // attempting to move an axis without homing first?
-    IF stMotionStage.nHomingMode <> E_EpicsHomeCmd.NONE THEN
+    IF stMotionStage.nHomingMode <> E_EpicsHomeCmd.NONE AND NOT stMotionStage.bHomed THEN
         // one can just set bHome here even though no homing was done?
         stMotionStage.sErrorMessage := 'Axis homing mode set, but homing routine pending';
     END_IF


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Implement warning message when the axis homing mode is assigned and the bHomed flag is not set before attempting to move the axis
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
EPICS side complains while an axis with homing mode defined, but bHomed is not set. in other words, no homing routine was executed for this axis before an absolute move was requested.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code Tested on TwinCAT 4026.11 running in Local Mode under VM.  A warning message in printed in the error message window each time an absolute move is performed on the axis while bHomed is unset to notify the operator. this notification will be reset once the axis is homed.
![bhomed](https://github.com/user-attachments/assets/053c4260-aaee-4790-b654-1b19ca90dde3)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be a comment in the code or updating a docstring -->
Descriptive comments were added above the implementation line in the modified FBs.
## Pre-merge checklist
- [x] Code works interactively
- [x] Test suite passes locally
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
