### PR TITLE
Reduce FFO fatigue and simplify commissioning state positioners through single boolean ffo off using maintenance mode

### DIFF
--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MiscStatesErrorFFO.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MiscStatesErrorFFO.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1">
   <POU Name="FB_MiscStatesErrorFFO" Id="{89bc15f3-9d13-41da-a444-416428941e28}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_MiscStatesErrorFFO
 (*
@@ -28,6 +28,8 @@ VAR_INPUT
     bKnownState: BOOL;
     // Lookup ID of the transition beam
     nTransitionID: DWORD;
+    // Set me true to prevent any ffos from occuring
+    bMaintenanceMode : BOOL;
 END_VAR
 VAR_OUTPUT
 END_VAR
@@ -60,7 +62,7 @@ END_VAR
     <Implementation>
       <ST><![CDATA[
 ffBeamParamsOk(
-    i_xOK:=F_SafeBPCompare(PMPS_GVL.stCurrentBeamParameters, stCurrentBeamReq),
+    i_xOK:=F_SafeBPCompare(PMPS_GVL.stCurrentBeamParameters, stCurrentBeamReq) OR bMaintenanceMode,
     i_xAutoReset:=TRUE,
     i_DevName:=sDeviceName,
     i_Desc:='Beam parameter mismatch',
@@ -77,6 +79,8 @@ ELSE
     ffZeroRate.i_xOK := stCurrentBeamReq.nRate > 0 AND stCurrentBeamReq.nBCRange > 0;
 END_CASE
 
+ffZeroRate.i_xOK := ffZeroRate.i_xOK OR bMaintenanceMode;
+
 ffZeroRate(
     i_xAutoReset := TRUE,
     i_DevName := sDeviceName,
@@ -86,7 +90,7 @@ ffZeroRate(
 );
 
 ffUnknown(
-    i_xOK := bknownState OR fbArbiter.CheckRequestInPool(nReqID:=nTransitionID),
+    i_xOK := bknownState OR fbArbiter.CheckRequestInPool(nReqID:=nTransitionID) OR bMaintenanceMode,
     i_xAutoReset := TRUE,
     i_DevName := sDeviceName,
     i_Desc := 'Unknown position between moves',
@@ -111,7 +115,7 @@ END_IF
 // This is required for non-autoresetting FBs to come up in a beam permitted state
 ffDebounce.i_xReset := bFirstCycle OR nTripCount=0;
 ffDebounce(
-    i_xOK := nTripCount < 5,
+    i_xOK := nTripCount < 5 OR bMaintenanceMode,
     i_DevName := sDeviceName,
     i_Desc := 'Tripped beam parameter mismatch off/on too many times, hold off',
     i_TypeCode := E_MotionFFType.TOO_MANY_TRIPS,
@@ -119,5 +123,12 @@ ffDebounce(
 );
 bFirstCycle := FALSE;]]></ST>
     </Implementation>
+    <LineIds Name="FB_MiscStatesErrorFFO">
+      <LineId Id="3" Count="17" />
+      <LineId Id="63" Count="0" />
+      <LineId Id="62" Count="0" />
+      <LineId Id="21" Count="40" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MotionBPTM.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_MotionBPTM.TcPOU
@@ -96,7 +96,7 @@ bTransitionAuthorized := bInternalAuth OR (bArbiterTimeout AND bMoveOnArbiterTim
 
 // Trip the beam for BPTM timeouts if we want to move
 // Only reset at safe beam OR at no bptm errors (some other FF should catch additional issues)
-ffBPTMTimeoutAndMove.i_xOK := NOT (bArbiterTimeout AND bMoveOnArbiterTimeout AND bEnable);
+ffBPTMTimeoutAndMove.i_xOK := NOT (bArbiterTimeout AND bMoveOnArbiterTimeout) OR (NOT THIS^.bEnable);
 ffBPTMTimeoutAndMove.i_xReset S= bResetBPTMTimeout OR (bptm.bDone AND NOT bptm.bError);
 ffBPTMTimeoutAndMove.i_xReset R= NOT ffBPTMTimeoutAndMove.i_xOK;
 ffBPTMTimeoutAndMove.i_xReset := ffBPTMTimeoutAndMove.i_xReset OR NOT bEnable;
@@ -127,7 +127,7 @@ bptm(
 );
 
 // Trip the beam for BPTM Errors
-ffBPTMError.i_xOK := NOT bptm.bError;
+ffBPTMError.i_xOK := (NOT bptm.bError) OR NOT THIS^.bEnable;
 ffBPTMError.i_xReset S= bptm.bDone AND ffBPTMError.i_xOK;
 ffBPTMError.i_xReset R= NOT ffBPTMError.i_xOK;
 ffBPTMError(
@@ -157,5 +157,25 @@ nPrevID := stGoalParams.nRequestAssertionID;
 ]]></ST>
       </Implementation>
     </Action>
+    <LineIds Name="FB_MotionBPTM">
+      <LineId Id="3" Count="8" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MotionBPTM.CheckCount">
+      <LineId Id="2" Count="3" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MotionBPTM.HandleTimeout">
+      <LineId Id="2" Count="20" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MotionBPTM.RunBPTM">
+      <LineId Id="2" Count="24" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_MotionBPTM.SetDoneMoving">
+      <LineId Id="2" Count="12" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PerMotorFFOND.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PerMotorFFOND.TcPOU
@@ -21,6 +21,8 @@ VAR_INPUT
     nActiveMotorCount: UINT;
     // Identifying name to use in group fast faults
     sDeviceName: STRING;
+    // Set me true to prevent any ffos from faulting
+    bMaintenanceMode : BOOL;
 END_VAR
 VAR_OUTPUT
     // Set to TRUE if the arrays don't have the same bounds. In this FB, that's an automatic fault.
@@ -54,7 +56,7 @@ bMotorCountError S= nActiveMotorCount > MotionConstants.MAX_STATE_MOTORS;
       <Implementation>
         <ST><![CDATA[
 ffProgrammerError(
-    i_xOK:=NOT bMotorCountError,
+    i_xOK:=NOT bMotorCountError OR THIS^.bMaintenanceMode,
     i_xAutoReset:=TRUE,
     i_DevName:=sDeviceName,
     i_Desc:='Programmer error picking motor count',
@@ -77,5 +79,21 @@ END_FOR
 ]]></ST>
       </Implementation>
     </Action>
+    <LineIds Name="FB_PerMotorFFOND">
+      <LineId Id="3" Count="5" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_PerMotorFFOND.CheckCount">
+      <LineId Id="2" Count="3" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_PerMotorFFOND.HandleFFO">
+      <LineId Id="2" Count="8" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_PerMotorFFOND.HandleLoops">
+      <LineId Id="2" Count="7" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPSND_Core.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_PositionStatePMPSND_Core.TcPOU
@@ -86,7 +86,7 @@ fbMotionReadPMPSDB(
     bError=>,
 );
 
-bEnable := stPMPSEpicsToPlc.bArbiterEnabled AND bEnableBeamParams;
+bEnable := (stPMPSEpicsToPlc.bArbiterEnabled AND bEnableBeamParams) OR (NOT stPMPSEpicsToPlc.bMaintMode);
 rtEnable(CLK:=bEnable);
 fbMotionBPTM(
     astMotionStage:=astMotionStageMax,
@@ -142,6 +142,7 @@ fbMiscStatesErrorFFO(
     sDeviceName:=sDeviceName,
     bKnownState:=stPlcToEpics.nGetValue > 0,
     nTransitionID:=fbMotionReadPMPSDB.astDbStateParams[0].nRequestAssertionID,
+    bMaintenanceMode:=stPMPSEpicsToPlc.bMaintMode
 );
 
 fbPerMotorFFO(
@@ -149,11 +150,20 @@ fbPerMotorFFO(
     fbFFHWO:=fbFFHWO,
     nActiveMotorCount:=nActiveMotorCount,
     sDeviceName:=sDeviceName,
+    bMaintenanceMode:=stPMPSEpicsToPlc.bMaintMode,
     bMotorCountError=>,
 );
 
 stPMPSPlcToEpics.stTransitionDb := fbMotionReadPMPSDB.astDbStateParams[0];
 stDbStateParams := fbMotionReadPMPSDB.astDbStateParams[stPlcToEpics.nGetValue];]]></ST>
     </Implementation>
+    <LineIds Name="FB_PositionStatePMPSND_Core">
+      <LineId Id="3" Count="76" />
+      <LineId Id="91" Count="0" />
+      <LineId Id="80" Count="6" />
+      <LineId Id="92" Count="0" />
+      <LineId Id="87" Count="3" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_StatePMPSEnables.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_StatePMPSEnables.TcPOU
@@ -123,7 +123,7 @@ END_IF]]></ST>
       <Implementation>
         <ST><![CDATA[
 ffNoGoal(
-    i_xOK:=bValidGoal,
+    i_xOK:=bValidGoal OR NOT THIS^.bEnable,
     i_xAutoReset:=TRUE,
     i_DevName:=stMotionStage.sName,
     i_Desc:='Invalid goal position in state move',
@@ -161,5 +161,25 @@ END_IF
 ]]></ST>
       </Implementation>
     </Action>
+    <LineIds Name="FB_StatePMPSEnables">
+      <LineId Id="3" Count="4" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_StatePMPSEnables.ApplyEnables">
+      <LineId Id="2" Count="31" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_StatePMPSEnables.GetBounds">
+      <LineId Id="2" Count="18" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_StatePMPSEnables.RunFastFaults">
+      <LineId Id="2" Count="8" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_StatePMPSEnables.SetEnables">
+      <LineId Id="2" Count="22" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_StatePMPSEnablesND.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/PMPS/FB_StatePMPSEnablesND.TcPOU
@@ -104,7 +104,7 @@ ffMaint(
 );
 
 ffProgrammerError(
-    i_xOK:=NOT bMotorCountError,
+    i_xOK:=(NOT bMotorCountError) OR THIS^.bMaintMode,
     i_xAutoReset:=TRUE,
     i_DevName:=sDeviceName,
     i_Desc:='Programmer error picking motor count',
@@ -113,5 +113,21 @@ ffProgrammerError(
 );]]></ST>
       </Implementation>
     </Action>
+    <LineIds Name="FB_StatePMPSEnablesND">
+      <LineId Id="3" Count="5" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_StatePMPSEnablesND.CheckCount">
+      <LineId Id="2" Count="3" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_StatePMPSEnablesND.DoLimits">
+      <LineId Id="2" Count="14" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_StatePMPSEnablesND.RunFastFaults">
+      <LineId Id="2" Count="16" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
- I am making this PR to intentionally start debate on this topic.

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

- I am proposing this change in order to simplify the user experience during commissioning.
- The proposal is for Arbiter enable/disable to still do the same thing except turning a pmps state positioner into maintenance mode would now make only one ffo occur, and that is an ffo to state you are in maintenance mode. All other ffos in the pmps state positioner would be blocked.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- I argue that the system as is too confusing from the user perspective. Even as SME, I can never remember what the maintenance mode and arbiter enable/disable are supposed to do. This change would simplify the user experience. I argue that we will have a better user experience if they can just take the system under maintenance level control from one boolean.
- Additionally, users already seem to expect this behavior anyways.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- This change has not yet been tested. I propose we debate the merits first before committing to implementing and testing the changes.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Test suite passes locally
- [ ] Code contains descriptive comments
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
