### PR TITLE
Replace E_DS402OpMode with E_MCS2OpMode and fix bParamsSet latch

### DIFF
--- a/lcls-twincat-motion/Library/DUTs/DS402/E_MCS2OpMode.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DS402/E_MCS2OpMode.TcDUT
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
-  <DUT Name="E_DS402OpMode" Id="{6b34f554-8c74-4ff3-b4ed-290b296a94b3}">
+  <DUT Name="E_MCS2OpMode" Id="{6b34f554-8c74-4ff3-b4ed-290b296a94b3}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 {attribute 'strict'}
 {attribute 'to_string'}
-TYPE E_DS402OpMode :
+TYPE E_MCS2OpMode :
 (
     NONE := 0,
     // P-T-P target profil
@@ -17,8 +17,8 @@ TYPE E_DS402OpMode :
     CST := 10,
     CSTCA := 11,
     // smartAct MCS2 open loop
-    MCS2_CALIBRATION:=-1,
-    MCS2_OL_STEP_MODE:=-4
+    CALIBRATE :=-1,
+    STEP :=-4
 ) SINT;
 END_TYPE
 ]]></Declaration>

--- a/lcls-twincat-motion/Library/DUTs/DS402/ST_DS402Drive.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DS402/ST_DS402Drive.TcDUT
@@ -5,6 +5,11 @@
 STRUCT
     (* Global variables for the TPDO data from the drive. Each one is linked to the respective TPDO channel. *)
     stDriveStatus 			AT %I*	: 	ST_DS402DriveStatus;
+    {attribute 'pytmc' := '
+        pv: eOpModeDisplay
+        io: i
+        field: DESC MCS2 current operating mode
+    '}
     nModeOfOperationDisplay AT %I*	: 	SINT;
     //nActualPosition 		AT %I*	: 	DINT;
     (*CSP drive mode*)

--- a/lcls-twincat-motion/Library/DUTs/DS402/ST_MCS2ChanParameter.TcDUT
+++ b/lcls-twincat-motion/Library/DUTs/DS402/ST_MCS2ChanParameter.TcDUT
@@ -131,12 +131,12 @@ STRUCT
     '}
     bCalibrationCmd : BOOL;
 
+    // Desired drive operating mode (source of truth). Default is closed-loop (CSP) absolute motion.
     {attribute 'pytmc' := '
         pv: eOpModeReq
-        io: io
+        io: o
         field: DESC DS402 operation mode request (default closed loop)
     '}
-    // Desired drive operating mode (source of truth). Default is closed-loop (CSP) absolute motion.
     eOpModeReq : E_MCS2OpModeReq := E_MCS2OpModeReq.CLOSED_LOOP;
 
     {attribute 'pytmc' := '
@@ -145,6 +145,7 @@ STRUCT
         field: DESC Channel configuration parameters.
     '}
     stChannelState        : ST_ChannelState;
+
     {attribute 'pytmc' := '
         pv: eHomeMode
         io: i

--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -16,7 +16,7 @@
     <LibraryReferences>{267a1a0a-101b-42eb-a25b-883e4b1e0514}</LibraryReferences>
     <CombineIds>false</CombineIds>
     <Company>SLAC</Company>
-    <Released>true</Released>
+    <Released>false</Released>
     <Title>lcls-twincat-motion</Title>
     <ProjectVersion>4.5.1</ProjectVersion>
     <WriteProductVersion>false</WriteProductVersion>
@@ -119,7 +119,7 @@
     <Compile Include="DUTs\DS402\E_MCS2HomeMethod.TcDUT">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="DUTs\DS402\E_DS402OpMode.TcDUT">
+    <Compile Include="DUTs\DS402\E_MCS2OpMode.TcDUT">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="DUTs\DS402\E_MCS2OpModeReq.TcDUT">

--- a/lcls-twincat-motion/Library/Library.plcproj
+++ b/lcls-twincat-motion/Library/Library.plcproj
@@ -16,9 +16,9 @@
     <LibraryReferences>{267a1a0a-101b-42eb-a25b-883e4b1e0514}</LibraryReferences>
     <CombineIds>false</CombineIds>
     <Company>SLAC</Company>
-    <Released>false</Released>
+    <Released>true</Released>
     <Title>lcls-twincat-motion</Title>
-    <ProjectVersion>0.0.0</ProjectVersion>
+    <ProjectVersion>4.5.1</ProjectVersion>
     <WriteProductVersion>false</WriteProductVersion>
     <POUsForPropertyAccessIncluded>false</POUsForPropertyAccessIncluded>
     <GlobalVersionStructureIncluded>false</GlobalVersionStructureIncluded>

--- a/lcls-twincat-motion/Library/POUs/Motion/DS402/MCS2/FB_MCS2DriveManager.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/DS402/MCS2/FB_MCS2DriveManager.TcPOU
@@ -23,6 +23,7 @@ VAR_OUTPUT
     bHomeModeEnabled : BOOL;
     bStepModeEnabled : BOOL;
     bCalibrationModeEnabled : BOOL;
+    eRequestedManualMode : E_MCS2OpMode := E_MCS2OpMode.CSP;
 END_VAR
 
 VAR
@@ -31,7 +32,6 @@ VAR
     tonStartupStep : TON;
     bFaultLast : BOOL := FALSE;
     ftFaultClear : F_TRIG;
-    eRequestedManualMode : E_DS402OpMode := E_DS402OpMode.CSP;
     bPendingManualModeSwitch : BOOL := FALSE;
     // Previous PV value, used to detect a mode-request change
     eLastModeReq : E_MCS2OpModeReq := E_MCS2OpModeReq.CLOSED_LOOP;
@@ -75,7 +75,7 @@ END_IF
 bFaultLast := bFault;
 
 // Status flag for manual operation mode (not CSP)
-bDS402Manual := (stDS402Drive.nModeOfOperationDisplay <> E_DS402OpMode.CSP);
+bDS402Manual := (stDS402Drive.nModeOfOperationDisplay <> E_MCS2OpMode.CSP);
 
 // DS402 startup sequence at boot or after fault (until operational)
 IF bStartupActive AND bDS402Manual THEN
@@ -132,13 +132,13 @@ ELSE
 
     IF bOperational THEN
         CASE stDS402Drive.nModeOfOperationDisplay OF
-            E_DS402OpMode.CSP:
+            E_MCS2OpMode.CSP:
                 bCSPModeEnabled := TRUE;
-            E_DS402OpMode.HOME:
+            E_MCS2OpMode.HOME:
                 bHomeModeEnabled := TRUE;
-            E_DS402OpMode.MCS2_OL_STEP_MODE:
+            E_MCS2OpMode.STEP:
                 bStepModeEnabled := TRUE;
-            E_DS402OpMode.MCS2_CALIBRATION:
+            E_MCS2OpMode.CALIBRATE:
                 bCalibrationModeEnabled := TRUE;
         END_CASE
     END_IF
@@ -163,14 +163,14 @@ ELSE
     // Map the requested mode (PV) onto the DS402 operation mode
     CASE stMCS2ChanParameter.eOpModeReq OF
         E_MCS2OpModeReq.STEP:
-            eRequestedManualMode := E_DS402OpMode.MCS2_OL_STEP_MODE;
+            eRequestedManualMode := E_MCS2OpMode.STEP;
         E_MCS2OpModeReq.HOME:
-            eRequestedManualMode := E_DS402OpMode.HOME;
+            eRequestedManualMode := E_MCS2OpMode.HOME;
         E_MCS2OpModeReq.CALIBRATION:
-            eRequestedManualMode := E_DS402OpMode.MCS2_CALIBRATION;
+            eRequestedManualMode := E_MCS2OpMode.CALIBRATE;
         ELSE
             // CLOSED_LOOP (default) and any unexpected value map to CSP closed-loop motion
-            eRequestedManualMode := E_DS402OpMode.CSP;
+            eRequestedManualMode := E_MCS2OpMode.CSP;
     END_CASE
 
     // Detect a change in the requested mode (PV write, from the user or a motion request)
@@ -193,8 +193,8 @@ ELSE
                 bManualTransition := FALSE;
             END_IF
         ELSE
-            IF eRequestedManualMode = E_DS402OpMode.CSP THEN
-                stDS402Drive.nModeOfOperation := E_DS402OpMode.CSP;
+            IF eRequestedManualMode = E_MCS2OpMode.CSP THEN
+                stDS402Drive.nModeOfOperation := E_MCS2OpMode.CSP;
                 bPendingManualModeSwitch := FALSE;
             ELSE
                 stDS402Drive.nDriveControl.4 := FALSE;

--- a/lcls-twincat-motion/Library/POUs/Motion/DS402/MCS2/FB_MotionStageMCS2.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/DS402/MCS2/FB_MotionStageMCS2.TcPOU
@@ -110,11 +110,15 @@ VAR
     {attribute 'hide'}
     rtStepCmdShortcut		 : R_TRIG;
     {attribute 'hide'}
-    rtCalibrateCmdShortcut: R_TRIG;
-    tSDOOpsTimer : TON;
-    bParamsEnable: BOOL;
-    bDelayReadAtInit : BOOL;
+    rtCalibrateCmdShortcut	 : R_TRIG;
+    {attribute 'hide'}
+    tSDOOpsTimer 			 : TON;
+    {attribute 'hide'}
+    bParamsEnable			 : BOOL;
+    {attribute 'hide'}
+    bDelayReadAtInit 		 : BOOL;
     bBaseExec: BOOL;
+    nCommandLocal  			 : E_MCS2OpMode := E_MCS2OpMode.CSP;
 END_VAR
 
 VAR CONSTANT
@@ -171,7 +175,6 @@ VAR CONSTANT
 END_VAR
 
 VAR PERSISTENT
-    nCommandLocal            : INT := E_EpicsMotorCmd.MOVE_ABSOLUTE;
     bSaved                   : BOOL;
     fSavedPosition           : LREAL;
 END_VAR]]></Declaration>
@@ -242,7 +245,7 @@ bNewMoveReq R= NOT stMotionStage.bExecute OR stMotionStage.bError;
 bPrepareDisable R= bNewMoveReq;
 
 IF rtUserExec.Q THEN
-    nCommandLocal := stMotionStage.nCommand;
+    //nCommandLocal := stMotionStage.nCommand;
     // Cover direct bExecute path, shortcut path already set bEnPosLag/fParameterValue
     IF NOT rtMoveCmdShortcut.Q
         AND NOT rtStepCmdShortcut.Q
@@ -266,7 +269,8 @@ fbDriveManager(
     stMotionStage        := stMotionStage,
     stDS402Drive         := stDS402Drive,
     stMCS2ChanParameter  := stChanParams,
-    bUserExec            := rtUserExec.Q
+    bUserExec            := rtUserExec.Q,
+    eRequestedManualMode => nCommandLocal
 );
 
 // Enable mode handling
@@ -301,32 +305,32 @@ IF fbDriveManager.bCSPModeEnabled THEN
     // Close loop: gate on NC standstill state (bEnableDone)
     bLocalExec := bBaseExec
                   AND stMotionStage.bEnableDone
-                  AND nCommandLocal = E_EpicsMotorCmd.MOVE_ABSOLUTE;
+                  AND stMotionStage.nCommand = E_EpicsMotorCmd.MOVE_ABSOLUTE;
 
 ELSIF fbDriveManager.bHomeModeEnabled THEN
     // Open loop homing: gate on DS402 operational state
     bLocalExec := bBaseExec
                   AND fbDriveManager.bOperational
-                  AND nCommandLocal = E_EpicsMotorCmd.HOME;
+                  AND stMotionStage.nCommand = E_EpicsMotorCmd.HOME;
 
 ELSIF fbDriveManager.bStepModeEnabled THEN
     // Open loop step: gate on DS402 operational state
     bLocalExec := bBaseExec
                   AND fbDriveManager.bOperational
-                  AND nCommandLocal = E_EpicsMotorCmd.JOG;
+                  AND stMotionStage.nCommand = E_EpicsMotorCmd.JOG;
 
 ELSIF fbDriveManager.bCalibrationModeEnabled THEN
     // Open loop calibration: gate on DS402 operational state
     bLocalExec := bBaseExec
                   AND fbDriveManager.bOperational
-                  AND nCommandLocal = E_EpicsMotorCmd.CALIBRATE;
+                  AND stMotionStage.nCommand = E_EpicsMotorCmd.CALIBRATE;
 ELSE
     bLocalExec := FALSE;
 END_IF
 
-bExecMove := bLocalExec AND ((nCommandLocal = E_EpicsMotorCmd.MOVE_ABSOLUTE)
-                          OR  (nCommandLocal = E_EpicsMotorCmd.JOG)
-                          OR  (nCommandLocal = E_EpicsMotorCmd.CALIBRATE));
+bExecMove := bLocalExec AND ((stMotionStage.nCommand = E_EpicsMotorCmd.MOVE_ABSOLUTE)
+                          OR  (stMotionStage.nCommand = E_EpicsMotorCmd.JOG)
+                          OR  (stMotionStage.nCommand = E_EpicsMotorCmd.CALIBRATE));
 bExecHome := bLocalExec AND NOT bExecMove;
 
 rtExec(CLK := bLocalExec);
@@ -391,7 +395,7 @@ fbWriteParameters(
 );
 
 CASE nCommandLocal OF
-    E_EpicsMotorCmd.MOVE_ABSOLUTE:
+    E_MCS2OpMode.CSP:
         Reset();
         Power();
         Halt();
@@ -401,13 +405,11 @@ CASE nCommandLocal OF
           IN CSP mode the drive control word is update via the NC
           Manual step mode and Homing will override this
         *)
-        IF stChanParams.eOpModeReq = E_MCS2OpModeReq.CLOSED_LOOP THEN
-            stDS402Drive.nModeOfOperation := stDS402Drive.nModeOfOperationNC;
-            stDS402Drive.nDriveControl    := stDS402Drive.nDriveControlNC;
-        END_IF
 
+        stDS402Drive.nModeOfOperation := stDS402Drive.nModeOfOperationNC;
+        stDS402Drive.nDriveControl    := stDS402Drive.nDriveControlNC;
 
-    E_EpicsMotorCmd.HOME:
+    E_MCS2OpMode.HOME:
         (*DS402 Manual Homing*)
         fbhome(
             bExecute := bExecHome AND fbWriteParameters.bParamsSet,
@@ -415,14 +417,14 @@ CASE nCommandLocal OF
             stMotionStage := stMotionStage
         );
 
-    E_EpicsMotorCmd.JOG:
+    E_MCS2OpMode.STEP:
         fbStepMode(
             bExecute       := bExecMove AND fbWriteParameters.bParamsSet,
             stDS402Drive  := stDS402Drive,
             stMotionStage := stMotionStage
         );
 
-    E_EpicsMotorCmd.CALIBRATE:
+    E_MCS2OpMode.CALIBRATE:
         fbCalibrate(
             bExecute	 := bExecMove AND fbWriteParameters.bParamsSet,
             stDS402Drive  := stDS402Drive,

--- a/lcls-twincat-motion/Library/POUs/Motion/DS402/MCS2/FB_MotionStageMCS2.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/DS402/MCS2/FB_MotionStageMCS2.TcPOU
@@ -30,8 +30,6 @@ VAR
     {attribute 'hide'}
     eModule                 : E_Module;
     {attribute 'hide'}
-    //eHomeMode               : E_EpicsHomeCmd := E_EpicsHomeCmd.AUTOZERO;
-    {attribute 'hide'}
     eDoneCause              : E_MoveDoneCause := E_MoveDoneCause.Unknown;
     {attribute 'hide'}
     fbMcPower               : MC_Power;
@@ -403,8 +401,11 @@ CASE nCommandLocal OF
           IN CSP mode the drive control word is update via the NC
           Manual step mode and Homing will override this
         *)
-        stDS402Drive.nModeOfOperation := stDS402Drive.nModeOfOperationNC;
-        stDS402Drive.nDriveControl    := stDS402Drive.nDriveControlNC;
+        IF stChanParams.eOpModeReq = E_MCS2OpModeReq.CLOSED_LOOP THEN
+            stDS402Drive.nModeOfOperation := stDS402Drive.nModeOfOperationNC;
+            stDS402Drive.nDriveControl    := stDS402Drive.nDriveControlNC;
+        END_IF
+
 
     E_EpicsMotorCmd.HOME:
         (*DS402 Manual Homing*)

--- a/lcls-twincat-motion/Library/POUs/Motion/DS402/MCS2/FB_MotionStageMCS2.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/DS402/MCS2/FB_MotionStageMCS2.TcPOU
@@ -17,6 +17,7 @@ VAR
     {attribute 'no_copy'}
     stChanParams       : REFERENCE TO ST_MCS2ChanParameter;
     // Hardware I/O
+    {attribute 'pytmc' := 'pv:'}
     stDS402Drive		: ST_DS402Drive;
 
     fbDriveManager		: FB_MCS2DriveManager;

--- a/lcls-twincat-motion/Library/POUs/Motion/DS402/MCS2/FB_WriteChanParameters.TcPOU
+++ b/lcls-twincat-motion/Library/POUs/Motion/DS402/MCS2/FB_WriteChanParameters.TcPOU
@@ -247,26 +247,28 @@ END_IF
 
 CallAllSdoWriters();
 
-// Boot sweep handles bParamsSet directly; in parallel mode we hold it TRUE
-// unless some writer is currently busy.
+// After the boot sweep, bParamsSet reflects writer activity in real time:
+// TRUE when no parameter writer is busy, FALSE while any is busy. The
 IF bBootSweepDone THEN
-    bParamsSet R= fbSetFErrorWin.bBusy
-              OR fbSetSoftLimMin.bBusy
-              OR fbSetSoftLimMax.bBusy
-              OR fbMaxCloseLoopFreqWrite.bBusy
-              OR fbSensorPowerModeWrite.bBusy
-              OR fbLogicalScaleOffsetWrite.bBusy
-              OR fbLogicalScaleInvWrite.bBusy
-              OR fbCalibrationOptWrite.bBusy
-              OR fbSetHomeVeloFast.bBusy
-              OR fbSetHomeVeloSlow.bBusy
-              OR fbSetHomeAcc.bBusy
-              OR fbSetHomeOffs.bBusy
-              OR fbSetHomeMethod.bBusy
-              OR fbReferencingOptWrite.bBusy
-              OR fbSetSteps.bBusy
-              OR fbSetStepAmp.bBusy
-              OR fbSetStepFreq.bBusy;
+    bParamsSet := NOT (
+        fbSetFErrorWin.bBusy
+        OR fbSetSoftLimMin.bBusy
+        OR fbSetSoftLimMax.bBusy
+        OR fbMaxCloseLoopFreqWrite.bBusy
+        OR fbSensorPowerModeWrite.bBusy
+        OR fbLogicalScaleOffsetWrite.bBusy
+        OR fbLogicalScaleInvWrite.bBusy
+        OR fbCalibrationOptWrite.bBusy
+        OR fbSetHomeVeloFast.bBusy
+        OR fbSetHomeVeloSlow.bBusy
+        OR fbSetHomeAcc.bBusy
+        OR fbSetHomeOffs.bBusy
+        OR fbSetHomeMethod.bBusy
+        OR fbReferencingOptWrite.bBusy
+        OR fbSetSteps.bBusy
+        OR fbSetStepAmp.bBusy
+        OR fbSetStepFreq.bBusy
+    );
 END_IF
 ]]></ST>
     </Implementation>

--- a/lcls-twincat-motion/Library/Tests/FB_MCS2DriveManager_Test.TcPOU
+++ b/lcls-twincat-motion/Library/Tests/FB_MCS2DriveManager_Test.TcPOU
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <POU Name="FB_MCS2DriveManager_Test" Id="{c2f1a8d4-6e3b-4a90-9f12-7b5c0d4e2a31}" SpecialFunc="None">
     <Declaration><![CDATA[(*
@@ -40,7 +40,7 @@ stDrive.stDriveStatus.VoltageEnabled := TRUE;
 stDrive.stDriveStatus.QuickStopActive := TRUE;
 stDrive.stDriveStatus.Fault := FALSE;
 stDrive.stDriveStatus.SwitchOnDisabled := FALSE;
-stDrive.nModeOfOperationDisplay := E_DS402OpMode.CSP;
+stDrive.nModeOfOperationDisplay := E_MCS2OpMode.CSP;
 
 fbSut(
     bUserExec := FALSE,
@@ -74,7 +74,7 @@ END_VAR
 
 // Drive currently in step mode; the PV says STEP.
 stChan.eOpModeReq := E_MCS2OpModeReq.STEP;
-stDrive.nModeOfOperationDisplay := E_DS402OpMode.MCS2_OL_STEP_MODE;
+stDrive.nModeOfOperationDisplay := E_MCS2OpMode.STEP;
 
 // A closed-loop move request arrives.
 stMotionStage.bMoveCmd := TRUE;
@@ -89,7 +89,7 @@ fbSut(
 
 // The move request overwrites the PV with CLOSED_LOOP and switches the drive to CSP.
 AssertTrue(stChan.eOpModeReq = E_MCS2OpModeReq.CLOSED_LOOP, 'Move request should select CLOSED_LOOP in the PV');
-AssertTrue(stDrive.nModeOfOperation = E_DS402OpMode.CSP, 'Drive should be switched to CSP for a closed-loop move');
+AssertTrue(stDrive.nModeOfOperation = E_MCS2OpMode.CSP, 'Drive should be switched to CSP for a closed-loop move');
 
 TEST_FINISHED();
 ]]></ST>
@@ -108,7 +108,7 @@ END_VAR
         <ST><![CDATA[TEST(__POUNAME());
 
 // Drive displaying CSP; user sets the mode PV to CALIBRATION (no motion request).
-stDrive.nModeOfOperationDisplay := E_DS402OpMode.CSP;
+stDrive.nModeOfOperationDisplay := E_MCS2OpMode.CSP;
 stChan.eOpModeReq := E_MCS2OpModeReq.CALIBRATION;
 
 fbSut(
@@ -120,7 +120,7 @@ fbSut(
 );
 
 // The PV change alone must drive the DS402 mode to calibration.
-AssertTrue(stDrive.nModeOfOperation = E_DS402OpMode.MCS2_CALIBRATION, 'PV CALIBRATION should switch drive to MCS2_CALIBRATION');
+AssertTrue(stDrive.nModeOfOperation = E_MCS2OpMode.CALIBRATE, 'PV CALIBRATION should switch drive to MCS2_CALIBRATION');
 
 TEST_FINISHED();
 ]]></ST>
@@ -139,7 +139,7 @@ END_VAR
         <ST><![CDATA[TEST(__POUNAME());
 
 // Drive displaying CSP; user sets the mode PV to STEP (no motion request).
-stDrive.nModeOfOperationDisplay := E_DS402OpMode.CSP;
+stDrive.nModeOfOperationDisplay := E_MCS2OpMode.CSP;
 stChan.eOpModeReq := E_MCS2OpModeReq.STEP;
 
 fbSut(
@@ -151,7 +151,7 @@ fbSut(
 );
 
 // The PV change alone must drive the DS402 mode to open-loop step mode.
-AssertTrue(stDrive.nModeOfOperation = E_DS402OpMode.MCS2_OL_STEP_MODE, 'PV STEP should switch drive to MCS2_OL_STEP_MODE');
+AssertTrue(stDrive.nModeOfOperation = E_MCS2OpMode.CALIBRATE, 'PV STEP should switch drive to MCS2_OL_STEP_MODE');
 
 TEST_FINISHED();
 ]]></ST>
@@ -170,7 +170,7 @@ END_VAR
         <ST><![CDATA[TEST(__POUNAME());
 
 // Drive displaying CSP, PV at its default closed-loop value.
-stDrive.nModeOfOperationDisplay := E_DS402OpMode.CSP;
+stDrive.nModeOfOperationDisplay := E_MCS2OpMode.CSP;
 
 // A step move request arrives.
 stChan.bStepMoveCmd := TRUE;
@@ -185,7 +185,7 @@ fbSut(
 
 // The step request writes STEP into the PV and switches the drive into step mode.
 AssertTrue(stChan.eOpModeReq = E_MCS2OpModeReq.STEP, 'Step request should select STEP in the PV');
-AssertTrue(stDrive.nModeOfOperation = E_DS402OpMode.MCS2_OL_STEP_MODE, 'Step request should switch drive to MCS2_OL_STEP_MODE');
+AssertTrue(stDrive.nModeOfOperation = E_MCS2OpMode.STEP, 'Step request should switch drive to MCS2_OL_STEP_MODE');
 
 TEST_FINISHED();
 ]]></ST>

--- a/lcls-twincat-motion/_Config/PLC/Library.xti
+++ b/lcls-twincat-motion/_Config/PLC/Library.xti
@@ -1085,7 +1085,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{E61EF94A-CFE8-4DDF-B7C9-5F7AD2CF9D83}" Name="Library" PrjFilePath="..\..\Library\Library.plcproj" TmcFilePath="..\..\Library\Library.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{BD10D0C6-4FE9-35B9-5891-19851FCAEE40}" TmcPath="Library\Library.tmc">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{23E65598-2759-5725-7D0E-C865302FC043}" TmcPath="Library\Library.tmc">
 			<Name>Library Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="8" AreaNo="4">

--- a/lcls-twincat-motion/lcls-twincat-motion.tsproj
+++ b/lcls-twincat-motion/lcls-twincat-motion.tsproj
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4026.17" TcVersionFixed="true">
-	<Project ProjectGUID="{29C6E7F0-1B9D-402A-96FB-1C62117E1C0C}" TargetNetId="172.21.148.154.1.1" Target64Bit="true" ShowHideConfigurations="#x3c6">
+	<Project ProjectGUID="{29C6E7F0-1B9D-402A-96FB-1C62117E1C0C}" TargetNetId="199.4.42.250.1.1" Target64Bit="true" ShowHideConfigurations="#x3c6">
 		<System>
 			<Tasks>
 				<Task Id="3" Priority="20" CycleTime="100000" AmsPort="350">

--- a/lcls-twincat-motion/lcls-twincat-motion.tsproj
+++ b/lcls-twincat-motion/lcls-twincat-motion.tsproj
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4026.17" TcVersionFixed="true">
-	<Project ProjectGUID="{29C6E7F0-1B9D-402A-96FB-1C62117E1C0C}" TargetNetId="199.4.42.250.1.1" Target64Bit="true" ShowHideConfigurations="#x3c6">
+	<Project ProjectGUID="{29C6E7F0-1B9D-402A-96FB-1C62117E1C0C}" TargetNetId="172.21.148.154.1.1" Target64Bit="true" ShowHideConfigurations="#x3c6">
 		<System>
 			<Tasks>
 				<Task Id="3" Priority="20" CycleTime="100000" AmsPort="350">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Renames the DS402 operation-mode enum from `E_DS402OpMode` to `E_MCS2OpMode` with the new enum's values (CSP/HOME/STEP/CALIBRATE) better reflecting the MCS2-specific use. Promotes `eRequestedManualMode` on `FB_MCS2DriveManager` to `VAR_OUTPUT` and wires it into `FB_MotionStageMCS2` as `nCommandLocal`, whose CASE statement now keys off `E_MCS2OpMode` values directly (instead of `E_EpicsMotorCmd`); `nCommandLocal` is no longer PERSISTENT. Fixes `bParamsSet` in `FB_WriteChanParameters`: the prior `R=` cleared the flag when any writer went busy but never restored it, so a single parameter write left `bParamsSet` permanently FALSE.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DREAM MCS2 motion control.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on MCS2 driving a couple of stick-slip stages. Verified mode change on demand, mode display via the new output PV, and that `bParamsSet` correctly returns to TRUE after writer activity completes.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Inline comments next to the updated `bParamsSet` logic in `FB_WriteChanParameters` describe the corrected real-time tracking behavior and call out the prior bug.

## Pre-merge checklist
- [x] Code works interactively
- [x] Test suite passes locally
- [x] Code contains descriptive comments
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``