### PR TITLE
Vacuum Library 4026 Migration: Migrate LVDT part to the motion library

### DIFF
--- a/lcls-twincat-motion/Library/DUTs/LVDT/ST_SerLVC4000.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/LVDT/ST_SerLVC4000.TcDUT
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.16">
+  <DUT Name="ST_SerLVC4000" Id="{1ecc4b20-fded-4e3a-82c1-cf810d73e466}">
+    <Declaration><![CDATA[TYPE ST_SerLVC4000 :
+STRUCT
+    (* Readbacks *)
+    {attribute 'pytmc' := '
+    pv: voltage;
+    io: i;
+    '}
+    i_iOut	:	INT; //Output voltage
+    (* Controls *)
+    {attribute 'pytmc' := '
+    pv: ADC_COEFF;
+    io: io;
+    '}
+    q_rADCsl	:	REAL; //ADC slope coeff
+    {attribute 'pytmc' := '
+    pv: ADC_OFFSET;
+    io: io;
+    '}
+    q_rADCos	:	REAL; //ADC offset
+    {attribute 'pytmc' := '
+    pv: CALIB_SET;
+    io: io;
+    '}
+    q_xCal	:	BOOL; //Activate calibration mode
+    {attribute 'pytmc' := '
+    pv: DISP_SET;
+    io: io;
+    '}
+    q_xFull	:	BOOL; //Set full displacement during calibration
+    {attribute 'pytmc' := '
+    pv: ZERO_SET;
+    io: io;
+    '}
+    q_xZero	:	BOOL; //Set zero during calibration
+    {attribute 'pytmc' := '
+    pv: GAIN_SET;
+    io: io;
+    '}
+    q_iGain	:	INT; //Set instrument gain
+    {attribute 'pytmc' := '
+    pv: CALIB_ABORT;
+    io: io;
+    '}
+    q_xAbortCal	:	BOOL; //Abort calibration mode
+    (* Internal params *)
+    {attribute 'pytmc' := '
+    pv: ADDR;
+    io: io;
+    '}
+    iAddr	:	INT; //RS485 address
+    xTimeout	:	BOOL; //Timeout (true if no comm)
+END_STRUCT
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/lcls-twincat-motion/Library/GVLs/Constants.TcGVL
+++ b/lcls-twincat-motion/Library/GVLs/Constants.TcGVL
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <GVL Name="Constants" Id="{352ad9bf-a34d-4366-bd0d-dad0c46d83d9}">
+    <Declaration><![CDATA[VAR_GLOBAL CONSTANT
+    gc_iSizeOfGGOArray : INT := 50;
+    gc_GaugeValidState :	INT := 4;
+END_VAR
+]]></Declaration>
+  </GVL>
+</TcPlcObject>

--- a/lcls-twincat-motion/Library/GVLs/GVL_MacroSensorsParameters.TcGVL
+++ b/lcls-twincat-motion/Library/GVLs/GVL_MacroSensorsParameters.TcGVL
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4018.5">
+  <GVL Name="GVL_MacroSensorsParameters" Id="{1082d9c1-a21d-43e2-a315-2445bcd762d2}">
+    <Declaration><![CDATA[VAR_GLOBAL CONSTANT
+    gcMaxLVC4000	:	INT := 20; //maximum number of LVC4000 units per port
+END_VAR]]></Declaration>
+  </GVL>
+</TcPlcObject>

--- a/lcls-twincat-motion/Library/GVLs/Global_Variables.TcGVL
+++ b/lcls-twincat-motion/Library/GVLs/Global_Variables.TcGVL
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <GVL Name="Global_Variables" Id="{a6c265d3-24f0-4c94-8227-7e6ead61f239}">
+    <Declaration><![CDATA[VAR_GLOBAL
+    g_iSizeOfGGOArray : INT := 50;
+
+    g_stSystem	:	ST_System(*System_Struct*):= (
+        xFirstScan := TRUE
+    );
+
+    g_DummyVG	:	ST_VG;
+
+
+     fbGetCurTaskIdx : GETCURTASKINDEX;
+     TaskInfo:PlcTaskSystemInfo;
+
+
+END_VAR
+]]></Declaration>
+  </GVL>
+</TcPlcObject>

--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -27,8 +27,11 @@
   <ItemGroup>
     <Folder Include="DUTs" />
     <Folder Include="DUTs\Deprecated" />
+    <Folder Include="DUTs\LVDT" />
     <Folder Include="GVLs" />
     <Folder Include="POUs\Motion\ITFs" />
+    <Folder Include="POUs\Motion\LVDT" />
+    <Folder Include="POUs\Motion\LVDT\MacroSensors" />
     <Folder Include="POUs\Motion\PMPS" />
     <Folder Include="POUs\Motion\States\Examples" />
     <Folder Include="POUs\Motion\States\Helpers" />
@@ -106,6 +109,9 @@
     <Compile Include="DUTs\Deprecated\ENUM_StatePMPSStatus.TcDUT">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="DUTs\LVDT\ST_SerLVC4000.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="DUTs\ST_AxisParameterSetExposed.TcDUT">
       <SubType>Code</SubType>
     </Compile>
@@ -171,6 +177,9 @@
       <LinkAlways>true</LinkAlways>
     </Compile>
     <Compile Include="DUTs\ST_StatePMPSPlcToEpics.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="GVLs\GVL_MacroSensorsParameters.TcGVL">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="GVLs\MOTION_GVL.TcGVL">
@@ -306,6 +315,15 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Motion\ITFs\I_PersistantDataStorage.TcIO">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Motion\LVDT\MacroSensors\FB_LVC4000Com.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Motion\LVDT\MacroSensors\FB_LVC4000SerialDriver.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Motion\LVDT\MacroSensors\FB_LVC4000Transaction.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Motion\PMPS\FB_EncErrorFFO.TcPOU">
@@ -690,6 +708,10 @@
       <DefaultResolution>Tc2_MC2, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc2_MC2</Namespace>
     </PlaceholderReference>
+    <PlaceholderReference Include="Tc2_SerialCom">
+      <DefaultResolution>Tc2_SerialCom, * (Beckhoff Automation GmbH)</DefaultResolution>
+      <Namespace>Tc2_SerialCom</Namespace>
+    </PlaceholderReference>
     <PlaceholderReference Include="Tc2_Standard">
       <DefaultResolution>Tc2_Standard, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc2_Standard</Namespace>
@@ -729,8 +751,8 @@
   <ProjectExtensions>
     <PlcProjectOptions>
       <XmlArchive>
-  <Data>
-    <o xml:space="preserve" t="OptionKey">
+        <Data>
+          <o xml:space="preserve" t="OptionKey">
       <v n="Name">"&lt;ProjectRoot&gt;"</v>
       <d n="SubKeys" t="Hashtable" ckt="String" cvt="OptionKey">
         <v>{192FAD59-8248-4824-A8DE-9177C94C195A}</v>
@@ -797,14 +819,14 @@
       </d>
       <d n="Values" t="Hashtable" />
     </o>
-  </Data>
-  <TypeList>
-    <Type n="Boolean">System.Boolean</Type>
-    <Type n="Hashtable">System.Collections.Hashtable</Type>
-    <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
-    <Type n="String">System.String</Type>
-  </TypeList>
-</XmlArchive>
+        </Data>
+        <TypeList>
+          <Type n="Boolean">System.Boolean</Type>
+          <Type n="Hashtable">System.Collections.Hashtable</Type>
+          <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
+          <Type n="String">System.String</Type>
+        </TypeList>
+      </XmlArchive>
     </PlcProjectOptions>
   </ProjectExtensions>
   <!-- 

--- a/lcls-twincat-motion/Library/POUs/Motion/LVDT/MacroSensors/FB_LVC4000Com.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/LVDT/MacroSensors/FB_LVC4000Com.TcPOU
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4018.5">
+  <POU Name="FB_LVC4000Com" Id="{0781e15c-c75f-440a-a77c-ba1b843f5b88}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_LVC4000Com
+(*
+A. Wallace 2016-7-20
+
+This FB is used for communicating with the LVC-4000 LVDT signal conditioners on
+RS-485. It is set up for multiple conditioners on one interface.
+
+Usage:
+Pass the array of your LVC4000 structures to the FB, along with your serial RX and TX buffers.
+Also pass the number of LVC-4000 connected to the bus. This must be less than gcMaxLVC4000.
+
+*)
+VAR_IN_OUT
+    iq_astLVC4000: ARRAY[1..gcMaxLVC4000] OF ST_SerLVC4000;
+    afbLVC4000SerialDriver: ARRAY[1..gcMaxLVC4000] OF FB_LVC4000SerialDriver;
+    SerialRXBuffer: ComBuffer;
+    SerialTXBuffer: ComBuffer;
+END_VAR
+VAR_INPUT
+    i_iQty	:	INT := 0;
+END_VAR
+VAR
+    iUnit: INT := 1;
+    tTimeOut: TIME := TIME#1s0ms;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[(* This program is called from Serial PTM IO *)
+
+i_iQty := MIN(i_iQty, gcMaxLVC4000);
+
+(* scan the units one at a time *)
+afbLVC4000SerialDriver[iUnit](
+    i_xExecute:= TRUE,
+    i_tTimeOut:= tTimeOut,
+    iq_stLVC4000:=iq_astLVC4000[iUnit] ,
+    iq_stSerialRXBuffer:= SerialRXBuffer,
+    iq_stSerialTXBuffer:=  SerialTXBuffer,
+    );
+
+IF afbLVC4000SerialDriver[iUnit].q_xDone
+OR afbLVC4000SerialDriver[iUnit].q_xError
+THEN
+        (* reset for next time *)
+        afbLVC4000SerialDriver[iUnit]( i_xExecute:= FALSE, iq_stLVC4000:=iq_astLVC4000[iUnit], iq_stSerialRXBuffer:= SerialRXBuffer, iq_stSerialTXBuffer:=  SerialTXBuffer);
+        (* select next pump *)
+        iUnit := iUnit + 1;
+        IF iUnit > i_iQty THEN
+            iUnit:= 1;
+        END_IF
+END_IF]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/LVDT/MacroSensors/FB_LVC4000SerialDriver.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/LVDT/MacroSensors/FB_LVC4000SerialDriver.TcPOU
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4018.5">
+  <POU Name="FB_LVC4000SerialDriver" Id="{ae4b86c1-3ea8-4881-a7dc-2dd9995b4e63}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_LVC4000SerialDriver
+VAR_INPUT
+    /// rising edge execute
+    i_xExecute: BOOL;
+    /// Maximum wait time for reply
+    i_tTimeOut: TIME := TIME#1s0ms;
+END_VAR
+VAR_OUTPUT
+    q_xDone: BOOL;
+    q_xError: BOOL;
+    q_xTimeout: BOOL;
+    q_sResult: STRING(255);
+    /// Last String Sent to Serial Device - for debugging
+    q_sLastSentString: STRING;
+    /// Last String Received from Serial Device - for debugging
+    q_sLastReceivedString: STRING;
+END_VAR
+VAR_IN_OUT
+    iq_stLVC4000	:	ST_SerLVC4000;
+    iq_stSerialRXBuffer: ComBuffer;
+    iq_stSerialTXBuffer: ComBuffer;
+END_VAR
+VAR
+    rtExecute: R_TRIG;
+    iStep: INT;
+    sCmd	:	STRING;
+    sSendData : STRING;
+    fbTrans: FB_LVC4000Transaction;
+    fbFormatString: FB_FormatString;
+    sErrMesg : STRING := 'In step %d fbtrans failed with message: %s';
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[(* This function block performs serial transactions with an LVC 4000 LVDT Signal Conditioner *)
+
+(* rising edge trigger *)
+rtExecute(CLK:= i_xExecute);
+IF rtExecute.Q  THEN
+    q_xDone	:= FALSE;
+    q_xError := FALSE;
+    q_sResult:= '';
+    a_ClearTrans();  (* to provide rising edge for execute *)
+    iStep := 10;
+END_IF
+
+
+CASE iStep OF
+    0: (* idle *)
+        ;
+
+    (* Get output *)
+    10:
+        sCmd := 'getOut';
+        fbtrans.i_xExecute := TRUE;
+        IF fbtrans.q_xDone THEN
+            iq_stLVC4000.i_iOut := STRING_TO_INT(fbtrans.q_sResponseData);
+            iStep := 8000;
+            a_ClearTrans();
+        ELSIF fbtrans.q_xError THEN
+            a_ErrorMesg();
+            iStep := 9000;
+            a_ClearTrans();
+        END_IF
+
+    8000: (* done *)
+        q_xDone := TRUE;
+        IF  i_xExecute = FALSE THEN
+            q_xDone:= FALSE;
+            iStep := 0;
+        END_IF
+
+    9000:
+        q_xError := TRUE;
+
+END_CASE
+
+//call transaction
+fbTrans(
+    i_iAddress:= iq_stLVC4000.iAddr,
+    i_tTimeOut:= i_tTimeOut,
+    i_sCmd:=sCmd,
+    i_sParam:=sSendData,
+    iq_stSerialRXBuffer:= iq_stSerialRXBuffer,
+    iq_stSerialTXBuffer:= iq_stSerialTXBuffer );
+
+iq_stLVC4000.xTimeout := fbtrans.q_xTimeout;
+q_sLastSentString := fbtrans.q_sLastSentString;
+q_sLastReceivedString := fbtrans.q_sLastReceivedString;]]></ST>
+    </Implementation>
+    <Action Name="a_ErrorMesg" Id="{b3a6f4e0-9fb2-41d0-94af-43ceed0c99de}">
+      <Implementation>
+        <ST><![CDATA[fbFormatString( sformat:=sErrMesg,
+    arg1:=F_INT(iStep),
+    arg2:=F_STRING(fbtrans.q_sResult),
+    sOut => q_sResult);]]></ST>
+      </Implementation>
+    </Action>
+    <Action Name="a_ClearTrans" Id="{cbc46b91-bc1a-4d15-840f-cb6f0aaaf34d}">
+      <Implementation>
+        <ST><![CDATA[(* Refactor this action to match your transaction *)
+fbtrans.i_xExecute := TRUE;
+fbtrans.i_sCmd:= '';
+fbtrans.i_sParam := '';
+fbTrans(
+    i_iAddress:= iq_stLVC4000.iAddr,
+    i_tTimeOut:= i_tTimeOut,
+    iq_stSerialRXBuffer:= iq_stSerialRXBuffer,
+    iq_stSerialTXBuffer:= iq_stSerialTXBuffer );
+fbtrans.i_xExecute := FALSE;
+fbTrans(
+    i_iAddress:= iq_stLVC4000.iAddr,
+    i_tTimeOut:= i_tTimeOut,
+    iq_stSerialRXBuffer:= iq_stSerialRXBuffer,
+    iq_stSerialTXBuffer:= iq_stSerialTXBuffer );]]></ST>
+      </Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/LVDT/MacroSensors/FB_LVC4000Transaction.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/LVDT/MacroSensors/FB_LVC4000Transaction.TcPOU
@@ -1,0 +1,154 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="FB_LVC4000Transaction" Id="{7f68d6c9-2d15-48e7-9147-99c051549076}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_LVC4000Transaction
+VAR_INPUT
+    /// rising edge execute
+    i_xExecute: BOOL;
+    /// RS-485 Address of LVC 4000
+    i_iAddress: INT;
+    /// Maximum wait time for reply
+    i_tTimeOut: TIME := TIME#1s0ms;
+    // Command field
+    i_sCmd: T_MAXSTRING;
+    // Parameter field
+    i_sParam: T_MAXSTRING;
+END_VAR
+VAR_OUTPUT
+    q_xDone: BOOL;
+    q_sResponseData: STRING;
+    q_xError: BOOL;
+    q_xTimeout: BOOL;
+    q_sResult: T_MAXSTRING;
+    /// Last String Sent to Serial Device - for debugging
+    q_sLastSentString: STRING;
+    /// Last String Received from Serial Device - for debugging
+    q_sLastReceivedString: STRING;
+END_VAR
+VAR_IN_OUT
+    iq_stSerialRXBuffer: ComBuffer;
+    iq_stSerialTXBuffer: ComBuffer;
+END_VAR
+VAR
+    rtExecute: R_TRIG;
+    iStep: INT;
+    fbClearComBuffer: ClearComBuffer;
+    sSendString: STRING;
+    fbFormatString: FB_FormatString;
+    iChecksum: INT;
+    fbSendString: SendString;
+    fbReceiveString: ReceiveString;
+    sReceivedString: STRING;
+    tonTimeout: TON;
+    sRXStringForChecksum: STRING;
+    sReceiveStringWOChecksum: STRING;
+    sRXCheckSum: STRING;
+    sRXAddress: STRING;
+    sRXParmNum: STRING;
+    CarRtn : BYTE :=16#0D;
+    rAddress: REAL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[(* This function block performs serial transactions with an LVC 4000 LVDT Signal Conditioner *)
+
+(* rising edge trigger *)
+rtExecute(CLK:= i_xExecute);
+IF rtExecute.Q THEN
+    q_xDone	:= FALSE;
+    q_sResponseData := '';
+    q_xError := FALSE;
+    //q_xTimeout := FALSE;
+    q_sResult:= '';
+    q_sLastSentString := '';
+    q_sLastReceivedString:= '';
+    iStep := 10;
+END_IF
+
+CASE iStep OF
+    0:
+        ; (* idle *)
+
+    10: (* clear com buffers *)
+        fbClearComBuffer(Buffer:= iq_stSerialRXBuffer);
+        fbClearComBuffer(Buffer:= iq_stSerialTXBuffer);
+        rAddress := INT_TO_REAL(i_iAddress);
+        (* build the send string *)
+        IF i_sParam = '' THEN
+            fbFormatString( sFormat:= ':%02.0f %s $R',
+                arg1:= F_REAL(rAddress),
+                arg2:= F_STRING(i_sCmd),
+                sOut=> sSendString);
+        ELSE
+            fbFormatString( sFormat:= ':%02.0f %s %s $R',
+            arg1:= F_REAL(rAddress),
+            arg2:= F_STRING(i_sCmd),
+            arg3:= F_STRING(i_sParam),
+            sOut=> sSendString);
+        END_IF
+        (* send it *)
+        fbSendString( SendString:= sSendString, TXbuffer:= iq_stSerialTXBuffer );
+        q_sLastSentString := sSendString;
+        iStep := iStep + 10;
+
+    20: (* Finish sending the String *)
+        IF fbSendString.Busy THEN
+            fbSendString( SendString:= sSendString, TXbuffer:= iq_stSerialTXBuffer );
+        ELSIF fbSendString.Error <> 0 THEN
+            q_sResult := CONCAT('In step 20 fbSendString resulted in error: ', INT_TO_STRING(fbSendString.Error));
+            iStep := 9000;
+        ELSIF NOT fbSendString.Busy THEN
+            IF i_sCmd = 'getOut' THEN
+            iStep := iStep + 10;
+            ELSE
+            iStep := 100; //no response?
+            END_IF
+        END_IF
+        (* Reset receive *)
+        fbReceiveString(
+            Reset:= TRUE,
+            ReceivedString:= sReceivedString,
+            RXbuffer:= iq_stSerialRXBuffer );
+        tonTimeout(IN:= FALSE);
+
+    30: (* Get reply *)
+        fbReceiveString(
+            Prefix:= ,
+            Suffix:= '$R',
+            Timeout:= i_tTimeOut,
+            Reset:= FALSE,
+            ReceivedString:= sReceivedString,
+            RXbuffer:= iq_stSerialRXBuffer );
+        tonTimeout(IN:= TRUE, PT:= i_tTimeOut);
+        IF fbReceiveString.Error <> 0 AND fbReceiveString.Error <> 16#1008 THEN //16#1008 is timeout error
+            q_sResult := CONCAT('In step 30 fbReceiveString resulted in error: ', INT_TO_STRING(fbReceiveString.Error));
+            iStep := 9000;
+        ELSIF fbReceiveString.RxTimeout OR tonTimeout.Q THEN
+            q_sResult := 'Device failed to reply within timeout period';
+            q_xTimeout := TRUE;
+            iStep := 9000;
+        ELSIF fbReceiveString.StringReceived THEN
+            q_xTimeout := FALSE; //no timeout
+            q_sLastReceivedString := sReceivedString;
+            q_sResponseData := sReceivedString;
+            q_sResult := 'Success.';
+            q_xDone:= TRUE;
+            iStep := 100;
+        END_IF
+
+    100: (* done *)
+        IF  i_xExecute = FALSE THEN
+            q_xDone:= FALSE;
+            iStep := 0;
+        END_IF
+
+    9000:
+        q_xError := TRUE;
+
+
+
+
+END_CASE]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
4026 Migration: Move the LVDT part  of the Vacuum Library to the motion library
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Upgrade the architecture for the vacuum Library. The LVDT part of the vacuum Library handles motion feedback. For the 4026 Migration and uniformity, it was agreed to move that section to the motion library.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The LVDT device used in the vacuum subsystems is the Serial device, thus it will require communication with real hardware for unittesting.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
No modification was made to the imported code.
## Pre-merge checklist
- [ ] Code works interactively
- [ ] Test suite passes locally
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
