### PR TITLE
Debouncer autoreset and counter max limit

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MiscStatesErrorFFO.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MiscStatesErrorFFO.TcPOU
@@ -97,7 +97,7 @@ ffUnknown(
 ftTripCount(CLK:=ffBeamParamsOk.i_xOK);
 
 IF ftTripCount.Q THEN
-    nTripCount := nTripCount + 1;
+    nTripCount := MAX(nTripCount + 1, 5);
 END_IF
 
 tonTripCount(
@@ -112,7 +112,7 @@ END_IF
 ffDebounce.i_xReset S= bFirstCycle;
 ffDebounce(
     i_xOK := nTripCount < 5,
-    i_xAutoReset := FALSE,
+    i_xAutoReset := TRUE,
     i_DevName := sDeviceName,
     i_Desc := 'Tripped beam parameter mismatch off/on too many times, hold off',
     i_TypeCode := E_MotionFFType.TOO_MANY_TRIPS,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Making the debouncer fast fault auto-reset
- nTripCount now has a maximum value of 5, so that it does not grow larger than that and delay beam while it ticks down

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-7551

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Test suite passes locally
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
